### PR TITLE
Add TransparentProxyService constructor

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -36,7 +36,8 @@ func main() {
 	if *verbose {
 		log.Printf("Server starting up! - configured to listen on http interface %s and https interface %s", *httpProxyAddr, *tlsProxyAddr)
 	}
-	proxyServer := proxy.NewTransparentProxyService(*verbose, ca)
+	p := proxy.NewTransparentProxyServer(*verbose)
+	proxyServer := proxy.NewTransparentProxyService(p, ca)
 	// Administrative endpoint.
 	go proxyServer.ServeMetadata(*ctrlAddr)
 	// Start proxy server endpoints.

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -5,12 +5,10 @@ import (
 	"flag"
 	"log"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/oss-rebuild/pkg/proxy/cert"
 	"github.com/google/oss-rebuild/pkg/proxy/docker"
-	"github.com/google/oss-rebuild/pkg/proxy/netlog"
 	"github.com/google/oss-rebuild/pkg/proxy/proxy"
 )
 
@@ -38,15 +36,9 @@ func main() {
 	if *verbose {
 		log.Printf("Server starting up! - configured to listen on http interface %s and https interface %s", *httpProxyAddr, *tlsProxyAddr)
 	}
-	p := proxy.NewTransparentProxyServer(*verbose)
+	proxyServer := proxy.NewTransparentProxyService(*verbose, ca)
 	// Administrative endpoint.
-	mx := new(sync.Mutex)
-	proxyServer := proxy.TransparentProxyService{
-		Proxy:      p,
-		Ca:         ca,
-		NetworkLog: netlog.CaptureActivityLog(p, mx),
-	}
-	go proxyServer.ServeMetadata(*ctrlAddr, mx)
+	go proxyServer.ServeMetadata(*ctrlAddr)
 	// Start proxy server endpoints.
 	go proxyServer.ProxyTLS(*tlsProxyAddr)
 	go proxyServer.ProxyHTTP(*httpProxyAddr)

--- a/pkg/proxy/proxy/transparent.go
+++ b/pkg/proxy/proxy/transparent.go
@@ -76,8 +76,7 @@ type TransparentProxyService struct {
 }
 
 // NewTransparentProxyService creates a new TransparentProxyService.
-func NewTransparentProxyService(verbose bool, ca *tls.Certificate) TransparentProxyService {
-	p := NewTransparentProxyServer(verbose)
+func NewTransparentProxyService(p *goproxy.ProxyHttpServer, ca *tls.Certificate) TransparentProxyService {
 	m := new(sync.Mutex)
 	return TransparentProxyService{
 		Proxy:      p,


### PR DESCRIPTION
 - Create constructor with mutex as a private member.
 - Initialize the network log inside the constructor.

Closes #89 
 