### PR TITLE
fix: Move rebuildremote uploads to the debug store

### DIFF
--- a/cmd/rebuilder/main.go
+++ b/cmd/rebuilder/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	debugStorage        = flag.String("debug-storage", "", "if provided, the location in which rebuild results should be stored")
+	debugStorage        = flag.String("debug-storage", "", "if provided, the location in which rebuild debug info should be stored")
 	gitCacheURL         = flag.String("git-cache-url", "", "if provided, the git-cache service to use to fetch repos")
 	defaultVersionCount = flag.Int("default-version-count", 5, "The number of versions to rebuild if no version is provided")
 	useTimewarp         = flag.Bool("timewarp", true, "whether to use launch an instance of the timewarp server")

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -351,6 +351,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--metadata-bucket=${google_storage_bucket.metadata.name}",
         "--attestation-bucket=${google_storage_bucket.attestations.name}",
         "--logs-bucket=${google_storage_bucket.logs.name}",
+        "--debug-storage=gs://${google_storage_bucket.debug.name}",
         "--gateway-url=${google_cloud_run_v2_service.gateway.uri}",
         "--user-agent=oss-rebuild+${var.host}/0.0.0",
         "--build-def-repo=https://github.com/google/oss-rebuild",
@@ -394,6 +395,11 @@ resource "google_storage_bucket_iam_binding" "orchestrator-writes-attestations" 
 resource "google_storage_bucket_iam_binding" "orchestrator-manages-metadata" {
   bucket  = google_storage_bucket.metadata.name
   role    = "roles/storage.objectAdmin"
+  members = ["serviceAccount:${google_service_account.orchestrator.email}"]
+}
+resource "google_storage_bucket_iam_binding" "orchestrator-writes-debug" {
+  bucket  = google_storage_bucket.debug.name
+  role    = "roles/storage.objectCreator"
   members = ["serviceAccount:${google_service_account.orchestrator.email}"]
 }
 resource "google_storage_bucket_iam_binding" "remote-build-writes-metadata" {

--- a/internal/api/apiservice/rebuild_test.go
+++ b/internal/api/apiservice/rebuild_test.go
@@ -304,6 +304,9 @@ RLpmHHG1JOVdOA==
 			fs := memfs.New()
 			afs := must(fs.Chroot("attestations"))
 			d.AttestationStore = rebuild.NewFilesystemAssetStore(afs)
+			d.DebugStoreBuilder = func(ctx context.Context) (rebuild.AssetStore, error) {
+				return rebuild.NewFilesystemAssetStore(must(fs.Chroot("debug-metadata"))), nil
+			}
 			remoteMetadata := rebuild.NewFilesystemAssetStore(must(fs.Chroot("remote-metadata")))
 			d.RemoteMetadataStoreBuilder = func(ctx context.Context, id string) (rebuild.LocatableAssetStore, error) {
 				return remoteMetadata, nil


### PR DESCRIPTION
The uploads were not easy to access before, because they were behind the oblivious uuid. This change makes the rebuildremote debug handling more similar to the smoketest handling.

I don't love the increasing number of asset stores this PR adds, but it seemed necessary in order to store the BuildInfo in a location we can programatically find using the RunID.

I left a few comments suggesting we can combine the debug storage and the local store. My thinking is that we can combine them in a layered asset store that has an internal memfs cache. (draft #191) I'm not wedded to that idea, but it's an option to avoid the bloat of asset stores.