### PR TITLE
Update KMS proto dependency

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -32,6 +32,7 @@ import (
 
 	"cloud.google.com/go/firestore"
 	kms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/google/oss-rebuild/internal/cache"
 	httpinternal "github.com/google/oss-rebuild/internal/http"
 	"github.com/google/oss-rebuild/internal/httpegress"
@@ -50,7 +51,6 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"google.golang.org/api/idtoken"
 	"google.golang.org/api/iterator"
-	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/oauth2 v0.17.0
 	google.golang.org/api v0.162.0
-	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de
 	google.golang.org/grpc v1.63.2
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -85,6 +84,7 @@ require (
 	golang.org/x/tools v0.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
+	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/pkg/kmsdsse/kmsdsse.go
+++ b/pkg/kmsdsse/kmsdsse.go
@@ -23,9 +23,9 @@ import (
 	"encoding/pem"
 
 	kms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/pkg/errors"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
 type CloudKMSSigner struct {


### PR DESCRIPTION
Direct use of the genproto target is deprecated. This moves the proto dep to be managed by the cloud.google.com KMS lib.