### PR TITLE
Fix typos

### DIFF
--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -40,7 +40,7 @@ import (
 
 // These are commonly used in PyPi metadata to point to the project git repo, using a map as a set.
 // Some people capitalize these differently, or add/remove spaces. We normalized to lower, no space.
-// This list is ordered, we will choose the first occurance.
+// This list is ordered, we will choose the first occurrence.
 var commonRepoLinks = []string{
 	"source",
 	"sourcecode",
@@ -51,7 +51,7 @@ var commonRepoLinks = []string{
 
 // There are two places to find the repo:
 // 1. In the ProjectURLs (project links)
-// 2. Embeded in the description
+// 2. Embedded in the description
 //
 // For 1, there are some ProjectURLs that are very common to use for a repo
 // (commonRepoLinks above), so we can break up the ProjectURLs

--- a/pkg/rebuild/rebuild/compare.go
+++ b/pkg/rebuild/rebuild/compare.go
@@ -67,7 +67,7 @@ func Stabilize(ctx context.Context, t Target, mux RegistryMux, rbPath string, fs
 		up = Asset{Type: DebugUpstreamAsset, Target: t}
 		w, err := assets.Writer(ctx, up)
 		if err != nil {
-			return rb, up, errors.Errorf("[INTERNAL] failued to store asset %v", up)
+			return rb, up, errors.Errorf("[INTERNAL] failed to store asset %v", up)
 		}
 		defer w.Close()
 		r, err := artifactReader(ctx, t, mux)

--- a/tools/benchmark/generate/main.go
+++ b/tools/benchmark/generate/main.go
@@ -80,7 +80,7 @@ var cratesioTop2000 = RebuildBenchmark{
 					log.Fatalf("error fetching download-ordered page %d: %v", page, err)
 				}
 				if resp.StatusCode != 200 {
-					log.Fatalf("error from regsitry fetching download-ordered page %d: %s", page, resp.Status)
+					log.Fatalf("error from registry fetching download-ordered page %d: %s", page, resp.Status)
 				}
 				var ms struct {
 					Metadata []cratesio.Metadata `json:"crates"`

--- a/tools/ctl/ide/rebuilder.go
+++ b/tools/ctl/ide/rebuilder.go
@@ -178,7 +178,7 @@ func (rb *Rebuilder) Kill() {
 	rb.m.Lock()
 	defer rb.m.Unlock()
 	if rb.instance != nil && !rb.instance.Dead() {
-		log.Println("Killing the exisitng rebuilder")
+		log.Println("Killing the existing rebuilder")
 		rb.instance.Kill()
 		rb.instance = nil
 		log.Printf("rebuilder exited")


### PR DESCRIPTION
The `strat` refactor is necessary as "go report"'s misspell analyzer considers it a misspelling of "start"