### PR TITLE
Separate out AssetStore path API

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -137,7 +137,7 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 		return nil, errors.Wrap(err, "creating attestation uploader")
 	}
 	d.LocalMetadataStore = rebuild.NewFilesystemAssetStore(memfs.New())
-	d.RemoteMetadataStoreBuilder = func(ctx context.Context, id string) (rebuild.AssetStore, error) {
+	d.RemoteMetadataStoreBuilder = func(ctx context.Context, id string) (rebuild.LocatableAssetStore, error) {
 		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, id), "gs://"+*metadataBucket)
 	}
 	d.OverwriteAttestations = *overwriteAttestations

--- a/cmd/oss-rebuild/main.go
+++ b/cmd/oss-rebuild/main.go
@@ -53,7 +53,7 @@ type Bundle struct {
 }
 
 func NewBundle(ctx context.Context, t rebuild.Target, attestation rebuild.AssetStore) (*Bundle, error) {
-	r, _, err := attestation.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.AttestationBundleAsset})
+	r, err := attestation.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.AttestationBundleAsset})
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "opening bundle"))
 	}

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -116,7 +116,7 @@ type RebuildPackageDeps struct {
 	BuildDefRepo               rebuild.Location
 	AttestationStore           rebuild.AssetStore
 	LocalMetadataStore         rebuild.AssetStore
-	RemoteMetadataStoreBuilder func(ctx context.Context, id string) (rebuild.AssetStore, error)
+	RemoteMetadataStoreBuilder func(ctx context.Context, id string) (rebuild.LocatableAssetStore, error)
 	OverwriteAttestations      bool
 	InferStub                  api.StubT[schema.InferenceRequest, schema.StrategyOneOf]
 }
@@ -290,7 +290,7 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 		return nil, err
 	}
 	var dockerfile string
-	w, _, err := deps.LocalMetadataStore.Reader(ctx, rebuild.Asset{Target: v.Target, Type: rebuild.DockerfileAsset})
+	w, err := deps.LocalMetadataStore.Reader(ctx, rebuild.Asset{Target: v.Target, Type: rebuild.DockerfileAsset})
 	if err == nil {
 		if b, err := io.ReadAll(w); err == nil {
 			dockerfile = string(b)

--- a/internal/verifier/attestation.go
+++ b/internal/verifier/attestation.go
@@ -40,7 +40,7 @@ func CreateAttestations(ctx context.Context, input rebuild.Input, finalStrategy 
 	t, manualStrategy := input.Target, input.Strategy
 	var dockerfile []byte
 	{
-		r, _, err := metadata.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.DockerfileAsset})
+		r, err := metadata.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.DockerfileAsset})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "opening rebuild Dockerfile")
 		}
@@ -52,7 +52,7 @@ func CreateAttestations(ctx context.Context, input rebuild.Input, finalStrategy 
 	}
 	var buildInfo rebuild.BuildInfo
 	{
-		r, _, err := metadata.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.BuildInfoAsset})
+		r, err := metadata.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.BuildInfoAsset})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "opening rebuild build info file")
 		}

--- a/internal/verifier/attestation_test.go
+++ b/internal/verifier/attestation_test.go
@@ -65,14 +65,12 @@ func TestCreateAttestations(t *testing.T) {
 		fs := memfs.New()
 		metadata := rebuild.NewFilesystemAssetStore(fs)
 		{
-			w, _, err := metadata.Writer(ctx, rebuild.Asset{Target: target, Type: rebuild.DockerfileAsset})
-			orDie(err)
+			w := must(metadata.Writer(ctx, rebuild.Asset{Target: target, Type: rebuild.DockerfileAsset}))
 			must(w.Write([]byte("FROM alpine:latest\nRUN echo deps\nENTRYPOINT [\"echo\", \"build\"]")))
 			orDie(w.Close())
 		}
 		{
-			w, _, err := metadata.Writer(ctx, rebuild.Asset{Target: target, Type: rebuild.BuildInfoAsset})
-			orDie(err)
+			w := must(metadata.Writer(ctx, rebuild.Asset{Target: target, Type: rebuild.BuildInfoAsset}))
 			must(w.Write(must(json.Marshal(buildInfo))))
 			orDie(w.Close())
 		}

--- a/internal/verifier/attestor.go
+++ b/internal/verifier/attestor.go
@@ -34,7 +34,7 @@ type Attestor struct {
 
 // BundleExists returns whether an existing attestation bundle exists.
 func (a Attestor) BundleExists(ctx context.Context, t rebuild.Target) (bool, error) {
-	r, _, err := a.Store.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.AttestationBundleAsset})
+	r, err := a.Store.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.AttestationBundleAsset})
 	if errors.Is(err, rebuild.ErrAssetNotFound) {
 		return false, nil
 	} else if err != nil {
@@ -63,7 +63,7 @@ func (a Attestor) PublishBundle(ctx context.Context, t rebuild.Target, stmts ...
 			return errors.Wrap(err, "marshalling DSSE")
 		}
 	}
-	w, _, err := a.Store.Writer(ctx, rebuild.Asset{Target: t, Type: rebuild.AttestationBundleAsset})
+	w, err := a.Store.Writer(ctx, rebuild.Asset{Target: t, Type: rebuild.AttestationBundleAsset})
 	if err != nil {
 		return errors.Wrap(err, "creating writer for bundle")
 	}

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -35,12 +35,14 @@ type ArtifactSummary struct {
 }
 
 // SummarizeArtifacts fetches and summarizes the rebuild and upstream artifacts.
-func SummarizeArtifacts(ctx context.Context, metadata rebuild.AssetStore, t rebuild.Target, upstreamURI string, hashes []crypto.Hash) (rb, up ArtifactSummary, err error) {
+func SummarizeArtifacts(ctx context.Context, metadata rebuild.LocatableAssetStore, t rebuild.Target, upstreamURI string, hashes []crypto.Hash) (rb, up ArtifactSummary, err error) {
 	rb = ArtifactSummary{Hash: hashext.NewMultiHash(hashes...), CanonicalHash: hashext.NewMultiHash(hashes...)}
 	up = ArtifactSummary{Hash: hashext.NewMultiHash(hashes...), CanonicalHash: hashext.NewMultiHash(hashes...), URI: upstreamURI}
 	// Fetch and process rebuild.
 	var r io.ReadCloser
-	r, rb.URI, err = metadata.Reader(ctx, rebuild.Asset{Target: t, Type: rebuild.RebuildAsset})
+	rbAsset := rebuild.Asset{Target: t, Type: rebuild.RebuildAsset}
+	rb.URI = metadata.URL(rbAsset).String()
+	r, err = metadata.Reader(ctx, rbAsset)
 	if err != nil {
 		err = errors.Wrap(err, "reading artifact")
 		return

--- a/internal/verifier/summary_test.go
+++ b/internal/verifier/summary_test.go
@@ -42,7 +42,9 @@ func TestSummarizeArtifacts(t *testing.T) {
 			Version:   "1.0.0",
 			Artifact:  "foo-1.0.0.whl",
 		}
-		w, rebuildURI, err := metadata.Writer(ctx, rebuild.Asset{Target: target, Type: rebuild.RebuildAsset})
+		asset := rebuild.Asset{Target: target, Type: rebuild.RebuildAsset}
+		rebuildURI := metadata.URL(asset).String()
+		w, err := metadata.Writer(ctx, asset)
 		orDie(err)
 		origHash := hashext.NewMultiHash(crypto.SHA256)
 		origZip := must(archivetest.ZipFile([]archive.ZipEntry{

--- a/pkg/builddef/set.go
+++ b/pkg/builddef/set.go
@@ -43,7 +43,7 @@ func NewFilesystemBuildDefinitionSet(fs billy.Filesystem) *FilesystemBuildDefini
 
 func (s *FilesystemBuildDefinitionSet) Get(ctx context.Context, t rebuild.Target) (rebuild.Strategy, error) {
 	definitions := rebuild.NewFilesystemAssetStore(s.fs)
-	r, _, err := definitions.Reader(ctx, rebuild.Asset{Type: rebuild.BuildDef, Target: t})
+	r, err := definitions.Reader(ctx, rebuild.Asset{Type: rebuild.BuildDef, Target: t})
 	if err != nil {
 		if errors.Is(err, rebuild.ErrAssetNotFound) {
 			return nil, nil // Return nil strategy if definition is not found
@@ -59,9 +59,9 @@ func (s *FilesystemBuildDefinitionSet) Get(ctx context.Context, t rebuild.Target
 }
 
 func (s *FilesystemBuildDefinitionSet) Path(ctx context.Context, t rebuild.Target) (string, error) {
-	definitions := rebuild.NewFilesystemAssetStore(s.fs)
-	_, pth, err := definitions.Reader(ctx, rebuild.Asset{Type: rebuild.BuildDef, Target: t})
-	return pth, err
+	defs := rebuild.NewFilesystemAssetStore(s.fs)
+	url := defs.URL(rebuild.Asset{Type: rebuild.BuildDef, Target: t})
+	return url.Path, nil
 }
 
 type GitBuildDefinitionSet struct {

--- a/pkg/rebuild/cratesio/rebuild.go
+++ b/pkg/rebuild/cratesio/rebuild.go
@@ -138,7 +138,7 @@ func (Rebuilder) Compare(ctx context.Context, t rebuild.Target, rb, up rebuild.A
 	{
 		var upRef string
 		{
-			r, _, err := assets.Reader(ctx, up)
+			r, err := assets.Reader(ctx, up)
 			if err != nil {
 				return nil, errors.Wrapf(err, "reading upstream")
 			}

--- a/pkg/rebuild/cratesio/rebuild_test.go
+++ b/pkg/rebuild/cratesio/rebuild_test.go
@@ -205,7 +205,7 @@ func TestCompare(t *testing.T) {
 			as := rebuild.NewFilesystemAssetStore(memfs.New())
 			rb, up := rebuild.Asset{Type: rebuild.DebugRebuildAsset, Target: tc.target}, rebuild.Asset{Type: rebuild.DebugUpstreamAsset, Target: tc.target}
 			{
-				w, _ := must2(as.Writer(context.Background(), rb))
+				w := must(as.Writer(context.Background(), rb))
 				gw := gzip.NewWriter(w)
 				tw := tar.NewWriter(gw)
 				for _, entry := range tc.rebuild {
@@ -215,7 +215,7 @@ func TestCompare(t *testing.T) {
 				orDie(gw.Close())
 			}
 			{
-				w, _ := must2(as.Writer(context.Background(), up))
+				w := must(as.Writer(context.Background(), up))
 				gw := gzip.NewWriter(w)
 				tw := tar.NewWriter(gw)
 				for _, entry := range tc.upstream {
@@ -240,13 +240,6 @@ func must[T any](t T, err error) T {
 		panic(err)
 	}
 	return t
-}
-
-func must2[T, U any](t T, u U, err error) (T, U) {
-	if err != nil {
-		panic(err)
-	}
-	return t, u
 }
 
 func orDie(err error) {

--- a/pkg/rebuild/npm/rebuild_test.go
+++ b/pkg/rebuild/npm/rebuild_test.go
@@ -183,7 +183,7 @@ func TestCompare(t *testing.T) {
 			as := rebuild.NewFilesystemAssetStore(memfs.New())
 			rb, up := rebuild.Asset{Type: rebuild.DebugRebuildAsset, Target: tc.target}, rebuild.Asset{Type: rebuild.DebugUpstreamAsset, Target: tc.target}
 			{
-				w, _ := must2(as.Writer(context.Background(), rb))
+				w := must(as.Writer(context.Background(), rb))
 				gw := gzip.NewWriter(w)
 				tw := tar.NewWriter(gw)
 				for _, entry := range tc.rebuild {
@@ -193,7 +193,7 @@ func TestCompare(t *testing.T) {
 				orDie(gw.Close())
 			}
 			{
-				w, _ := must2(as.Writer(context.Background(), up))
+				w := must(as.Writer(context.Background(), up))
 				gw := gzip.NewWriter(w)
 				tw := tar.NewWriter(gw)
 				for _, entry := range tc.upstream {
@@ -218,13 +218,6 @@ func must[T any](t T, err error) T {
 		panic(err)
 	}
 	return t
-}
-
-func must2[T, U any](t T, u U, err error) (T, U) {
-	if err != nil {
-		panic(err)
-	}
-	return t, u
 }
 
 func orDie(err error) {

--- a/pkg/rebuild/pypi/rebuild_test.go
+++ b/pkg/rebuild/pypi/rebuild_test.go
@@ -154,7 +154,7 @@ func TestCompare(t *testing.T) {
 			as := rebuild.NewFilesystemAssetStore(memfs.New())
 			rb, up := rebuild.Asset{Type: rebuild.DebugRebuildAsset, Target: tc.target}, rebuild.Asset{Type: rebuild.DebugUpstreamAsset, Target: tc.target}
 			{
-				w, _ := must2(as.Writer(context.Background(), rb))
+				w := must(as.Writer(context.Background(), rb))
 				zw := zip.NewWriter(w)
 				for _, entry := range tc.rebuild {
 					orDie(entry.WriteTo(zw))
@@ -162,7 +162,7 @@ func TestCompare(t *testing.T) {
 				orDie(zw.Close())
 			}
 			{
-				w, _ := must2(as.Writer(context.Background(), up))
+				w := must(as.Writer(context.Background(), up))
 				zw := zip.NewWriter(w)
 				for _, entry := range tc.upstream {
 					orDie(entry.WriteTo(zw))
@@ -185,13 +185,6 @@ func must[T any](t T, err error) T {
 		panic(err)
 	}
 	return t
-}
-
-func must2[T, U any](t T, u U, err error) (T, U) {
-	if err != nil {
-		panic(err)
-	}
-	return t, u
 }
 
 func orDie(err error) {

--- a/pkg/rebuild/rebuild/compare.go
+++ b/pkg/rebuild/rebuild/compare.go
@@ -42,7 +42,7 @@ func artifactReader(ctx context.Context, t Target, mux RegistryMux) (io.ReadClos
 func Canonicalize(ctx context.Context, t Target, mux RegistryMux, rbPath string, fs billy.Filesystem, assets AssetStore) (rb, up Asset, err error) {
 	{ // Canonicalize rebuild
 		rb = Asset{Type: DebugRebuildAsset, Target: t}
-		w, _, err := assets.Writer(ctx, rb)
+		w, err := assets.Writer(ctx, rb)
 		if err != nil {
 			return rb, up, errors.Errorf("[INTERNAL] failed to store asset %v", rb)
 		}
@@ -58,7 +58,7 @@ func Canonicalize(ctx context.Context, t Target, mux RegistryMux, rbPath string,
 	}
 	{ // Canonicalize upstream
 		up = Asset{Type: DebugUpstreamAsset, Target: t}
-		w, _, err := assets.Writer(ctx, up)
+		w, err := assets.Writer(ctx, up)
 		if err != nil {
 			return rb, up, errors.Errorf("[INTERNAL] failued to store asset %v", up)
 		}
@@ -78,7 +78,7 @@ func Canonicalize(ctx context.Context, t Target, mux RegistryMux, rbPath string,
 // Summarize constructs ContentSummary objects for the upstream and rebuilt artifacts.
 func Summarize(ctx context.Context, t Target, rb, up Asset, assets AssetStore) (csRB, csUP *archive.ContentSummary, err error) {
 	{ // Summarize rebuild
-		r, _, err := assets.Reader(ctx, rb)
+		r, err := assets.Reader(ctx, rb)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "[INTERNAL] Failed to find rebuilt artifact")
 		}
@@ -89,7 +89,7 @@ func Summarize(ctx context.Context, t Target, rb, up Asset, assets AssetStore) (
 		}
 	}
 	{ // Summarize upstream
-		r, _, err := assets.Reader(ctx, up)
+		r, err := assets.Reader(ctx, up)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "[INTERNAL] Failed to find upstream artifact")
 		}

--- a/pkg/rebuild/rebuild/rebuildmany.go
+++ b/pkg/rebuild/rebuild/rebuildmany.go
@@ -123,7 +123,7 @@ func RebuildMany(ctx context.Context, rebuilder Rebuilder, inputs []Input, regis
 		resetLogger()
 		{
 			asset := Asset{Type: DebugLogsAsset, Target: t}
-			w, _, err := localAssets.Writer(ctx, asset)
+			w, err := localAssets.Writer(ctx, asset)
 			if err != nil {
 				log.Printf("Failed to create writer for log asset: %v\n", err)
 			} else {
@@ -139,7 +139,7 @@ func RebuildMany(ctx context.Context, rebuilder Rebuilder, inputs []Input, regis
 		}
 		if debugStorer != nil {
 			for _, asset := range assets {
-				if _, err := AssetCopy(ctx, debugStorer, localAssets, asset); err != nil {
+				if err := AssetCopy(ctx, debugStorer, localAssets, asset); err != nil {
 					log.Printf("Failed to upload asset to debug storer: %v\n", err)
 				}
 			}


### PR DESCRIPTION
Previously, The reader and writer apis had an ad hoc additional return value which was the ill-defined "resource path" for that asset. This change breaks that out into a more formal API and uses URLs as the medium of exchange.

As for the design choice to split out the URL() method into a separate interface: I found it useful to have users of this function declare in their signatures exactly where they want to "break out" of accessing assets exclusively through the AssetStore.