### PR TITLE
Disable authentication for kms verifier

### DIFF
--- a/cmd/oss-rebuild/main.go
+++ b/cmd/oss-rebuild/main.go
@@ -133,7 +133,7 @@ func (b *Bundle) Byproduct(name string) ([]byte, error) {
 }
 
 func makeKMSVerifier(ctx context.Context, cryptoKeyVersion string) (dsse.Verifier, error) {
-	kc, err := kms.NewKeyManagementClient(ctx)
+	kc, err := kms.NewKeyManagementClient(ctx, option.WithoutAuthentication())
 	if err != nil {
 		return nil, errors.Wrap(err, "creating KMS client")
 	}


### PR DESCRIPTION
People using the oss-rebuild CLI should not need an authenticated KMS
client instance. The option.WithoutAuthentication client should be
enough.