### PR TITLE
Use npx -c to ensure compatibility before npm@8.0.0

### DIFF
--- a/pkg/rebuild/npm/strategy.go
+++ b/pkg/rebuild/npm/strategy.go
@@ -43,7 +43,7 @@ func (b *NPMPackBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebui
 {{if ne .VersionOverride "" -}}
 PATH=/usr/bin:/bin:/usr/local/bin /usr/bin/npm version --prefix {{.Location.Dir}} --no-git-tag-version {{.VersionOverride}}
 {{end -}}
-/usr/bin/npx --package=npm@{{.NPMVersion}} -- "cd {{.Location.Dir}} && npm pack"
+/usr/bin/npx --package=npm@{{.NPMVersion}} -c "cd {{.Location.Dir}} && npm pack"
 `, b)
 	if err != nil {
 		return rebuild.Instructions{}, err
@@ -87,7 +87,7 @@ func (b *NPMCustomBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (reb
 /usr/bin/npm config --location-global set registry {{.BuildEnv.TimewarpURL "npm" .RegistryTime}}
 trap '/usr/bin/npm config --location-global delete registry' EXIT
 wget -O - https://unofficial-builds.nodejs.org/download/release/v{{.NodeVersion}}/node-v{{.NodeVersion}}-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/local/
-/usr/local/bin/npx --package=npm@{{.NPMVersion}} -- "cd {{.Location.Dir}} && npm install --force"
+/usr/local/bin/npx --package=npm@{{.NPMVersion}} -c "cd {{.Location.Dir}} && npm install --force"
 `, buildAndEnv)
 	if err != nil {
 		return rebuild.Instructions{}, err
@@ -97,7 +97,7 @@ wget -O - https://unofficial-builds.nodejs.org/download/release/v{{.NodeVersion}
 {{if ne .VersionOverride "" -}}
 PATH=/usr/bin:/bin:/usr/local/bin /usr/bin/npm version --prefix {{.Location.Dir}} --no-git-tag-version {{.VersionOverride}}
 {{end -}}
-/usr/local/bin/npx --package=npm@{{.NPMVersion}} -- "cd {{.Location.Dir}} && npm run {{.Command}}" && rm -rf node_modules && npm pack
+/usr/local/bin/npx --package=npm@{{.NPMVersion}} -c "cd {{.Location.Dir}} && npm run {{.Command}}" && rm -rf node_modules && npm pack
 `, b)
 	if err != nil {
 		return rebuild.Instructions{}, err

--- a/pkg/rebuild/npm/strategy_test.go
+++ b/pkg/rebuild/npm/strategy_test.go
@@ -46,7 +46,7 @@ func TestNPMCustomBuild(t *testing.T) {
 				Source:     "git checkout --force 'the_ref'",
 				Deps:       "",
 				Build: `PATH=/usr/bin:/bin:/usr/local/bin /usr/bin/npm version --prefix the_dir --no-git-tag-version green
-/usr/bin/npx --package=npm@red -- "cd the_dir && npm pack"`,
+/usr/bin/npx --package=npm@red -c "cd the_dir && npm pack"`,
 				OutputPath: "the_dir/the_artifact",
 			},
 		},
@@ -62,7 +62,7 @@ func TestNPMCustomBuild(t *testing.T) {
 				SystemDeps: []string{"git", "npm"},
 				Source:     "git checkout --force 'the_ref'",
 				Deps:       "",
-				Build:      `/usr/bin/npx --package=npm@red -- "cd the_dir && npm pack"`,
+				Build:      `/usr/bin/npx --package=npm@red -c "cd the_dir && npm pack"`,
 				OutputPath: "the_dir/the_artifact",
 			},
 		},
@@ -83,9 +83,9 @@ func TestNPMCustomBuild(t *testing.T) {
 				Deps: `/usr/bin/npm config --location-global set registry http://npm:2006-01-02T03:04:05Z@orange
 trap '/usr/bin/npm config --location-global delete registry' EXIT
 wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/local/
-/usr/local/bin/npx --package=npm@red -- "cd the_dir && npm install --force"`,
+/usr/local/bin/npx --package=npm@red -c "cd the_dir && npm install --force"`,
 				Build: `PATH=/usr/bin:/bin:/usr/local/bin /usr/bin/npm version --prefix the_dir --no-git-tag-version green
-/usr/local/bin/npx --package=npm@red -- "cd the_dir && npm run yellow" && rm -rf node_modules && npm pack`,
+/usr/local/bin/npx --package=npm@red -c "cd the_dir && npm run yellow" && rm -rf node_modules && npm pack`,
 				OutputPath: "the_dir/the_artifact",
 			},
 		},
@@ -106,8 +106,8 @@ wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue
 				Deps: `/usr/bin/npm config --location-global set registry http://npm:2006-01-02T03:04:05Z@orange
 trap '/usr/bin/npm config --location-global delete registry' EXIT
 wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/local/
-/usr/local/bin/npx --package=npm@red -- "cd the_dir && npm install --force"`,
-				Build:      `/usr/local/bin/npx --package=npm@red -- "cd the_dir && npm run yellow" && rm -rf node_modules && npm pack`,
+/usr/local/bin/npx --package=npm@red -c "cd the_dir && npm install --force"`,
+				Build:      `/usr/local/bin/npx --package=npm@red -c "cd the_dir && npm run yellow" && rm -rf node_modules && npm pack`,
 				OutputPath: "the_dir/the_artifact",
 			},
 		},


### PR DESCRIPTION
Comparing the two npm versions, `--` wasn't present in v7 while `-c` remains supported:
- v8: https://docs.npmjs.com/cli/v8/commands/npx
- v7: https://docs.npmjs.com/cli/v7/commands/npx

This manifested as failures during dependency install:

```
Error: Invalid tag name "cd . && npm install --force": Tags may not have any characters that encodeURIComponent encodes.
```