### PR TITLE
docs: Add note about GCP ADC requirement to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ bin/
 # jj
 .jj/
 
+# VSCode project settings
+.vscode/
+
 # Go
 # From https://github.com/github/gitignore/blob/7b22f8ab6c85b4ef1469d72a8ba96462e2a44853/Go.gitignore
 *.test

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ oss-rebuild list pypi absl-py
 
 ### Usage Requirements
 
-`oss-rebuild` uses a public GCP KMS signature verification key to validate attestations.
+`oss-rebuild` uses a public [Cloud KMS](https://cloud.google.com/kms/docs) key to validate attestation signatures.
 Anonymous authentication is not supported so an [ADC credential](https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment) must be present.
 
 This can be accomplished with:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ rebuilt:
 $ oss-rebuild list pypi absl-py
 ```
 
+### Usage Requirements
+
+`oss-rebuild` uses a public GCP KMS signature verification key to validate attestations.
+Anonymous authentication is not supported so an [ADC credential](https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment) must be present.
+
+This can be accomplished with:
+
+```bash
+$ gcloud init
+$ gcloud auth application-default login
+```
+
+To disable signature verification and skip the requirement for KMS access use: `--verify=false`.
+
 ## Contributing
 
 Join us in building a more secure and reliable open-source ecosystem!


### PR DESCRIPTION
As an alternative to https://github.com/google/oss-rebuild/pull/251

This adds a note about the GCP ADC requirements for fetching the KMS public signing key. It does not seem that  unauthenticated access is supported for public signing keys. 