### PR TITLE
Split metadata bucket.

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -48,7 +48,7 @@ var (
 	buildLocalURL         = flag.String("build-local-url", "", "URL of the rebuild service")
 	inferenceURL          = flag.String("inference-url", "", "URL of the inference service")
 	signingKeyVersion     = flag.String("signing-key-version", "", "Resource name of the signing CryptoKeyVersion")
-	rebuildBucket         = flag.String("rebuild-bucket", "", "GCS bucket for rebuild artifacts")
+	metadataBucket        = flag.String("metadata-bucket", "", "GCS bucket for rebuild artifacts")
 	attestationBucket     = flag.String("attestation-bucket", "", "GCS bucket to which to publish rebuild attestation")
 	logsBucket            = flag.String("logs-bucket", "", "GCS bucket for rebuild logs")
 	prebuildBucket        = flag.String("prebuild-bucket", "", "GCS bucket from which prebuilt build tools are stored")
@@ -136,9 +136,9 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	if err != nil {
 		return nil, errors.Wrap(err, "creating attestation uploader")
 	}
-	d.MetadataStore = rebuild.NewFilesystemAssetStore(memfs.New())
-	d.RebuildStoreBuilder = func(ctx context.Context, id string) (rebuild.AssetStore, error) {
-		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, id), "gs://"+*rebuildBucket)
+	d.LocalMetadataStore = rebuild.NewFilesystemAssetStore(memfs.New())
+	d.RemoteMetadataStoreBuilder = func(ctx context.Context, id string) (rebuild.AssetStore, error) {
+		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, id), "gs://"+*metadataBucket)
 	}
 	d.OverwriteAttestations = *overwriteAttestations
 	u, err := url.Parse(*inferenceURL)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -48,6 +48,7 @@ var (
 	inferenceURL          = flag.String("inference-url", "", "URL of the inference service")
 	signingKeyVersion     = flag.String("signing-key-version", "", "Resource name of the signing CryptoKeyVersion")
 	metadataBucket        = flag.String("metadata-bucket", "", "GCS bucket for rebuild metadata")
+	rebuildBucket         = flag.String("rebuild-bucket", "", "GCS bucket for rebuild artifacts")
 	attestationBucket     = flag.String("attestation-bucket", "", "GCS bucket to which to publish rebuild attestation")
 	logsBucket            = flag.String("logs-bucket", "", "GCS bucket for rebuild logs")
 	prebuildBucket        = flag.String("prebuild-bucket", "", "GCS bucket from which prebuilt build tools are stored")
@@ -137,6 +138,9 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	}
 	d.MetadataBuilder = func(ctx context.Context, id string) (rebuild.AssetStore, error) {
 		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, id), "gs://"+*metadataBucket)
+	}
+	d.RebuildStoreBuilder = func(ctx context.Context, id string) (rebuild.AssetStore, error) {
+		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, id), "gs://"+*rebuildBucket)
 	}
 	d.OverwriteAttestations = *overwriteAttestations
 	u, err := url.Parse(*inferenceURL)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -25,6 +25,7 @@ import (
 	"cloud.google.com/go/firestore"
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/oss-rebuild/internal/api"
 	"github.com/google/oss-rebuild/internal/api/apiservice"
@@ -47,7 +48,6 @@ var (
 	buildLocalURL         = flag.String("build-local-url", "", "URL of the rebuild service")
 	inferenceURL          = flag.String("inference-url", "", "URL of the inference service")
 	signingKeyVersion     = flag.String("signing-key-version", "", "Resource name of the signing CryptoKeyVersion")
-	metadataBucket        = flag.String("metadata-bucket", "", "GCS bucket for rebuild metadata")
 	rebuildBucket         = flag.String("rebuild-bucket", "", "GCS bucket for rebuild artifacts")
 	attestationBucket     = flag.String("attestation-bucket", "", "GCS bucket to which to publish rebuild attestation")
 	logsBucket            = flag.String("logs-bucket", "", "GCS bucket for rebuild logs")
@@ -136,9 +136,7 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	if err != nil {
 		return nil, errors.Wrap(err, "creating attestation uploader")
 	}
-	d.MetadataBuilder = func(ctx context.Context, id string) (rebuild.AssetStore, error) {
-		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, id), "gs://"+*metadataBucket)
-	}
+	d.MetadataStore = rebuild.NewFilesystemAssetStore(memfs.New())
 	d.RebuildStoreBuilder = func(ctx context.Context, id string) (rebuild.AssetStore, error) {
 		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, id), "gs://"+*rebuildBucket)
 	}

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -128,6 +128,13 @@ resource "google_storage_bucket" "metadata" {
   uniform_bucket_level_access = true
   depends_on = [google_project_service.storage]
 }
+resource "google_storage_bucket" "rebuild-artifacts" {
+  name                        = "${var.host}-rebuild-artifacts"
+  location                    = "us-central1"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  depends_on = [google_project_service.storage]
+}
 resource "google_storage_bucket" "logs" {
   name                        = "${var.host}-rebuild-logs"
   location                    = "us-central1"
@@ -349,6 +356,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--prebuild-bucket=${google_storage_bucket.bootstrap-tools.name}",
         "--signing-key-version=${data.google_kms_crypto_key_version.signing-key-version.name}",
         "--metadata-bucket=${google_storage_bucket.metadata.name}",
+        "--rebuild-bucket=${google_storage_bucket.rebuild-artifacts.name}",
         "--attestation-bucket=${google_storage_bucket.attestations.name}",
         "--logs-bucket=${google_storage_bucket.logs.name}",
         "--gateway-url=${google_cloud_run_v2_service.gateway.uri}",
@@ -396,8 +404,13 @@ resource "google_storage_bucket_iam_binding" "orchestrator-manages-metadata" {
   role    = "roles/storage.objectAdmin"
   members = ["serviceAccount:${google_service_account.orchestrator.email}"]
 }
-resource "google_storage_bucket_iam_binding" "remote-build-writes-metadata" {
-  bucket  = google_storage_bucket.metadata.name
+resource "google_storage_bucket_iam_binding" "orchestrator-manages-rebuild-artifacts" {
+  bucket  = google_storage_bucket.rebuild-artifacts.name
+  role    = "roles/storage.objectAdmin"
+  members = ["serviceAccount:${google_service_account.orchestrator.email}"]
+}
+resource "google_storage_bucket_iam_binding" "remote-build-writes-rebuild-artifacts" {
+  bucket  = google_storage_bucket.rebuild-artifacts.name
   role    = "roles/storage.objectCreator"
   members = ["serviceAccount:${google_service_account.builder-remote.email}"]
 }

--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -37,11 +37,11 @@ type RemoteOptions struct {
 	Project             string
 	BuildServiceAccount string
 	LogsBucket          string
-	// MetadataStore stores the dockerfile and build info. Cloud build does not need access to this.
-	MetadataStore AssetStore
-	// RebuildStore stores the rebuilt artifact. Cloud build needs access to upload artifacts here.
-	RebuildStore       AssetStore
-	UtilPrebuildBucket string
+	// LocalMetadataStore stores the dockerfile and build info. Cloud build does not need access to this.
+	LocalMetadataStore AssetStore
+	// RemoteMetadataStore stores the rebuilt artifact. Cloud build needs access to upload artifacts here.
+	RemoteMetadataStore AssetStore
+	UtilPrebuildBucket  string
 	// TODO: Consider moving this to Strategy.
 	UseTimewarp bool
 }
@@ -180,7 +180,7 @@ func RebuildRemote(ctx context.Context, input Input, id string, opts RemoteOptio
 		return errors.Wrap(err, "creating dockerfile")
 	}
 	{
-		w, _, err := opts.MetadataStore.Writer(ctx, Asset{Target: t, Type: DockerfileAsset})
+		w, _, err := opts.LocalMetadataStore.Writer(ctx, Asset{Target: t, Type: DockerfileAsset})
 		if err != nil {
 			return errors.Wrap(err, "creating writer for Dockerfile")
 		}
@@ -191,11 +191,11 @@ func RebuildRemote(ctx context.Context, input Input, id string, opts RemoteOptio
 	}
 	// NOTE: Ignore the local writer since GCS doesn't flush writes until Close.
 	// TODO: Could be resolved by adding ResourcePath() method.
-	_, imageUploadPath, err := opts.RebuildStore.Writer(ctx, Asset{Target: t, Type: ContainerImageAsset})
+	_, imageUploadPath, err := opts.RemoteMetadataStore.Writer(ctx, Asset{Target: t, Type: ContainerImageAsset})
 	if err != nil {
 		return errors.Wrap(err, "creating dummy writer for container image")
 	}
-	_, rebuildUploadPath, err := opts.RebuildStore.Writer(ctx, Asset{Target: t, Type: RebuildAsset})
+	_, rebuildUploadPath, err := opts.RemoteMetadataStore.Writer(ctx, Asset{Target: t, Type: RebuildAsset})
 	if err != nil {
 		return errors.Wrap(err, "creating dummy writer for rebuild")
 	}
@@ -204,7 +204,7 @@ func RebuildRemote(ctx context.Context, input Input, id string, opts RemoteOptio
 		return errors.Wrap(err, "performing build")
 	}
 	{
-		w, _, err := opts.MetadataStore.Writer(ctx, Asset{Target: t, Type: BuildInfoAsset})
+		w, _, err := opts.LocalMetadataStore.Writer(ctx, Asset{Target: t, Type: BuildInfoAsset})
 		if err != nil {
 			return errors.Wrap(err, "creating writer for build info")
 		}


### PR DESCRIPTION
Previously the metadata bucket was used for both the rebuilt artifacts and also the build info/docker file.

This gave cloud build unnecessary access to both the build info and the dockerfile which are both written and read by the orchestrator.

After this PR, cloud build only has Create access to the newly created rebuild-artifacts bucket. That bucket only stores:
  1. The rebuilt artifact.
  2. The docker image used for the build.

Further, cloud build no longer has access to the metadata bucket, which contains the build info and docker file. Because it's only used locally to the orchestrator, I considered switching it to a filesystem or in-memory asset store, except we want these assets available for debugging so I'm keeping it as a bucket for now.

One interesting affect of this PR, is that `verifier.SummarizeArtifacts` only requires `rebuildStore` and `verifier.CreateAttestations` only requires the metadata store, clearly distinguishing where each of those steps get their input.

This further reduces the already tightly restricted permissions afforded the the cloud build role.