### PR TITLE
Support run-bench targeting local instance of rebuilder.

### DIFF
--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -373,7 +373,7 @@ var runBenchmark = &cobra.Command{
 						}
 						if resp.StatusCode != 200 {
 							totalErrors++
-							aggErrors = append(aggErrors, errors.Wrapf(errors.New(resp.Status), "request: %s", req.URL.String()).Error())
+							aggErrors = append(aggErrors, errors.Wrapf(errors.New(resp.Status), "requesting %s", req.URL.String()).Error())
 						}
 					}
 					bar.Increment()

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -278,7 +278,7 @@ var runBenchmark = &cobra.Command{
 		if *buildLocal {
 			// The build-local service does not support creating a new run-id.
 			// If we're talking to build-local directly, then we skip run-id generation.
-			run = "build-local-run"
+			run = time.Now().UTC().Format(time.RFC3339)
 		} else {
 			u := apiURL.JoinPath("runs")
 			values := url.Values{

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -513,7 +513,7 @@ var (
 	api = flag.String("api", "", "OSS Rebuild API endpoint URI")
 	// run-bench
 	maxConcurrency = flag.Int("max-concurrency", 90, "maximum number of inflight requests")
-	buildLocal     = flag.Bool("build-local", false, "true if this request is goind direct to build-local (not through API first)")
+	buildLocal     = flag.Bool("local", false, "true if this request is going direct to build-local (not through API first)")
 	// get-results
 	runFlag      = flag.String("run", "", "the run(s) from which to fetch results")
 	bench        = flag.String("bench", "", "a path to a benchmark file. if provided, only results from that benchmark will be fetched")
@@ -534,7 +534,7 @@ var (
 func init() {
 	runBenchmark.Flags().AddGoFlag(flag.Lookup("api"))
 	runBenchmark.Flags().AddGoFlag(flag.Lookup("max-concurrency"))
-	runBenchmark.Flags().AddGoFlag(flag.Lookup("build-local"))
+	runBenchmark.Flags().AddGoFlag(flag.Lookup("local"))
 
 	runOne.Flags().AddGoFlag(flag.Lookup("api"))
 	runOne.Flags().AddGoFlag(flag.Lookup("strategy"))


### PR DESCRIPTION
Change the run-bench to detecting a url that looks like a cloud run url (the same way run-one does). Based on this switch, run-bench will only conditionally upgrade to https or include an oauth token.

When the `--build-local` bool flag is provided, run-bench will skip the runid creation process, and it will also skip the warmup checks.

To help with running the local builder, the user agent is now optional.