### PR TITLE
Break up dependencies and source steps.

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -75,6 +75,9 @@ var rebuildContainerTpl = template.Must(
 				 while ! nc -z localhost 8080;do sleep 1;done
 				{{- end}}
 				 apk add {{join " " .Instructions.SystemDeps}}
+				EOF
+				RUN <<'EOF'
+				 set -eux
 				 mkdir /src && cd /src
 				 {{.Instructions.Source| indent}}
 				 {{.Instructions.Deps | indent}}

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -53,6 +53,9 @@ FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
  apk add git make
+EOF
+RUN <<'EOF'
+ set -eux
  mkdir /src && cd /src
  git clone ...
  make deps ...
@@ -89,6 +92,9 @@ RUN <<'EOF'
  ./timewarp -port 8080 &
  while ! nc -z localhost 8080;do sleep 1;done
  apk add git make
+EOF
+RUN <<'EOF'
+ set -eux
  mkdir /src && cd /src
  git clone ...
  make deps ...
@@ -126,6 +132,9 @@ FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
  apk add curl jq
+EOF
+RUN <<'EOF'
+ set -eux
  mkdir /src && cd /src
  # Download source code
  curl -LO https://example.com/source.tar.gz


### PR DESCRIPTION
This improves docker layer caching for locally-executed builds with large deps.