### PR TITLE
refactor: Use DebugStoreID instead of ArtifactUploadID

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -146,7 +146,7 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 		if ctx.Value(rebuild.RunID) == nil {
 			return nil, errors.New("RunID must be set in the context")
 		}
-		return rebuild.DebugStoreFromContext(context.WithValue(ctx, rebuild.UploadArtifactsPathID, *debugStorage))
+		return rebuild.DebugStoreFromContext(context.WithValue(ctx, rebuild.DebugStoreID, *debugStorage))
 	}
 	d.RemoteMetadataStoreBuilder = func(ctx context.Context, uuid string) (rebuild.LocatableAssetStore, error) {
 		return rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, uuid), "gs://"+*metadataBucket)

--- a/internal/api/rebuilderservice/smoketest.go
+++ b/internal/api/rebuilderservice/smoketest.go
@@ -144,7 +144,7 @@ func RebuildSmoketest(ctx context.Context, sreq schema.SmoketestRequest, deps *R
 	}
 	ctx = context.WithValue(ctx, rebuild.AssetDirID, deps.AssetDir)
 	if deps.DebugStorage != nil {
-		ctx = context.WithValue(ctx, rebuild.UploadArtifactsPathID, *deps.DebugStorage)
+		ctx = context.WithValue(ctx, rebuild.DebugStoreID, *deps.DebugStorage)
 	}
 	var verdicts []rebuild.Verdict
 	var err error

--- a/pkg/rebuild/rebuild/context.go
+++ b/pkg/rebuild/rebuild/context.go
@@ -20,7 +20,6 @@ type ctxKey int
 const (
 	RetainArtifactsID ctxKey = iota
 	AssetDirID
-	UploadArtifactsPathID
 	DebugStoreID
 	RepoCacheClientID
 	HTTPBasicClientID

--- a/pkg/rebuild/rebuild/storage.go
+++ b/pkg/rebuild/rebuild/storage.go
@@ -109,10 +109,10 @@ func AssetCopy(ctx context.Context, to, from AssetStore, a Asset) error {
 
 // DebugStoreFromContext constructs a DebugStorer using values from the given context.
 func DebugStoreFromContext(ctx context.Context) (AssetStore, error) {
-	if uploadpath, ok := ctx.Value(UploadArtifactsPathID).(string); ok {
+	if uploadpath, ok := ctx.Value(DebugStoreID).(string); ok {
 		u, err := url.Parse(uploadpath)
 		if err != nil {
-			return nil, errors.Wrap(err, "parsing UploadArtifactsPathID as url")
+			return nil, errors.Wrap(err, "parsing DesbugStoreID as url")
 		}
 		if u.Scheme == "gs" {
 			storer, err := NewGCSStore(ctx, uploadpath)

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -95,7 +95,7 @@ var tui = &cobra.Command{
 		var fireClient rundex.Reader
 		if *benchmarkDir != "" {
 			fireClient = rundex.NewLocalClient(localfiles.Rundex())
-			tctx = context.WithValue(tctx, rebuild.UploadArtifactsPathID, "file://"+localfiles.AssetsPath())
+			tctx = context.WithValue(tctx, rebuild.DebugStoreID, "file://"+localfiles.AssetsPath())
 		} else {
 			if *debugStorage != "" {
 				u, err := url.Parse(*debugStorage)
@@ -108,7 +108,7 @@ var tui = &cobra.Command{
 						log.Fatalf("--debug-storage cannot have additional path elements, found %s", prefix)
 					}
 				}
-				tctx = context.WithValue(tctx, rebuild.UploadArtifactsPathID, *debugStorage)
+				tctx = context.WithValue(tctx, rebuild.DebugStoreID, *debugStorage)
 			}
 			// TODO: Support filtering in the UI on TUI.
 			var err error


### PR DESCRIPTION
As far as I can tell, we weren't using DebugStoreID at all but it more accurately describes the value read in DebugStoreFromContext.

Optionally, we could rename this as DebugStorePathID.