### PR TITLE
Refactor run bench to print verdicts

### DIFF
--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -392,7 +392,7 @@ func defaultLimiters() map[string]<-chan time.Time {
 }
 
 func urlIsCloudRun(u *url.URL) bool {
-	return strings.Contains(u.Host, ".run.app")
+	return strings.HasSuffix(u.Host, ".run.app")
 }
 
 var runBenchmark = &cobra.Command{

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -227,7 +227,7 @@ type WorkerPool struct {
 }
 
 func (pool *WorkerPool) Process(ctx context.Context, packages []benchmark.Package) []schema.Verdict {
-	jobs := make(chan benchmark.Package, *maxConcurrency)
+	jobs := make(chan benchmark.Package, pool.Size)
 	results := make(chan schema.Verdict)
 	bar := pb.StartNew(len(packages))
 	bar.ShowTimeLeft = true
@@ -238,7 +238,7 @@ func (pool *WorkerPool) Process(ctx context.Context, packages []benchmark.Packag
 		close(jobs)
 	}()
 	var wg sync.WaitGroup
-	for i := 0; i < *maxConcurrency; i++ {
+	for i := 0; i < pool.Size; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -230,7 +230,7 @@ func makeHTTPRequest(ctx context.Context, u *url.URL, msg schema.Message) *http.
 }
 
 var runBenchmark = &cobra.Command{
-	Use:   "run-bench smoketest|attest -api <URI> [-build-local] <benchmark.json>",
+	Use:   "run-bench smoketest|attest -api <URI> [-local] <benchmark.json>",
 	Short: "Run benchmark",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -506,7 +506,7 @@ var runBenchmark = &cobra.Command{
 		// TODO: Maybe add more format options, or include more data in the csv?
 		case "csv":
 			for _, v := range verdicts {
-				cmd.OutOrStdout().Write([]byte(fmt.Sprintf("%s,%s\n", v.Target, v.Message)))
+				io.WriteString(cmd.OutOrStdout(), fmt.Sprintf("%s,%s\n", v.Target, v.Message))
 			}
 		case "summary":
 			var successes int
@@ -515,7 +515,7 @@ var runBenchmark = &cobra.Command{
 					successes++
 				}
 			}
-			cmd.OutOrStdout().Write([]byte(fmt.Sprintf("Successes: %d/%d\n", successes, len(verdicts))))
+			io.WriteString(cmd.OutOrStdout(), fmt.Sprintf("Successes: %d/%d\n", successes, len(verdicts)))
 		default:
 			log.Fatalf("Unsupported format: %s", *format)
 		}

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -398,7 +398,7 @@ func urlIsCloudRun(u *url.URL) bool {
 }
 
 var runBenchmark = &cobra.Command{
-	Use:   "run-bench smoketest|attest -api <URI> [-local] <benchmark.json> [-format=csv]",
+	Use:   "run-bench smoketest|attest -api <URI>  [-local] [-format=csv] <benchmark.json>",
 	Short: "Run benchmark",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -229,7 +229,7 @@ type WorkerPool struct {
 }
 
 func (pool *WorkerPool) Process(ctx context.Context, out chan schema.Verdict, packages []benchmark.Package) {
-	jobs := make(chan benchmark.Package, pool.Size)
+	jobs := make(chan benchmark.Package)
 	go func() {
 		for _, p := range packages {
 			jobs <- p
@@ -492,7 +492,7 @@ var runBenchmark = &cobra.Command{
 				WorkerConfig: wrkConf,
 			}
 		}
-		var verdictChan chan schema.Verdict
+		verdictChan := make(chan schema.Verdict)
 		go pool.Process(ctx, verdictChan, set.Packages)
 		var verdicts []schema.Verdict
 		for v := range verdictChan {

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/csv"
 	"encoding/hex"
 	"encoding/json"
 	"flag"
@@ -505,8 +506,11 @@ var runBenchmark = &cobra.Command{
 		switch *format {
 		// TODO: Maybe add more format options, or include more data in the csv?
 		case "csv":
+			w := csv.NewWriter(cmd.OutOrStdout())
 			for _, v := range verdicts {
-				io.WriteString(cmd.OutOrStdout(), fmt.Sprintf("%s,%s\n", v.Target, v.Message))
+				if err := w.Write([]string{fmt.Sprintf("%v", v.Target), v.Message}); err != nil {
+					log.Fatal(errors.Wrap(err, "writing CSV"))
+				}
 			}
 		case "summary":
 			var successes int


### PR DESCRIPTION
run-bench only collected the HTTP results but didn't have any visibility when a 200 happened. This PR adds much richer logging on run-bench to keep track of the verdicts being returned.

As part of this PR I refactored the run-bench goroutines into a first class struct called a WorkerPool, and the different types of runs (smoketest vs attest) are each an implementation of a PackageWorker.