### PR TITLE
 Refactor python repo inference.

### DIFF
--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -27,11 +27,16 @@ var (
 	githubRE    = re.MustCompile(`(?i)\bgithub(\.com)?[:/]([\w-]+/[\w-\.]+)`)
 	gitlabRE    = re.MustCompile(`(?i)\bgitlab(\.com)?[:/]([\w-]+/[\w-\.]+)`)
 	bitbucketRE = re.MustCompile(`(?i)\bbitbucket(\.org)?[:/]([\w-]+/[\w-\.]+)`)
+	commonRepos = []*re.Regexp{
+		githubRE,
+		gitlabRE,
+		bitbucketRE,
+	}
 )
 
 var errUnsupportedRepo = errors.Errorf("unsupported repo type")
 
-// CanonicalizeRepoURI parses the supported repos into canonical HTTP.
+// CanonicalizeRepoURI parses repos into a canonical HTTP. This changes
 func CanonicalizeRepoURI(uri string) (string, error) {
 	if uri == "" {
 		return "", errors.New("No repo URL")
@@ -59,4 +64,19 @@ func CanonicalizeRepoURI(uri string) (string, error) {
 	}
 	u.RawQuery = ""
 	return u.String(), nil
+}
+
+// FindARepo attempts to find something that looks like a repo in the text. It will return empty string when no repo is found.
+func FindARepo(text string) string {
+	for _, pattern := range commonRepos {
+		if repo := pattern.FindString(text); repo != "" {
+			return repo
+		}
+	}
+	return ""
+}
+
+// SmellsLikeARepo returns true if the uri matches a well known URI pattern.
+func SmellsLikeARepo(uri string) bool {
+	return FindARepo(uri) != ""
 }

--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -75,8 +75,3 @@ func FindCommonRepo(text string) string {
 	}
 	return ""
 }
-
-// SmellsLikeARepo returns true if the uri matches a well known URI pattern.
-func SmellsLikeARepo(uri string) bool {
-	return FindCommonRepo(uri) != ""
-}

--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -36,7 +36,7 @@ var (
 
 var errUnsupportedRepo = errors.Errorf("unsupported repo type")
 
-// CanonicalizeRepoURI parses repos into a canonical HTTP. This changes
+// CanonicalizeRepoURI parses repos into a canonical HTTPS URI.
 func CanonicalizeRepoURI(uri string) (string, error) {
 	if uri == "" {
 		return "", errors.New("No repo URL")
@@ -66,8 +66,8 @@ func CanonicalizeRepoURI(uri string) (string, error) {
 	return u.String(), nil
 }
 
-// FindARepo attempts to find something that looks like a repo in the text. It will return empty string when no repo is found.
-func FindARepo(text string) string {
+// FindCommonRepo attempts to find something that looks like a repo in the text. It will return empty string when no repo is found.
+func FindCommonRepo(text string) string {
 	for _, pattern := range commonRepos {
 		if repo := pattern.FindString(text); repo != "" {
 			return repo
@@ -78,5 +78,5 @@ func FindARepo(text string) string {
 
 // SmellsLikeARepo returns true if the uri matches a well known URI pattern.
 func SmellsLikeARepo(uri string) bool {
-	return FindARepo(uri) != ""
+	return FindCommonRepo(uri) != ""
 }

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -34,7 +34,7 @@ func TestFindARepoAndSmellsLike(t *testing.T) {
 		{"https://bitbucket.org/team/repo", "bitbucket.org/team/repo"},          // Bitbucket
 	}
 	for _, test := range tests {
-		actual := FindARepo(test.input)
+		actual := FindCommonRepo(test.input)
 		if actual != test.expected {
 			t.Errorf("FindARepo(%s) = %s, expected %s", test.input, actual, test.expected)
 		}

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -18,14 +18,14 @@ import (
 	"testing"
 )
 
-func TestFindARepoAndSmellsLike(t *testing.T) {
+func TestFindARepo(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
 	}{
 		{"", ""},       // Empty input
 		{"foobar", ""}, // Invalid URL
-		// FindARepo and SmellsLikeARepo don't canonicallize.
+		// FindARepo doesn't canonicallize.
 		{"github.com/user/repo", "github.com/user/repo"},                        // GitHub, basic
 		{"github:user/repo", "github:user/repo"},                                // GitHub, alt format
 		{"https://github.com/org/project.git", "github.com/org/project.git"},    // GitHub, with .git
@@ -37,11 +37,6 @@ func TestFindARepoAndSmellsLike(t *testing.T) {
 		actual := FindCommonRepo(test.input)
 		if actual != test.expected {
 			t.Errorf("FindARepo(%s) = %s, expected %s", test.input, actual, test.expected)
-		}
-		actualSmell := SmellsLikeARepo(test.input)
-		expectedSmell := (test.expected != "")
-		if actualSmell != expectedSmell {
-			t.Errorf("SmellsLikeARepo(%s) = %t, expected %t", test.input, actualSmell, expectedSmell)
 		}
 	}
 }

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -18,6 +18,34 @@ import (
 	"testing"
 )
 
+func TestFindARepoAndSmellsLike(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},       // Empty input
+		{"foobar", ""}, // Invalid URL
+		// FindARepo and SmellsLikeARepo don't canonicallize.
+		{"github.com/user/repo", "github.com/user/repo"},                        // GitHub, basic
+		{"github:user/repo", "github:user/repo"},                                // GitHub, alt format
+		{"https://github.com/org/project.git", "github.com/org/project.git"},    // GitHub, with .git
+		{"http://github.com/org/project/tree/branch", "github.com/org/project"}, // GitHub, with path
+		{"GitLab.com/Group/Repo", "GitLab.com/Group/Repo"},                      // GitLab, case insensitive
+		{"https://bitbucket.org/team/repo", "bitbucket.org/team/repo"},          // Bitbucket
+	}
+	for _, test := range tests {
+		actual := FindARepo(test.input)
+		if actual != test.expected {
+			t.Errorf("FindARepo(%s) = %s, expected %s", test.input, actual, test.expected)
+		}
+		actualSmell := SmellsLikeARepo(test.input)
+		expectedSmell := (test.expected != "")
+		if actualSmell != expectedSmell {
+			t.Errorf("SmellsLikeARepo(%s) = %t, expected %t", test.input, actualSmell, expectedSmell)
+		}
+	}
+}
+
 func TestCanonicalizeRepoURI(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -41,6 +41,7 @@ import (
 
 // These are commonly used in PyPi metadata to point to the project git repo, using a map as a set.
 // Some people capitalize these differently, or add/remove spaces. We normalized to lower, no space.
+// This list is ordered, we will choose the first occurance.
 var commonRepoLinks = map[string]bool{
 	"source":     true,
 	"sourcecode": true,
@@ -90,7 +91,7 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 	}
 	// 2. project source link | not known repo
 	if len(repoLinks) != 0 {
-		return uri.CanonicalizeRepoURI([0])
+		return uri.CanonicalizeRepoURI(repoLinks[0])
 	}
 	// 3. description         | known repo
 	r := uri.FindARepo(project.Description)

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -92,6 +92,7 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 	}
 	// 3. description, known repo
 	r := uri.FindCommonRepo(project.Description)
+	// TODO: Maybe revisit this sponsors logic?
 	if r != "" && !strings.Contains(r, "sponsors") {
 		return uri.CanonicalizeRepoURI(r)
 	}

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -80,22 +80,22 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 		}
 	}
 	// Four priority levels:
-	// 1. project source link | known repo
+	// 1. project source link, known repo
 	for _, url := range repoLinks {
 		if repo := uri.FindCommonRepo(url); repo != "" {
 			return uri.CanonicalizeRepoURI(repo)
 		}
 	}
-	// 2. project source link | not known repo
+	// 2. project source link, unknown repo
 	if len(repoLinks) != 0 {
 		return uri.CanonicalizeRepoURI(repoLinks[0])
 	}
-	// 3. description         | known repo
+	// 3. description, known repo
 	r := uri.FindCommonRepo(project.Description)
 	if r != "" && !strings.Contains(r, "sponsors") {
 		return uri.CanonicalizeRepoURI(r)
 	}
-	// 4. other project links | known repo
+	// 4. other project links, known repo
 	for _, url := range project.ProjectURLs {
 		if strings.Contains(url, "sponsors") {
 			continue

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -90,13 +90,12 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 	}
 	// 2. project source link | not known repo
 	if len(repoLinks) != 0 {
-		return repoLinks[0], nil
+		return uri.CanonicalizeRepoURI([0])
 	}
 	// 3. description         | known repo
 	r := uri.FindARepo(project.Description)
-	if !strings.Contains(r, "sponsors") {
-		log.Printf("Found repo from the description: %s\n", r)
-		return r, nil
+	if r != "" && !strings.Contains(r, "sponsors") {
+		return uri.CanonicalizeRepoURI(r)
 	}
 	// 4. other project links | known repo
 	for _, url := range project.ProjectURLs {

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -42,12 +42,12 @@ import (
 // These are commonly used in PyPi metadata to point to the project git repo, using a map as a set.
 // Some people capitalize these differently, or add/remove spaces. We normalized to lower, no space.
 // This list is ordered, we will choose the first occurance.
-var commonRepoLinks = map[string]bool{
-	"source":     true,
-	"sourcecode": true,
-	"repository": true,
-	"project":    true,
-	"github":     true,
+var commonRepoLinks = []string{
+	"source",
+	"sourcecode",
+	"repository",
+	"project",
+	"github",
 }
 
 // There are two places to find the repo:
@@ -72,15 +72,12 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 	}
 	var repoLinks []string
 	for name, url := range project.ProjectURLs {
-		_, ok := commonRepoLinks[strings.ReplaceAll(strings.ToLower(name), " ", "")]
-		if !ok {
-			continue
+		for _, commonName := range commonRepoLinks {
+			if strings.ToLower(name) == commonName {
+				repoLinks = append(repoLinks, url)
+				break
+			}
 		}
-		// Exclude sponsor URLs.
-		if strings.Contains(url, "sponsors") {
-			continue
-		}
-		repoLinks = append(repoLinks, url)
 	}
 	// Four priority levels:
 	// 1. project source link | known repo

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -91,13 +91,12 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 		return uri.CanonicalizeRepoURI(repoLinks[0])
 	}
 	// 3. description         | known repo
-	r := uri.FindARepo(project.Description)
+	r := uri.FindCommonRepo(project.Description)
 	if r != "" && !strings.Contains(r, "sponsors") {
 		return uri.CanonicalizeRepoURI(r)
 	}
 	// 4. other project links | known repo
 	for _, url := range project.ProjectURLs {
-		// Exclude sponsor URLs.
 		if strings.Contains(url, "sponsors") {
 			continue
 		}

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -72,8 +72,8 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 		return "", nil
 	}
 	var linksNamedSource []string
-	for name, url := range project.ProjectURLs {
-		for _, commonName := range commonRepoLinks {
+	for _, commonName := range commonRepoLinks {
+		for name, url := range project.ProjectURLs {
 			if strings.ReplaceAll(strings.ToLower(name), " ", "") == commonName {
 				linksNamedSource = append(linksNamedSource, url)
 				break

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -82,8 +82,8 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 	// Four priority levels:
 	// 1. project source link | known repo
 	for _, url := range repoLinks {
-		if uri.SmellsLikeARepo(url) {
-			return uri.CanonicalizeRepoURI(url)
+		if repo := uri.FindCommonRepo(url); repo != "" {
+			return uri.CanonicalizeRepoURI(repo)
 		}
 	}
 	// 2. project source link | not known repo
@@ -100,8 +100,8 @@ func (Rebuilder) InferRepo(t rebuild.Target, mux rebuild.RegistryMux) (string, e
 		if strings.Contains(url, "sponsors") {
 			continue
 		}
-		if uri.SmellsLikeARepo(url) {
-			return uri.CanonicalizeRepoURI(url)
+		if repo := uri.FindCommonRepo(url); repo != "" {
+			return uri.CanonicalizeRepoURI(repo)
 		}
 	}
 	return "", errors.New("no git repo")

--- a/pkg/registry/pypi/pypi.go
+++ b/pkg/registry/pypi/pypi.go
@@ -46,6 +46,7 @@ type Info struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description"`
 	Version     string            `json:"version"`
+	Homepage    string            `json:"home_page"`
 	ProjectURLs map[string]string `json:"project_urls"`
 }
 


### PR DESCRIPTION
After we added support for unknown repos, this heuristic needed some
love. I changed to a prioritized system with the following order:
1. Homepage if it's using a uri pointing to a common repo host.
1. Project links using a common "source" name, with common uri host.
1. Project links using a common "source" name, with uncommon uri host.
1. Description links using a common host uri.
1. Project links outside the common "source" name, with common uri host.