### PR TITLE
Firestore should return error gracefully.

### DIFF
--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -159,6 +159,7 @@ var getResults = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Printf("Fetched %d rebuilds", len(rebuilds))
 		byCount := firestore.GroupRebuilds(rebuilds)
 		if len(byCount) == 0 {
 			log.Println("No results")

--- a/tools/ctl/firestore/firestore.go
+++ b/tools/ctl/firestore/firestore.go
@@ -277,8 +277,10 @@ func (f *Client) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest) (r
 		rebuilds[r.ID()] = r
 	}
 	if err := <-cerr; err != nil {
-		log.Fatal("query error", err.Error())
+		err = errors.Wrap(err, "query error")
+		return nil, err
 	}
+	log.Printf("Fetched %d rebuilds", len(rebuilds))
 	return
 }
 

--- a/tools/ctl/firestore/firestore.go
+++ b/tools/ctl/firestore/firestore.go
@@ -280,7 +280,6 @@ func (f *Client) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest) (r
 		err = errors.Wrap(err, "query error")
 		return nil, err
 	}
-	log.Printf("Fetched %d rebuilds", len(rebuilds))
 	return
 }
 

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -346,6 +346,7 @@ func (e *explorer) makeRunNode(runid string) *tview.TreeNode {
 				log.Println(errors.Wrapf(err, "failed to get rebuilds for runid: %s", runid))
 				return
 			}
+			log.Printf("Fetched %d rebuilds", len(rebuilds))
 			byCount := firestore.GroupRebuilds(rebuilds)
 			for i := len(byCount) - 1; i >= 0; i-- {
 				vgnode := e.makeVerdictGroupNode(byCount[i], 100*float32(byCount[i].Count)/float32(len(rebuilds)))


### PR DESCRIPTION
This caused debugging to be really challenging, TUI would simply crash and no useful error would be logged because output was still being redirected to the TUI component.

I think it's reasonable for the TUI to keep running even if a firestore query fails.

I also added a success log message because otherwise empty queries are indistinguishable from hung queries.