### PR TITLE
Migrate uses of os errors to fs equivalents

### DIFF
--- a/pkg/proxy/docker/docker_test.go
+++ b/pkg/proxy/docker/docker_test.go
@@ -777,8 +777,8 @@ func TestGetEnvVar(t *testing.T) {
 		Want    string
 		WantErr error
 	}){
-		{[]byte(`{}`), "FOO", "", os.ErrNotExist},
-		{[]byte(`{"Env":["BAR="]}`), "FOO", "", os.ErrNotExist},
+		{[]byte(`{}`), "FOO", "", fs.ErrNotExist},
+		{[]byte(`{"Env":["BAR="]}`), "FOO", "", fs.ErrNotExist},
 		{[]byte(`{"Env":["FOO="]}`), "FOO", "", nil},
 		{[]byte(`{"Env":["FOO=a"]}`), "FOO", "a", nil},
 		{[]byte(`{"Env":["FOO='a'"]}`), "FOO", "'a'", nil},

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -23,8 +23,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -108,7 +108,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 	topLevel := t.Package + "-" + vmeta.Version.Version
 	vcsInfo, err := getFileFromCrate(bytes.NewReader(crateBytes), topLevel+"/.cargo_vcs_info.json")
 	var info reg.CargoVCSInfo
-	if err == os.ErrNotExist {
+	if errors.Is(err, fs.ErrNotExist) {
 		log.Printf("No .cargo_vcs_info.json file found")
 	} else if err != nil {
 		return "", "", errors.Wrapf(err, "[INTERNAL] Failed to extract upstream .cargo_vcs_info.json")
@@ -236,7 +236,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	topLevel := t.Package + "-" + vmeta.Version.Version
 	lockContent, err := getFileFromCrate(bytes.NewReader(b), topLevel+"/Cargo.lock")
 	var lock *ExplicitLockfile
-	if err == os.ErrNotExist {
+	if errors.Is(err, fs.ErrNotExist) {
 		lock = nil
 	} else if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream Cargo.lock")
@@ -286,7 +286,7 @@ func getFileFromCrate(crate io.Reader, path string) ([]byte, error) {
 			return nil, err
 		}
 	}
-	return nil, os.ErrNotExist
+	return nil, fs.ErrNotExist
 }
 
 // findAndValidateCargoTOML ensures the package config has the expected name and version, or finds a new version if necessary.

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/fs"
 	"log"
-	"os"
 	re "regexp"
 	"strings"
 
@@ -357,5 +356,5 @@ func getFile(fname string, zr *zip.Reader) ([]byte, error) {
 			return io.ReadAll(fi)
 		}
 	}
-	return nil, os.ErrNotExist
+	return nil, fs.ErrNotExist
 }

--- a/pkg/rebuild/rebuild/rebuildone.go
+++ b/pkg/rebuild/rebuild/rebuildone.go
@@ -16,8 +16,8 @@ package rebuild
 
 import (
 	"context"
+	iofs "io/fs"
 	"log"
-	"os"
 	"time"
 
 	billy "github.com/go-git/go-billy/v5"
@@ -117,7 +117,7 @@ func RebuildOne(ctx context.Context, r Rebuilder, input Input, mux RegistryMux, 
 	rbPath := inst.OutputPath
 	_, err = fs.Stat(rbPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, iofs.ErrNotExist) {
 			return &Verdict{Target: t, Message: errors.Wrap(err, "failed to locate artifact").Error(), Strategy: strategy}, []Asset{}, nil
 		}
 		return nil, nil, errors.Wrapf(err, "failed to stat artifact")


### PR DESCRIPTION
The os errors are intended for use in OS I/O operations, not as generic errors for fs-like abstractions. See guidance: https://pkg.go.dev/os#IsNotExist