### PR TITLE
Add option to disable capturing network activity log

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -57,8 +57,8 @@ func main() {
 			log.Fatalf("Error unmarshaling policy file content: %v", err)
 		}
 	}
-	proxyService := proxy.NewTransparentProxyService(p, ca, proxy.PolicyMode(*policyMode), &pl, proxy.TransparentProxyServiceOpts{
-		SkipLogInit: false,
+	proxyService := proxy.NewTransparentProxyService(p, ca, proxy.PolicyMode(*policyMode), proxy.TransparentProxyServiceOpts{
+		Policy: &pl,
 	})
 	proxyService.Proxy.OnRequest().DoFunc(
 		func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -57,8 +57,9 @@ func main() {
 			log.Fatalf("Error unmarshaling policy file content: %v", err)
 		}
 	}
-	proxyService := proxy.NewTransparentProxyService(p, ca, proxy.PolicyMode(*policyMode), &pl)
-	proxyService.LogActivity()
+	proxyService := proxy.NewTransparentProxyService(p, ca, proxy.PolicyMode(*policyMode), &pl, proxy.TransparentProxyServiceOpts{
+		SkipLogInit: false,
+	})
 	proxyService.Proxy.OnRequest().DoFunc(
 		func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 			return proxyService.ApplyNetworkPolicy(req, ctx)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -58,6 +58,7 @@ func main() {
 		}
 	}
 	proxyService := proxy.NewTransparentProxyService(p, ca, proxy.PolicyMode(*policyMode), &pl)
+	proxyService.LogActivity()
 	proxyService.Proxy.OnRequest().DoFunc(
 		func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 			return proxyService.ApplyNetworkPolicy(req, ctx)

--- a/pkg/proxy/proxy/transparent.go
+++ b/pkg/proxy/proxy/transparent.go
@@ -125,17 +125,6 @@ func NewTransparentProxyService(p *goproxy.ProxyHttpServer, ca *tls.Certificate,
 	}
 }
 
-// RotateLog clears the activity log if logging is enabled. Otherwise starts capturing network activity.
-func (t *TransparentProxyService) RotateLog() {
-	t.mx.Lock()
-	defer t.mx.Unlock()
-	if t.networkLog == nil {
-		t.networkLog = netlog.CaptureActivityLog(t.Proxy, t.mx)
-	} else {
-		t.networkLog.HTTPRequests = []netlog.HTTPRequestLog{}
-	}
-}
-
 // ProxyHTTP serves an endpoint that transparently redirects HTTP connections to the proxy server.
 // This endpoint also explicitly (i.e. non-transparently) proxies HTTP and TLS connections.
 func (t TransparentProxyService) ProxyHTTP(addr string) {

--- a/pkg/proxy/proxy/transparent.go
+++ b/pkg/proxy/proxy/transparent.go
@@ -108,11 +108,16 @@ func NewTransparentProxyService(p *goproxy.ProxyHttpServer, ca *tls.Certificate,
 	return TransparentProxyService{
 		Proxy:      p,
 		Ca:         ca,
-		NetworkLog: netlog.CaptureActivityLog(p, m),
+		NetworkLog: &netlog.NetworkActivityLog{},
 		Mode:       mode,
 		Policy:     pl,
 		mx:         m,
 	}
+}
+
+// LogActivity starts recording network activity in memory.
+func (t *TransparentProxyService) LogActivity() {
+	t.NetworkLog = netlog.CaptureActivityLog(t.Proxy, t.mx)
 }
 
 // ProxyHTTP serves an endpoint that transparently redirects HTTP connections to the proxy server.

--- a/pkg/proxy/proxy/transparent_test.go
+++ b/pkg/proxy/proxy/transparent_test.go
@@ -207,7 +207,7 @@ func TestPolicyEndpoint(t *testing.T) {
 			wantResp:   http.StatusMethodNotAllowed,
 		},
 	}
-	proxyService := NewTransparentProxyService(NewTransparentProxyServer(false), nil, "enforce", &policy.Policy{}, TransparentProxyServiceOpts{})
+	proxyService := NewTransparentProxyService(NewTransparentProxyServer(false), nil, "enforce", TransparentProxyServiceOpts{})
 	policy.RegisterRule("URLMatchRule", func() policy.Rule { return &policy.URLMatchRule{} })
 	mux := http.NewServeMux()
 	mux.HandleFunc("/policy", proxyService.policyHandler)

--- a/pkg/proxy/proxy/transparent_test.go
+++ b/pkg/proxy/proxy/transparent_test.go
@@ -207,7 +207,7 @@ func TestPolicyEndpoint(t *testing.T) {
 			wantResp:   http.StatusMethodNotAllowed,
 		},
 	}
-	proxyService := NewTransparentProxyService(NewTransparentProxyServer(false), nil, "enforce", &policy.Policy{})
+	proxyService := NewTransparentProxyService(NewTransparentProxyServer(false), nil, "enforce", &policy.Policy{}, TransparentProxyServiceOpts{})
 	policy.RegisterRule("URLMatchRule", func() policy.Rule { return &policy.URLMatchRule{} })
 	mux := http.NewServeMux()
 	mux.HandleFunc("/policy", proxyService.policyHandler)

--- a/pkg/proxy/proxy/transparent_test.go
+++ b/pkg/proxy/proxy/transparent_test.go
@@ -207,7 +207,9 @@ func TestPolicyEndpoint(t *testing.T) {
 			wantResp:   http.StatusMethodNotAllowed,
 		},
 	}
-	proxyService := NewTransparentProxyService(NewTransparentProxyServer(false), nil, "enforce", TransparentProxyServiceOpts{})
+	proxyService := NewTransparentProxyService(NewTransparentProxyServer(false), nil, "enforce", TransparentProxyServiceOpts{
+		Policy: &policy.Policy{},
+	})
 	policy.RegisterRule("URLMatchRule", func() policy.Rule { return &policy.URLMatchRule{} })
 	mux := http.NewServeMux()
 	mux.HandleFunc("/policy", proxyService.policyHandler)


### PR DESCRIPTION
Add TransparentProxyServiceOpts struct to disable network activity logging in order to avoid unbounded memory usage.