### PR TITLE
Use virtual-hosted GCS URL

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -69,7 +69,7 @@ var rebuildContainerTpl = template.Must(
 				RUN <<'EOF'
 				 set -eux
 				{{- if .UseTimewarp}}
-				 wget https://storage.googleapis.com/{{.UtilPrebuildBucket}}/timewarp
+				 wget https://{{.UtilPrebuildBucket}}.storage.googleapis.com/timewarp
 				 chmod +x timewarp
 				 ./timewarp -port 8080 &
 				 while ! nc -z localhost 8080;do sleep 1;done
@@ -157,7 +157,7 @@ var proxyBuildTpl = template.Must(
 	}).Parse(
 		textwrap.Dedent(`
 				set -eux
-				curl -O https://storage.googleapis.com/{{.UtilPrebuildBucket}}/proxy
+				curl -O https://{{.UtilPrebuildBucket}}.storage.googleapis.com/proxy
 				chmod +x proxy
 				docker network create proxynet
 				useradd --system {{.User}}
@@ -219,7 +219,7 @@ var assetUploadTpl = template.Must(
 	).Parse(
 		textwrap.Dedent(`
 				set -eux
-				wget https://storage.googleapis.com/{{.UtilPrebuildBucket}}/gsutil_writeonly
+				wget https://{{.UtilPrebuildBucket}}.storage.googleapis.com/gsutil_writeonly
 				chmod +x gsutil_writeonly
 				{{- range .Uploads}}
 				./gsutil_writeonly cp {{.From}} {{.To}}

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -84,7 +84,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
- wget https://storage.googleapis.com/my-bucket/timewarp
+ wget https://my-bucket.storage.googleapis.com/timewarp
  chmod +x timewarp
  ./timewarp -port 8080 &
  while ! nc -z localhost 8080;do sleep 1;done
@@ -260,7 +260,7 @@ docker run --name=container img
 					{
 						Name: "docker.io/library/alpine:3.19",
 						Script: `set -eux
-wget https://storage.googleapis.com/test-bootstrap/gsutil_writeonly
+wget https://test-bootstrap.storage.googleapis.com/gsutil_writeonly
 chmod +x gsutil_writeonly
 ./gsutil_writeonly cp /workspace/image.tgz file:///npm/pkg/version/pkg-version.tgz/image.tgz
 ./gsutil_writeonly cp /workspace/pkg-version.tgz file:///npm/pkg/version/pkg-version.tgz/pkg-version.tgz
@@ -308,7 +308,7 @@ docker kill tetragon
 					{
 						Name: "docker.io/library/alpine:3.19",
 						Script: `set -eux
-wget https://storage.googleapis.com/test-bootstrap/gsutil_writeonly
+wget https://test-bootstrap.storage.googleapis.com/gsutil_writeonly
 chmod +x gsutil_writeonly
 ./gsutil_writeonly cp /workspace/image.tgz file:///npm/pkg/version/pkg-version.tgz/image.tgz
 ./gsutil_writeonly cp /workspace/pkg-version.tgz file:///npm/pkg/version/pkg-version.tgz/pkg-version.tgz
@@ -337,7 +337,7 @@ chmod +x gsutil_writeonly
 					{
 						Name: "gcr.io/cloud-builders/docker",
 						Script: `set -eux
-curl -O https://storage.googleapis.com/test-bootstrap/proxy
+curl -O https://test-bootstrap.storage.googleapis.com/proxy
 chmod +x proxy
 docker network create proxynet
 useradd --system proxyu
@@ -391,7 +391,7 @@ curl http://proxy:3127/summary > /workspace/netlog.json
 					{
 						Name: "docker.io/library/alpine:3.19",
 						Script: `set -eux
-wget https://storage.googleapis.com/test-bootstrap/gsutil_writeonly
+wget https://test-bootstrap.storage.googleapis.com/gsutil_writeonly
 chmod +x gsutil_writeonly
 ./gsutil_writeonly cp /workspace/image.tgz file:///npm/pkg/version/pkg-version.tgz/image.tgz
 ./gsutil_writeonly cp /workspace/pkg-version.tgz file:///npm/pkg/version/pkg-version.tgz/pkg-version.tgz


### PR DESCRIPTION
Both of these API pattern seems to be present in GCS's XML API for
compatibility with AWS S3. However the bucket-in-domain pattern is far more
reliable to parse than the other form as it overlaps with the standard GCS JSON
API path pattern (`/storage/...`).