### PR TITLE
Add a gateway limit for pypi.org

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -45,7 +45,7 @@ func waitOn(c chan<- func()) {
 var queues = map[string]chan<- func(){
 	"crates.io":  consumeEvery(time.Second),
 	"github.com": consumeEvery(200 * time.Millisecond),
-	"pypi.org":   consumeEvery(time.Second),
+	"pypi.org":   consumeEvery(200 * time.Millisecond),
 }
 
 // Handle provides a redirect to the "uri" param applying the configured policy.

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -45,6 +45,7 @@ func waitOn(c chan<- func()) {
 var queues = map[string]chan<- func(){
 	"crates.io":  consumeEvery(time.Second),
 	"github.com": consumeEvery(200 * time.Millisecond),
+	"pypi.org":   consumeEvery(time.Second),
 }
 
 // Handle provides a redirect to the "uri" param applying the configured policy.


### PR DESCRIPTION
We already have one for crates and github, but not pypi. The most recent attestation run had some pypi rejections which this will hopefully fix.