### PR TITLE
Add verdicts to API smoketest endpoint response

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -199,7 +199,10 @@ func HandleRebuildSmoketest(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 	if respCopy.Len() > 0 {
-		io.Copy(rw, respCopy)
+		if _, err := io.Copy(rw, respCopy); err != nil {
+			log.Println("Failed to write verdicts into the http response.")
+			http.Error(rw, "Internal Error", 500)
+		}
 	} else {
 		log.Println("No SmoketestResponse to forward.")
 		http.Error(rw, "Internal Error", 500)
@@ -417,7 +420,7 @@ func HandleRebuildPackage(rw http.ResponseWriter, req *http.Request) {
 		MetadataBucket:      *metadataBucket,
 	}
 	// TODO: These doRebuild functions should return a verdict, and this handler
-	// endpoint should forward those to the caller as a schema.Verdict.
+	// should forward those to the caller as a schema.Verdict.
 	switch t.Ecosystem {
 	case rebuild.NPM:
 		hashes = append(hashes, crypto.SHA512)

--- a/cmd/rebuilder/main.go
+++ b/cmd/rebuilder/main.go
@@ -199,9 +199,9 @@ func HandleRebuildSmoketest(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, fmt.Sprintf("Unexpected number of results [want=%d,got=%d]", len(sreq.Versions), len(verdicts)), 500)
 		return
 	}
-	smkVerdicts := make([]schema.SmoketestVerdict, len(verdicts))
+	smkVerdicts := make([]schema.Verdict, len(verdicts))
 	for i, v := range verdicts {
-		smkVerdicts[i] = schema.SmoketestVerdict{
+		smkVerdicts[i] = schema.Verdict{
 			Target:        v.Target,
 			Message:       v.Message,
 			StrategyOneof: schema.NewStrategyOneOf(v.Strategy),

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -180,7 +180,7 @@ func (sreq *SmoketestRequest) ToInputs() ([]rebuild.Input, error) {
 	return inputs, nil
 }
 
-type SmoketestVerdict struct {
+type Verdict struct {
 	Target        rebuild.Target
 	Message       string
 	StrategyOneof StrategyOneOf
@@ -189,7 +189,7 @@ type SmoketestVerdict struct {
 
 // SmoketestResponse is the result of a rebuild smoketest.
 type SmoketestResponse struct {
-	Verdicts []SmoketestVerdict
+	Verdicts []Verdict
 	Executor string
 }
 


### PR DESCRIPTION
The API smoketest endpoint now returns verdict objects. I also changed the schema.SmoketestVerdict to be just schema.Verdict