### PR TITLE
fix: Update BuildInfo before checking build status

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -440,7 +440,7 @@ func doCloudBuild(ctx context.Context, client gcb.Client, build *cloudbuild.Buil
 	for i, s := range bi.Steps {
 		bi.BuildImages[s.Name] = build.Results.BuildStepImages[i]
 	}
-	return nil
+	return gcb.ToError(build)
 }
 
 func makeDockerfile(input Input, opts RemoteOptions) (string, error) {


### PR DESCRIPTION
Before, the GCB code wouldn't return the build object on failures,
making it hard to log the BuildInfo in those cases. Now even GCB
build failures will update the BuildInfo and consequently logged,
which makes it easier to debug.