### PR TITLE
Bump go version to 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.21", "1.22"]
+        go-version: ["1.22", "1.23"]
 
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/oss-rebuild
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/bigquery v1.59.1


### PR DESCRIPTION
With 1.23 released, 1.21 has gone out of the support window.