### PR TITLE
Add dockerfile format to infer command

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -452,7 +452,7 @@ func doCloudBuild(ctx context.Context, client gcb.Client, build *cloudbuild.Buil
 	return buildErr
 }
 
-func makeDockerfile(input Input, opts RemoteOptions) (string, error) {
+func MakeDockerfile(input Input, opts RemoteOptions) (string, error) {
 	env := BuildEnv{HasRepo: false, PreferPreciseToolchain: true}
 	if opts.UseTimewarp {
 		env.TimewarpHost = "localhost:8080"
@@ -485,7 +485,7 @@ func makeDockerfile(input Input, opts RemoteOptions) (string, error) {
 func RebuildRemote(ctx context.Context, input Input, id string, opts RemoteOptions) error {
 	t := input.Target
 	bi := BuildInfo{Target: t, ID: id, Builder: os.Getenv("K_REVISION"), BuildStart: time.Now()}
-	dockerfile, err := makeDockerfile(input, opts)
+	dockerfile, err := MakeDockerfile(input, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating dockerfile")
 	}

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -205,7 +205,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := makeDockerfile(tc.input, tc.opts)
+			actual, err := MakeDockerfile(tc.input, tc.opts)
 			if (err != nil) != tc.expectedErr {
 				t.Errorf("Unexpected error: %v", err)
 			}


### PR DESCRIPTION
This adds the `--format=dockerfile` option on the `infer` command. It's helpful to see the full dockerfile when debugging inference, and easy to pipe this directly into docker locally. For example:


```
go run tools/ctl/ctl.go infer --ecosystem=debian --package=main/file --version=5.45-3+b1 --artifact=libmagic-mgc_5.45-3+b1_amd64.deb --format=dockerfile | docker buildx build -t tmp - && docker run -it -t tmp
```