### PR TITLE
Firestore logging for RebuildRemote

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -109,6 +109,10 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	if err != nil {
 		return nil, errors.Wrap(err, "making http client")
 	}
+	d.FirestoreClient, err = firestore.NewClient(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating firestore client")
+	}
 	d.Signer, err = makeKMSSigner(ctx, *signingKeyVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating signer")

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -278,7 +278,7 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 		rawStrategy = string(enc)
 	}
 
-	_, err := deps.FirestoreClient.Collection("ecosystem").Doc(string(v.Target.Ecosystem)).Collection("packages").Doc(sanitize(sreq.Package)).Collection("versions").Doc(v.Target.Version).Collection("attempts").Doc(sreq.ID).Set(ctx, schema.SmoketestAttempt{
+	_, err := deps.FirestoreClient.Collection("ecosystem").Doc(string(v.Target.Ecosystem)).Collection("packages").Doc(sanitize(v.Target.Package)).Collection("versions").Doc(v.Target.Version).Collection("attempts").Doc(req.ID).Set(ctx, schema.SmoketestAttempt{
 		Ecosystem:       string(v.Target.Ecosystem),
 		Package:         v.Target.Package,
 		Version:         v.Target.Version,

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -233,7 +233,7 @@ func buildAndAttest(ctx context.Context, deps *RebuildPackageDeps, mux rebuild.R
 	return nil
 }
 
-func doRebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps *RebuildPackageDeps) (*schema.Verdict, error) {
+func rebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps *RebuildPackageDeps) (*schema.Verdict, error) {
 	t := rebuild.Target{Ecosystem: req.Ecosystem, Package: req.Package, Version: req.Version}
 	v := schema.Verdict{
 		Target: t,
@@ -278,7 +278,7 @@ func doRebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, dep
 }
 
 func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps *RebuildPackageDeps) (*schema.Verdict, error) {
-	v, err := doRebuildPackage(ctx, req, deps)
+	v, err := rebuildPackage(ctx, req, deps)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add firestore logging for attestation based executions.

I split the RebuildPackage function into a handful of smaller functions. The motivation is that I wanted to capture most failure types that do an early return with an error. By pushing the "meat" of execution into these new functions, there's only one or two return values I need to capture and write to firestore, rather than lots of early return errors.