### PR TITLE
Add host matching to URLMatchRule

### DIFF
--- a/pkg/proxy/policy/policy.go
+++ b/pkg/proxy/policy/policy.go
@@ -97,13 +97,23 @@ const (
 // Implements the Rule interface. Matches the request URL based on the MatchingType.
 type URLMatchRule struct {
 	Host      string       `json:"host"`
+	HostMatch MatchingType `json:"matchHostBy"`
 	Path      string       `json:"path"`
 	PathMatch MatchingType `json:"matchPathBy"`
 }
 
 func (rule URLMatchRule) Allows(req *http.Request) bool {
 	url := req.URL
-	if url.Hostname() != rule.Host {
+	switch rule.HostMatch {
+	case PrefixMatch:
+		if !strings.HasPrefix(url.Hostname(), rule.Host) {
+			return false
+		}
+	case FullMatch:
+		if url.Hostname() != rule.Host {
+			return false
+		}
+	default:
 		return false
 	}
 

--- a/pkg/proxy/policy/policy.go
+++ b/pkg/proxy/policy/policy.go
@@ -92,6 +92,7 @@ type MatchingType string
 const (
 	FullMatch   MatchingType = "full"
 	PrefixMatch MatchingType = "prefix"
+	SuffixMatch MatchingType = "suffix"
 )
 
 // Implements the Rule interface. Matches the request URL based on the MatchingType.
@@ -105,8 +106,8 @@ type URLMatchRule struct {
 func (rule URLMatchRule) Allows(req *http.Request) bool {
 	url := req.URL
 	switch rule.HostMatch {
-	case PrefixMatch:
-		if !strings.HasPrefix(url.Hostname(), rule.Host) {
+	case SuffixMatch:
+		if !strings.HasSuffix(url.Hostname(), rule.Host) {
 			return false
 		}
 	case FullMatch:

--- a/pkg/proxy/policy/policy_test.go
+++ b/pkg/proxy/policy/policy_test.go
@@ -44,18 +44,18 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 			wantResp: http.StatusForbidden,
 		},
 		{
-			name: "empty host and path allows all through prefix match",
+			name: "empty host and path allows all through suffix match",
 			policy: Policy{
 				AnyOf: []Rule{
 					URLMatchRule{
 						Host:      "",
-						HostMatch: PrefixMatch,
+						HostMatch: SuffixMatch,
 						Path:      "",
 						PathMatch: PrefixMatch,
 					},
 				},
 			},
-			url:      "https://host.com/path/with/prefix",
+			url:      "https://host.com/path",
 			wantResp: http.StatusOK,
 		},
 		{
@@ -74,7 +74,7 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 			wantResp: http.StatusForbidden,
 		},
 		{
-			name: "partial host policy rule does not fully match url host",
+			name: "host policy rule does not fully match url host",
 			policy: Policy{
 				AnyOf: []Rule{
 					URLMatchRule{
@@ -89,12 +89,12 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 			wantResp: http.StatusForbidden,
 		},
 		{
-			name: "partial host policy rule matches partially with url host",
+			name: "host policy rule matches url host suffix",
 			policy: Policy{
 				AnyOf: []Rule{
 					URLMatchRule{
-						Host:      "host",
-						HostMatch: PrefixMatch,
+						Host:      "host.com",
+						HostMatch: SuffixMatch,
 						Path:      "/path",
 						PathMatch: PrefixMatch,
 					},
@@ -102,6 +102,21 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 			},
 			url:      "https://host.com/path/with/prefix",
 			wantResp: http.StatusOK,
+		},
+		{
+			name: "host policy rule blocks non matching suffix",
+			policy: Policy{
+				AnyOf: []Rule{
+					URLMatchRule{
+						Host:      ".net",
+						HostMatch: SuffixMatch,
+						Path:      "/path",
+						PathMatch: PrefixMatch,
+					},
+				},
+			},
+			url:      "https://host.com/path/with/prefix",
+			wantResp: http.StatusForbidden,
 		},
 		{
 			name: "path prefix matching type allows matching url",

--- a/pkg/proxy/policy/policy_test.go
+++ b/pkg/proxy/policy/policy_test.go
@@ -30,11 +30,41 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 			wantResp: http.StatusForbidden,
 		},
 		{
-			name: "empty host policy rule does not match any url",
+			name: "empty HostMatch blocks everything",
 			policy: Policy{
 				AnyOf: []Rule{
 					URLMatchRule{
 						Host:      "",
+						Path:      "",
+						PathMatch: PrefixMatch,
+					},
+				},
+			},
+			url:      "https://host.com/path/with/prefix",
+			wantResp: http.StatusForbidden,
+		},
+		{
+			name: "empty host and path allows all through prefix match",
+			policy: Policy{
+				AnyOf: []Rule{
+					URLMatchRule{
+						Host:      "",
+						HostMatch: PrefixMatch,
+						Path:      "",
+						PathMatch: PrefixMatch,
+					},
+				},
+			},
+			url:      "https://host.com/path/with/prefix",
+			wantResp: http.StatusOK,
+		},
+		{
+			name: "empty host policy rule does not fully match url host",
+			policy: Policy{
+				AnyOf: []Rule{
+					URLMatchRule{
+						Host:      "",
+						HostMatch: FullMatch,
 						Path:      "path",
 						PathMatch: PrefixMatch,
 					},
@@ -44,18 +74,34 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 			wantResp: http.StatusForbidden,
 		},
 		{
-			name: "partial host policy rule does not match any url",
+			name: "partial host policy rule does not fully match url host",
 			policy: Policy{
 				AnyOf: []Rule{
 					URLMatchRule{
 						Host:      "host",
-						Path:      "path",
+						HostMatch: FullMatch,
+						Path:      "/path",
 						PathMatch: PrefixMatch,
 					},
 				},
 			},
 			url:      "https://host.com/path/with/prefix",
 			wantResp: http.StatusForbidden,
+		},
+		{
+			name: "partial host policy rule matches partially with url host",
+			policy: Policy{
+				AnyOf: []Rule{
+					URLMatchRule{
+						Host:      "host",
+						HostMatch: PrefixMatch,
+						Path:      "/path",
+						PathMatch: PrefixMatch,
+					},
+				},
+			},
+			url:      "https://host.com/path/with/prefix",
+			wantResp: http.StatusOK,
 		},
 		{
 			name: "path prefix matching type allows matching url",
@@ -63,6 +109,7 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 				AnyOf: []Rule{
 					URLMatchRule{
 						Host:      "host.com",
+						HostMatch: FullMatch,
 						Path:      "/path",
 						PathMatch: PrefixMatch,
 					},
@@ -77,6 +124,7 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 				AnyOf: []Rule{
 					URLMatchRule{
 						Host:      "host.com",
+						HostMatch: FullMatch,
 						Path:      "/path",
 						PathMatch: PrefixMatch,
 					},
@@ -91,6 +139,7 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 				AnyOf: []Rule{
 					URLMatchRule{
 						Host:      "host.com",
+						HostMatch: FullMatch,
 						Path:      "/matching/path",
 						PathMatch: FullMatch,
 					},
@@ -105,6 +154,7 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 				AnyOf: []Rule{
 					URLMatchRule{
 						Host:      "host.com",
+						HostMatch: FullMatch,
 						Path:      "/path",
 						PathMatch: FullMatch,
 					},

--- a/pkg/proxy/proxy/transparent_test.go
+++ b/pkg/proxy/proxy/transparent_test.go
@@ -26,6 +26,7 @@ func TestApplyNetworkPolicy(t *testing.T) {
 				AnyOf: []policy.Rule{
 					policy.URLMatchRule{
 						Host:      "host.com",
+						HostMatch: policy.FullMatch,
 						Path:      "/path",
 						PathMatch: policy.PrefixMatch,
 					},
@@ -41,6 +42,7 @@ func TestApplyNetworkPolicy(t *testing.T) {
 				AnyOf: []policy.Rule{
 					policy.URLMatchRule{
 						Host:      "host.com",
+						HostMatch: policy.FullMatch,
 						Path:      "/path",
 						PathMatch: policy.PrefixMatch,
 					},
@@ -56,6 +58,7 @@ func TestApplyNetworkPolicy(t *testing.T) {
 				AnyOf: []policy.Rule{
 					policy.URLMatchRule{
 						Host:      "host.com",
+						HostMatch: policy.FullMatch,
 						Path:      "/path",
 						PathMatch: policy.PrefixMatch,
 					},
@@ -71,6 +74,7 @@ func TestApplyNetworkPolicy(t *testing.T) {
 				AnyOf: []policy.Rule{
 					policy.URLMatchRule{
 						Host:      "host.com",
+						HostMatch: policy.FullMatch,
 						Path:      "/path",
 						PathMatch: policy.PrefixMatch,
 					},


### PR DESCRIPTION
Add the ability to specify suffix or full string matching for host names in the proxy.