### PR TITLE
Create a simple RPC framework

### DIFF
--- a/internal/api/rpc.go
+++ b/internal/api/rpc.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	httpinternal "github.com/google/oss-rebuild/internal/http"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema/form"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type Dependencies interface{}
+
+type InitT[D Dependencies] func(context.Context) (D, error)
+type HandlerT[I schema.Message, O any, D Dependencies] func(context.Context, I, D) (*O, error)
+type StubT[I schema.Message, O any] func(context.Context, I) (*O, error)
+
+type NoDeps struct{}
+
+func NoDepsInit(context.Context) (*NoDeps, error) { return &NoDeps{}, nil }
+
+type NoReturn struct{}
+
+var ErrNotOK = errors.New("non-OK response")
+
+func Stub[I schema.Message, O any](client httpinternal.BasicClient, u url.URL) StubT[I, O] {
+	return func(ctx context.Context, i I) (*O, error) {
+		values, err := form.Marshal(i)
+		if err != nil {
+			return nil, errors.Wrap(err, "serializing request")
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(values.Encode()))
+		if err != nil {
+			return nil, errors.Wrap(err, "building http request")
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, errors.Wrap(err, "making http request")
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, errors.Wrap(ErrNotOK, resp.Status)
+		}
+		var o O
+		if err := json.NewDecoder(resp.Body).Decode(&o); err != nil {
+			return nil, errors.Wrap(err, "decoding response")
+		}
+		return &o, nil
+	}
+}
+
+func StubFromHandler[I schema.Message, O any, D Dependencies](client httpinternal.BasicClient, u url.URL, handler HandlerT[I, O, D]) StubT[I, O] {
+	return Stub[I, O](client, u)
+}
+
+func AsStatus(code codes.Code, err error) error {
+	return status.New(code, err.Error()).Err()
+}
+
+var grpcToHTTP = map[codes.Code]int{
+	codes.OK:                 http.StatusOK,
+	codes.Canceled:           499, // Client Closed Request
+	codes.Unknown:            http.StatusInternalServerError,
+	codes.InvalidArgument:    http.StatusBadRequest,
+	codes.DeadlineExceeded:   http.StatusGatewayTimeout,
+	codes.NotFound:           http.StatusNotFound,
+	codes.AlreadyExists:      http.StatusConflict,
+	codes.PermissionDenied:   http.StatusForbidden,
+	codes.ResourceExhausted:  http.StatusTooManyRequests,
+	codes.FailedPrecondition: http.StatusBadRequest,
+	codes.Aborted:            http.StatusConflict,
+	codes.OutOfRange:         http.StatusBadRequest,
+	codes.Unimplemented:      http.StatusNotImplemented,
+	codes.Internal:           http.StatusInternalServerError,
+	codes.Unavailable:        http.StatusServiceUnavailable,
+	codes.DataLoss:           http.StatusInternalServerError,
+	codes.Unauthenticated:    http.StatusUnauthorized,
+}
+
+func Handler[I schema.Message, O any, D Dependencies](initDeps InitT[D], handler HandlerT[I, O, D]) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		ctx := context.Background()
+		r.ParseForm()
+		var req I
+		if err := form.Unmarshal(r.Form, &req); err != nil {
+			log.Println(errors.Wrap(err, "parsing request"))
+			http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		deps, err := initDeps(ctx)
+		if err != nil {
+			log.Println(errors.Wrap(err, "initializing dependencies"))
+			http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		o, err := handler(ctx, req, deps)
+		s := status.Convert(err)
+		status, ok := grpcToHTTP[s.Code()]
+		if !ok {
+			log.Printf("unknown error code: %s\n", s.Code())
+			status = http.StatusInternalServerError
+		}
+		if status != http.StatusOK {
+			log.Println(s.Err())
+			http.Error(rw, http.StatusText(status), status)
+			return
+		}
+		if o != nil {
+			if err := json.NewEncoder(rw).Encode(o); err != nil {
+				log.Println(errors.Wrap(err, "encoding response"))
+				http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			}
+		}
+	}
+}

--- a/internal/api/rpc_test.go
+++ b/internal/api/rpc_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type FooRequest struct {
+	Foo string `form:",required"`
+}
+
+type FooResponse struct {
+	Bar string
+}
+
+func TestNoDepsInit(t *testing.T) {
+	ctx := context.Background()
+	deps, err := NoDepsInit(ctx)
+	if err != nil {
+		t.Errorf("NoDepsInit returned an error: %v", err)
+	}
+	if deps == nil {
+		t.Error("NoDepsInit returned nil deps")
+	}
+}
+
+func TestStub(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm(): %v", err)
+		}
+		if r.Method != "POST" {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+		if form := r.Form.Encode(); form != "foo=foo" {
+			t.Errorf("Expected form 'foo=foo', got '%s'", form)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"Bar":"Bar"}`))
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	stub := Stub[FooRequest, FooResponse](server.Client(), *u)
+
+	ctx := context.Background()
+	result, err := stub(ctx, FooRequest{Foo: "foo"})
+
+	if err != nil {
+		t.Errorf("Stub returned an error: %v", err)
+	}
+	expected := &FooResponse{Bar: "Bar"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+func TestStubFromHandler(t *testing.T) {
+	h := func(ctx context.Context, req FooRequest, _ *NoDeps) (*FooResponse, error) {
+		if req.Foo != "foo" {
+			t.Errorf("request.Foo: want='foo' got='%s'", req.Foo)
+		}
+		return &FooResponse{Bar: "Bar"}, nil
+	}
+	server := httptest.NewServer(Handler(NoDepsInit, h))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	stub := StubFromHandler(server.Client(), *u, h)
+
+	ctx := context.Background()
+	result, err := stub(ctx, FooRequest{Foo: "foo"})
+
+	if err != nil {
+		t.Errorf("Stub returned an error: %v", err)
+	}
+	expected := FooResponse{Bar: "Bar"}
+	if !reflect.DeepEqual(*result, expected) {
+		t.Errorf("Expected %v, got %v", expected, *result)
+	}
+}
+
+func TestHandler(t *testing.T) {
+	handler := func(ctx context.Context, req FooRequest, _ *NoDeps) (*FooResponse, error) {
+		if req.Foo != "foo" {
+			t.Errorf("request.Foo: want='foo' got='%s'", req.Foo)
+		}
+		return &FooResponse{Bar: "Bar"}, nil
+	}
+
+	server := httptest.NewServer(Handler(NoDepsInit, handler))
+	defer server.Close()
+
+	resp, err := server.Client().PostForm(server.URL, url.Values{"foo": {"foo"}})
+
+	if err != nil {
+		t.Fatalf("Request returned an error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("Error unmarshaling response: %v", err)
+	}
+
+	expected := map[string]string{"Bar": "Bar"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// Test for AsStatus
+func TestAsStatus(t *testing.T) {
+	err := AsStatus(codes.NotFound, errors.New("foo"))
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatal("AsStatus did not return a status error")
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("Expected code NotFound, got %v", st.Code())
+	}
+	if st.Message() != "foo" {
+		t.Errorf("Expected message '%s', got '%s'", "foo", st.Message())
+	}
+}
+
+func TestHandlerWithError(t *testing.T) {
+	handler := func(ctx context.Context, req FooRequest, _ *NoDeps) (*FooResponse, error) {
+		return nil, AsStatus(codes.InvalidArgument, errors.New("foo"))
+	}
+
+	server := httptest.NewServer(Handler(NoDepsInit, handler))
+	defer server.Close()
+
+	resp, err := http.PostForm(server.URL, url.Values{"foo": {"foo"}})
+
+	if err != nil {
+		t.Errorf("Request returned an error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, resp.StatusCode)
+	}
+
+	expectedBody := "Bad Request\n"
+	b, _ := io.ReadAll(resp.Body)
+	if string(b) != expectedBody {
+		t.Errorf("Expected body '%s', got '%s'", expectedBody, string(b))
+	}
+}


### PR DESCRIPTION
The major benefit of this small bit of code is we can separate the complex dependencies and binary-configured settings from the handler implementations which (finally) makes them feasible to test. To boot, we also get type safety for cross-service RPCs and encoding/decoding boilerplate for free. 