### PR TITLE
Json decode before encode in the CLI.

### DIFF
--- a/cmd/oss-rebuild/main.go
+++ b/cmd/oss-rebuild/main.go
@@ -131,7 +131,7 @@ func (b *Bundle) Byproduct(name string) ([]byte, error) {
 }
 
 func writeIndentedJson(out io.Writer, b []byte) error {
-	var decoded interface{}
+	var decoded any
 	if err := json.NewDecoder(bytes.NewBuffer(b)).Decode(&decoded); err != nil {
 		return errors.Wrap(err, "decoding json")
 	}
@@ -223,7 +223,6 @@ The ecosystem is one of npm, pypi, or cratesio. For npm the artifact is the <pac
 			if err != nil {
 				log.Fatal(errors.Wrap(err, "getting build.json"))
 			}
-			cmd.OutOrStdout().Write(build)
 			if err := writeIndentedJson(cmd.OutOrStdout(), build); err != nil {
 				log.Fatal(errors.Wrap(err, "encoding build.json"))
 			}

--- a/cmd/oss-rebuild/main.go
+++ b/cmd/oss-rebuild/main.go
@@ -130,6 +130,19 @@ func (b *Bundle) Byproduct(name string) ([]byte, error) {
 	return nil, fmt.Errorf("byproduct named %s not found", name)
 }
 
+func writeIndentedJson(out io.Writer, b []byte) error {
+	var decoded interface{}
+	if err := json.NewDecoder(bytes.NewBuffer(b)).Decode(&decoded); err != nil {
+		return errors.Wrap(err, "decoding json")
+	}
+	e := json.NewEncoder(out)
+	e.SetIndent("", "  ")
+	if err := e.Encode(decoded); err != nil {
+		log.Fatal(errors.Wrap(err, "encoding json"))
+	}
+	return nil
+}
+
 var getCmd = &cobra.Command{
 	Use:   "get <ecosystem> <package> <version> [<artifact>]",
 	Short: "Get rebuild attestation for a specific artifact.",
@@ -210,9 +223,8 @@ The ecosystem is one of npm, pypi, or cratesio. For npm the artifact is the <pac
 			if err != nil {
 				log.Fatal(errors.Wrap(err, "getting build.json"))
 			}
-			e := json.NewEncoder(cmd.OutOrStdout())
-			e.SetIndent("", "  ")
-			if err := e.Encode(build); err != nil {
+			cmd.OutOrStdout().Write(build)
+			if err := writeIndentedJson(cmd.OutOrStdout(), build); err != nil {
 				log.Fatal(errors.Wrap(err, "encoding build.json"))
 			}
 		case "steps":
@@ -220,9 +232,7 @@ The ecosystem is one of npm, pypi, or cratesio. For npm the artifact is the <pac
 			if err != nil {
 				log.Fatal(errors.Wrap(err, "getting steps.json"))
 			}
-			e := json.NewEncoder(cmd.OutOrStdout())
-			e.SetIndent("", "  ")
-			if err := e.Encode(steps); err != nil {
+			if err := writeIndentedJson(cmd.OutOrStdout(), steps); err != nil {
 				log.Fatal(errors.Wrap(err, "encoding steps.json"))
 			}
 		default:


### PR DESCRIPTION
When fetching the build or steps from our attestations the CLI was converting them back to base64 instead of adding intendation. I think this is because we were asking the json encoder to Encode() a bytes string that was already json, so it encoded those bytes into base64 and added quotes outside it.