### PR TITLE
Create a serialization lib for url.Values

### DIFF
--- a/cmd/rebuilder/main.go
+++ b/cmd/rebuilder/main.go
@@ -35,6 +35,7 @@ import (
 	pypirb "github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema/form"
 	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
 	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
 	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
@@ -138,7 +139,7 @@ func doMavenRebuildSmoketest(ctx context.Context, req schema.SmoketestRequest) (
 func HandleRebuildSmoketest(rw http.ResponseWriter, req *http.Request) {
 	req.ParseForm()
 	var sreq schema.SmoketestRequest
-	if err := sreq.FromValues(req.Form); err != nil {
+	if err := form.Unmarshal(req.Form, &sreq); err != nil {
 		http.Error(rw, err.Error(), 400)
 		return
 	}

--- a/pkg/rebuild/schema/form/form.go
+++ b/pkg/rebuild/schema/form/form.go
@@ -1,0 +1,112 @@
+package form
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+	"reflect"
+	"strings"
+)
+
+var (
+	ErrInvalidType      = errors.New("invalid type")
+	ErrUnsupportedField = errors.New("unsupported field")
+	ErrMissingRequired  = errors.New("missing required field")
+)
+
+type fieldOptions struct {
+	name     string
+	required bool
+}
+
+func options(field reflect.StructField) fieldOptions {
+	var opt fieldOptions
+	parts := strings.Split(field.Tag.Get("form"), ",")
+	if opt.name = parts[0]; opt.name == "" {
+		opt.name = strings.ToLower(field.Name)
+	}
+	for _, val := range parts[1:] {
+		if val == "required" {
+			opt.required = true
+		}
+	}
+	return opt
+}
+
+func Marshal(in any) (url.Values, error) {
+	tvalue := reflect.ValueOf(in)
+	ttype := tvalue.Type()
+	if ttype.Kind() != reflect.Struct {
+		return nil, ErrInvalidType
+	}
+	v := url.Values{}
+	for i := 0; i < ttype.NumField(); i++ {
+		field, value := ttype.Field(i), tvalue.Field(i)
+		if !field.IsExported() {
+			continue
+		} else if field.Anonymous {
+			return nil, ErrUnsupportedField
+		}
+		opt := options(field)
+		if value.IsZero() {
+			continue
+		}
+		switch field.Type.Kind() {
+		case reflect.String:
+			v.Set(opt.name, value.String())
+		case reflect.Slice:
+			if field.Type.Elem().Kind() == reflect.String {
+				v[opt.name] = value.Interface().([]string)
+				continue
+			}
+			fallthrough
+		default:
+			jsonv, err := json.Marshal(value.Interface())
+			if err != nil {
+				return nil, err
+			}
+			v.Set(opt.name, string(jsonv))
+		}
+	}
+	return v, nil
+}
+
+func Unmarshal(v url.Values, out any) error {
+	tvalue := reflect.ValueOf(out).Elem()
+	ttype := tvalue.Type()
+	if ttype.Kind() != reflect.Struct {
+		return ErrInvalidType
+	}
+	for i := 0; i < ttype.NumField(); i++ {
+		field, value := ttype.Field(i), tvalue.Field(i)
+		if !field.IsExported() {
+			continue
+		} else if field.Anonymous {
+			return ErrUnsupportedField
+		}
+		opt := options(field)
+		urlval := v.Get(opt.name)
+		if urlval == "" {
+			if opt.required {
+				return ErrMissingRequired
+			}
+			continue
+		}
+		switch field.Type.Kind() {
+		case reflect.String:
+			value.SetString(urlval)
+		case reflect.Slice:
+			if field.Type.Elem().Kind() == reflect.String {
+				value.Set(reflect.ValueOf(v[opt.name]))
+				continue
+			}
+			fallthrough
+		default:
+			err := json.Unmarshal([]byte(urlval), value.Addr().Interface())
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/rebuild/schema/form/form_test.go
+++ b/pkg/rebuild/schema/form/form_test.go
@@ -1,0 +1,151 @@
+package form
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+type TestStruct struct {
+	StringField   string   `form:"string_field,required"`
+	IntField      int      `form:"int_field"`
+	SliceField    []string `form:"slice_field"`
+	IntSliceField []int    `form:""`
+}
+
+func TestMarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   interface{}
+		want    url.Values
+		wantErr bool
+	}{
+		{
+			name: "Valid struct",
+			input: TestStruct{
+				StringField:   "test",
+				IntField:      123,
+				SliceField:    []string{"a", "b", "c"},
+				IntSliceField: []int{1, 2, 3},
+			},
+			want: url.Values{
+				"string_field":  []string{"test"},
+				"int_field":     []string{"123"},
+				"slice_field":   []string{"a", "b", "c"},
+				"intslicefield": []string{"[1,2,3]"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Not a struct",
+			input:   "not a struct",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Pointer not a struct",
+			input:   &TestStruct{},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Marshal(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Marshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Marshal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   url.Values
+		want    TestStruct
+		wantErr bool
+	}{
+		{
+			name: "Valid input",
+			input: url.Values{
+				"string_field": {"test"},
+				"int_field":    {"123"},
+				"slice_field":  {"a", "b", "c"},
+			},
+			want: TestStruct{
+				StringField: "test",
+				IntField:    123,
+				SliceField:  []string{"a", "b", "c"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing required field",
+			input: url.Values{
+				"int_field":   {"123"},
+				"slice_field": {"a", "b", "c"},
+			},
+			want:    TestStruct{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got TestStruct
+			err := Unmarshal(tt.input, &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Unmarshal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOptions(t *testing.T) {
+	type testStruct struct {
+		Field1 string `form:"custom_name,required"`
+		Field2 string
+		Field3 string `form:",required"`
+	}
+
+	tests := []struct {
+		name  string
+		field reflect.StructField
+		want  fieldOptions
+	}{
+		{
+			name:  "Custom name and required",
+			field: reflect.TypeOf(testStruct{}).Field(0),
+			want:  fieldOptions{name: "custom_name", required: true},
+		},
+		{
+			name:  "Default name",
+			field: reflect.TypeOf(testStruct{}).Field(1),
+			want:  fieldOptions{name: "field2", required: false},
+		},
+		{
+			name:  "Default name required",
+			field: reflect.TypeOf(testStruct{}).Field(2),
+			want:  fieldOptions{name: "field3", required: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := options(tt.field)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("options() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/oss-rebuild/internal/oauth"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema/form"
 	"github.com/google/oss-rebuild/tools/benchmark"
 	"github.com/google/oss-rebuild/tools/ctl/firestore"
 	"github.com/google/oss-rebuild/tools/ctl/ide"
@@ -256,7 +257,7 @@ func (ex *Executor) Process(ctx context.Context, out chan schema.Verdict, packag
 }
 
 func makeHTTPRequest(ctx context.Context, u *url.URL, msg schema.Message) *http.Request {
-	values, err := msg.ToValues()
+	values, err := form.Marshal(msg)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "creating values"))
 	}
@@ -579,11 +580,11 @@ var runOne = &cobra.Command{
 		var req *http.Request
 		if mode == firestore.SmoketestMode {
 			req = makeHTTPRequest(ctx, apiURL.JoinPath("smoketest"), &schema.SmoketestRequest{
-				Ecosystem:     rebuild.Ecosystem(*ecosystem),
-				Package:       *pkg,
-				Versions:      []string{*version},
-				StrategyOneof: strategy,
-				ID:            "runOne",
+				Ecosystem: rebuild.Ecosystem(*ecosystem),
+				Package:   *pkg,
+				Versions:  []string{*version},
+				Strategy:  strategy,
+				ID:        "runOne",
 			})
 		} else if mode == firestore.AttestMode {
 			req = makeHTTPRequest(ctx, apiURL.JoinPath("rebuild"), &schema.RebuildPackageRequest{


### PR DESCRIPTION
While the use of reflection is sub-optimal, we can end up removing a great deal of the boilerplate in our handlers and unblock the use of the upcoming rpc library.