### PR TITLE
refactor: Rename SmoketestAttempt -> RebuildAttempt

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -319,7 +319,7 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 			dockerfile = string(b)
 		}
 	}
-	_, err = deps.FirestoreClient.Collection("ecosystem").Doc(string(v.Target.Ecosystem)).Collection("packages").Doc(sanitize(v.Target.Package)).Collection("versions").Doc(v.Target.Version).Collection("attempts").Doc(req.ID).Set(ctx, schema.SmoketestAttempt{
+	_, err = deps.FirestoreClient.Collection("ecosystem").Doc(string(v.Target.Ecosystem)).Collection("packages").Doc(sanitize(v.Target.Package)).Collection("versions").Doc(v.Target.Version).Collection("attempts").Doc(req.ID).Set(ctx, schema.RebuildAttempt{
 		Ecosystem:       string(v.Target.Ecosystem),
 		Package:         v.Target.Package,
 		Version:         v.Target.Version,

--- a/internal/api/apiservice/smoketest.go
+++ b/internal/api/apiservice/smoketest.go
@@ -66,7 +66,7 @@ func RebuildSmoketest(ctx context.Context, sreq schema.SmoketestRequest, deps *R
 	}
 	resp, err := rebuildSmoketest(ctx, sreq, deps)
 	for _, v := range resp.Verdicts {
-		_, err := deps.FirestoreClient.Collection("ecosystem").Doc(string(v.Target.Ecosystem)).Collection("packages").Doc(sanitize(sreq.Package)).Collection("versions").Doc(v.Target.Version).Collection("attempts").Doc(sreq.ID).Set(ctx, schema.SmoketestAttempt{
+		_, err := deps.FirestoreClient.Collection("ecosystem").Doc(string(v.Target.Ecosystem)).Collection("packages").Doc(sanitize(sreq.Package)).Collection("versions").Doc(v.Target.Version).Collection("attempts").Doc(sreq.ID).Set(ctx, schema.RebuildAttempt{
 			Ecosystem:       string(v.Target.Ecosystem),
 			Package:         v.Target.Package,
 			Version:         v.Target.Version,

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -233,8 +233,8 @@ type CreateRunResponse struct {
 	ID string
 }
 
-// SmoketestAttempt stores rebuild and execution metadata on a single smoketest run.
-type SmoketestAttempt struct {
+// RebuildAttempt stores rebuild and execution metadata on a single smoketest run.
+type RebuildAttempt struct {
 	Ecosystem       string          `firestore:"ecosystem,omitempty"`
 	Package         string          `firestore:"package,omitempty"`
 	Version         string          `firestore:"version,omitempty"`

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -640,7 +640,7 @@ func (t *TuiApp) runBenchmark(bench string) {
 		}
 		now := time.Now().UnixMilli()
 		fire.WriteRebuild(t.Ctx, rundex.Rebuild{
-			SmoketestAttempt: schema.SmoketestAttempt{
+			RebuildAttempt: schema.RebuildAttempt{
 				Ecosystem:       string(v.Target.Ecosystem),
 				Package:         v.Target.Package,
 				Version:         v.Target.Version,

--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -38,18 +38,18 @@ import (
 
 // Rebuild represents the result of a specific rebuild.
 type Rebuild struct {
-	schema.SmoketestAttempt
+	schema.RebuildAttempt
 	Created time.Time
 }
 
 // NewRebuildFromFirestore creates a Rebuild instance from a "attempt" collection document.
 func NewRebuildFromFirestore(doc *firestore.DocumentSnapshot) Rebuild {
-	var sa schema.SmoketestAttempt
+	var sa schema.RebuildAttempt
 	if err := doc.DataTo(&sa); err != nil {
 		panic(err)
 	}
 	var rb Rebuild
-	rb.SmoketestAttempt = sa
+	rb.RebuildAttempt = sa
 	rb.Created = time.UnixMilli(sa.Created)
 	return rb
 }


### PR DESCRIPTION
We use this format only to store data in firestore, but we use it for
both smoketest and attestation runs.