### PR TITLE
chore: Refactor maven implementation to use Registry and Rebuilder interfaces

### DIFF
--- a/internal/api/inferenceservice/infer.go
+++ b/internal/api/inferenceservice/infer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
 	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
+	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
 	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
 	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/pkg/errors"
@@ -65,6 +66,7 @@ func Infer(ctx context.Context, req schema.InferenceRequest, deps *InferDeps) (*
 		CratesIO: cratesreg.HTTPRegistry{Client: deps.HTTPClient},
 		NPM:      npmreg.HTTPRegistry{Client: deps.HTTPClient},
 		PyPI:     pypireg.HTTPRegistry{Client: deps.HTTPClient},
+		Maven:    mavenreg.HTTPRegistry{Client: deps.HTTPClient},
 		Debian:   debianreg.HTTPRegistry{Client: deps.HTTPClient},
 	}
 	var s rebuild.Strategy

--- a/internal/api/inferenceservice/infer.go
+++ b/internal/api/inferenceservice/infer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/oss-rebuild/internal/httpx"
 	"github.com/google/oss-rebuild/pkg/rebuild/cratesio"
 	"github.com/google/oss-rebuild/pkg/rebuild/debian"
+	"github.com/google/oss-rebuild/pkg/rebuild/maven"
 	"github.com/google/oss-rebuild/pkg/rebuild/npm"
 	"github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -84,6 +85,8 @@ func Infer(ctx context.Context, req schema.InferenceRequest, deps *InferDeps) (*
 		s, err = doInfer(ctx, cratesio.Rebuilder{}, t, mux, req.LocationHint())
 	case rebuild.Debian:
 		s, err = doInfer(ctx, debian.Rebuilder{}, t, mux, req.LocationHint())
+	case rebuild.Maven:
+		s, err = doInfer(ctx, maven.Rebuilder{}, t, mux, req.LocationHint())
 	default:
 		return nil, api.AsStatus(codes.InvalidArgument, errors.New("unsupported ecosystem"))
 	}

--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -43,6 +43,14 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 	if err != nil {
 		return "", err
 	}
+	// In some projects the groupId only exists on the parent.
+	// To keep the POM-parsing clean, we apply these fixups here.
+	if pom.GroupID == "" && pom.Parent.GroupID != "" {
+		pom.GroupID = pom.Parent.GroupID
+	}
+	if pom.VersionID == "" && pom.Parent.VersionID != "" {
+		pom.VersionID = pom.Parent.VersionID
+	}
 	return uri.CanonicalizeRepoURI(pom.URL)
 }
 

--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -166,7 +166,6 @@ func getPomXML(tree *object.Tree, path string) (pomXML PomXML, err error) {
 }
 
 func getJarJDK(ctx context.Context, name, version string, mux rebuild.RegistryMux) (string, error) {
-	//r, err := mavenreg.HTTPRegistry{}.ReleaseFile(context.Background(), name, version, mavenreg.TypeJar)
 	releaseFile, err := mux.Maven.ReleaseFile(ctx, name, version, maven.TypeJar)
 	if err != nil {
 		return "", errors.Wrap(err, "fetching jar file")

--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -43,14 +43,6 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 	if err != nil {
 		return "", err
 	}
-	// In some projects the groupId only exists on the parent.
-	// To keep the POM-parsing clean, we apply these fixups here.
-	if pom.GroupID == "" && pom.Parent.GroupID != "" {
-		pom.GroupID = pom.Parent.GroupID
-	}
-	if pom.VersionID == "" && pom.Parent.VersionID != "" {
-		pom.VersionID = pom.Parent.VersionID
-	}
 	return uri.CanonicalizeRepoURI(pom.URL)
 }
 

--- a/pkg/rebuild/maven/pom.go
+++ b/pkg/rebuild/maven/pom.go
@@ -1,0 +1,82 @@
+// Copyright 2024 The OSS Rebuild Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maven
+
+import (
+	"context"
+	"encoding/xml"
+	"io"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/registry/maven"
+)
+
+// PomXML is the root element of a Maven POM file.
+type PomXML struct {
+	GroupID    string `xml:"project>groupId"`
+	ArtifactID string `xml:"project>artifactId"`
+	VersionID  string `xml:"project>version"`
+	URL        string `xml:"project>url"`
+	SCMURL     string `xml:"project>scm>url"`
+	Parent     Parent `xml:"project>parent"`
+}
+
+// Parent represents the parent package ref within a Maven POM file.
+type Parent struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	VersionID  string `xml:"version"`
+}
+
+// Repo returns the repository URL for a Maven package.
+func (p *PomXML) Repo() string {
+	if p.SCMURL != "" {
+		return p.SCMURL
+	}
+	return p.URL
+}
+
+// Name returns the Maven package name.
+func (p *PomXML) Name() string {
+	return p.Group() + ":" + p.ArtifactID
+}
+
+// Group returns the Maven package group.
+func (p *PomXML) Group() string {
+	if g := p.GroupID; g != "" {
+		return g
+	}
+	return p.Parent.GroupID
+}
+
+// Version returns the Maven package version.
+func (p *PomXML) Version() string {
+	if v := p.VersionID; v != "" {
+		return v
+	}
+	return p.Parent.VersionID
+}
+
+// NewPomXML returns the POM file for a Maven package version.
+func NewPomXML(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (p PomXML, err error) {
+	var r io.ReadCloser
+	r, err = mux.Maven.ReleaseFile(ctx, t.Package, t.Version, maven.TypePOM)
+	if err != nil {
+		return
+	}
+	defer r.Close()
+	err = xml.NewDecoder(r).Decode(&p)
+	return
+}

--- a/pkg/rebuild/maven/pom.go
+++ b/pkg/rebuild/maven/pom.go
@@ -24,13 +24,14 @@ import (
 )
 
 // PomXML is the root element of a Maven POM file.
+// The root element is called "project" and this is handled by the Decode method.
 type PomXML struct {
-	GroupID    string `xml:"project>groupId"`
-	ArtifactID string `xml:"project>artifactId"`
-	VersionID  string `xml:"project>version"`
-	URL        string `xml:"project>url"`
-	SCMURL     string `xml:"project>scm>url"`
-	Parent     Parent `xml:"project>parent"`
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	VersionID  string `xml:"version"`
+	URL        string `xml:"url"`
+	SCMURL     string `xml:"scm>url"`
+	Parent     Parent `xml:"parent"`
 }
 
 // Parent represents the parent package ref within a Maven POM file.

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -88,16 +88,17 @@ func TestNewPomXML(t *testing.T) {
 				},
 			}
 
-			if pom, err := NewPomXML(ctx, target, mux); err != nil && !tc.isError {
-				t.Fatalf("NewPomXML() error = %v", err)
-			} else if pom.ArtifactID != tc.expected.ArtifactID {
-				t.Errorf("NewPomXML() mismatch pom.ArtifactID expected=%s got=%s", tc.expected.ArtifactID, pom.ArtifactID)
-			} else if pom.GroupID != tc.expected.GroupID {
-				t.Errorf("NewPomXML() mismatch pom.GroupID expected=%s got=%s", tc.expected.GroupID, pom.GroupID)
-			} else if pom.VersionID != tc.expected.VersionID {
-				t.Errorf("NewPomXML() mismatch pom.VersionID expected=%s got=%s", tc.expected.VersionID, pom.VersionID)
-			} else if diff := cmp.Diff(tc.expected, pom); diff != "" {
-				t.Errorf("NewPomXML() cmp.Diff mismatch (-want +got):\n%s", diff)
+			pom, err := NewPomXML(ctx, target, mux)
+			if err != nil {
+				if !tc.isError {
+					t.Fatalf("NewPomXML() error = %v", err)
+				}
+				return
+			} else if tc.isError {
+				t.Fatalf("NewPomXML() expected error but no error returned")
+			}
+			if diff := cmp.Diff(tc.expected, pom); diff != "" {
+				t.Errorf("NewPomXML() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -1,0 +1,104 @@
+package maven
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
+)
+
+type TestRegistry struct {
+	releaseFile string
+}
+
+func (TestRegistry) PackageMetadata(_ context.Context, _ string) (*mavenreg.MavenPackage, error) {
+	return nil, nil
+}
+
+func (TestRegistry) PackageVersion(_ context.Context, _, _ string) (*mavenreg.MavenVersion, error) {
+	return nil, nil
+}
+
+func (r TestRegistry) ReleaseFile(_ context.Context, _, _, _ string) (io.ReadCloser, error) {
+	reader := strings.NewReader(r.releaseFile)
+	return io.NopCloser(reader), nil
+}
+
+func TestNewPomXML(t *testing.T) {
+	tests := []struct {
+		testName string
+		input    string
+		expected PomXML
+		isError  bool
+	}{
+		{
+			testName: "parse_artifact_id",
+			input:    "<project><artifactId>ARTIFACT_ID</artifactId></project>",
+			expected: PomXML{
+				ArtifactID: "ARTIFACT_ID",
+			},
+		},
+		{
+			testName: "parse_artifact_id_with_attributes",
+			input:    "<project><artifactId what=\"not\">ARTIFACT_ID</artifactId></project>",
+			expected: PomXML{
+				ArtifactID: "ARTIFACT_ID",
+			},
+		},
+		{
+			testName: "parse_parent",
+			input:    "<project><parent><groupId>PARENT_GROUP_ID</groupId></parent><groupId>GROUP_ID</groupId></project>",
+			expected: PomXML{
+				GroupID: "GROUP_ID",
+				Parent: Parent{
+					GroupID: "PARENT_GROUP_ID",
+				},
+			},
+		},
+		{
+			testName: "empty_parse_error",
+			input:    "",
+			expected: PomXML{},
+			isError:  true,
+		},
+		{
+			testName: "random_parse_error",
+			input:    "<something>",
+			expected: PomXML{},
+			isError:  true,
+		},
+		{
+			testName: "no_fields_parse",
+			input:    "<project/>",
+			expected: PomXML{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			ctx := context.Background()
+			target := rebuild.Target{}
+			mux := rebuild.RegistryMux{
+				Maven: TestRegistry{
+					releaseFile: tc.input,
+				},
+			}
+
+			if pom, err := NewPomXML(ctx, target, mux); err != nil && !tc.isError {
+				t.Fatalf("NewPomXML() error = %v", err)
+			} else if pom.ArtifactID != tc.expected.ArtifactID {
+				t.Errorf("NewPomXML() mismatch pom.ArtifactID expected=%s got=%s", tc.expected.ArtifactID, pom.ArtifactID)
+			} else if pom.GroupID != tc.expected.GroupID {
+				t.Errorf("NewPomXML() mismatch pom.GroupID expected=%s got=%s", tc.expected.GroupID, pom.GroupID)
+			} else if pom.VersionID != tc.expected.VersionID {
+				t.Errorf("NewPomXML() mismatch pom.VersionID expected=%s got=%s", tc.expected.VersionID, pom.VersionID)
+			} else if diff := cmp.Diff(tc.expected, pom); diff != "" {
+				t.Errorf("NewPomXML() cmp.Diff mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -14,7 +14,10 @@
 
 package maven
 
-import "github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+import (
+	"github.com/google/oss-rebuild/pkg/rebuild/flow"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
 
 type MavenBuild struct {
 	rebuild.Location
@@ -25,18 +28,21 @@ type MavenBuild struct {
 
 var _ rebuild.Strategy = &MavenBuild{}
 
-func (b *MavenBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
-	src, err := rebuild.BasicSourceSetup(b.Location, &be)
-	if err != nil {
-		return rebuild.Instructions{}, err
+func (b *MavenBuild) ToWorkflow() *rebuild.WorkflowStrategy {
+	return &rebuild.WorkflowStrategy{
+		Location: b.Location,
+		Source: []flow.Step{{
+			Uses: "git-checkout",
+		}},
+		Deps: []flow.Step{{
+			Runs: "true",
+		}},
+		Build: []flow.Step{{
+			Uses: "true",
+		}},
 	}
+}
 
-	return rebuild.Instructions{
-		Location:   b.Location,
-		Source:     src,
-		Deps:       "true",
-		Build:      "true",
-		SystemDeps: []string{"maven"},
-		OutputPath: t.Artifact,
-	}, nil
+func (b *MavenBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
+	return b.ToWorkflow().GenerateFor(t, be)
 }

--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -26,12 +26,17 @@ type MavenBuild struct {
 var _ rebuild.Strategy = &MavenBuild{}
 
 func (b *MavenBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
+	src, err := rebuild.BasicSourceSetup(b.Location, &be)
+	if err != nil {
+		return rebuild.Instructions{}, err
+	}
+
 	return rebuild.Instructions{
-		Location:   rebuild.Location{},
-		Source:     "", // src
-		Deps:       "", // deps
-		Build:      "", // build
-		SystemDeps: []string{"wget", "git", "build-essential", "fakeroot", "devscripts"},
+		Location:   b.Location,
+		Source:     src,
+		Deps:       "true",
+		Build:      "true",
+		SystemDeps: []string{"maven"},
 		OutputPath: t.Artifact,
 	}, nil
 }

--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The OSS Rebuild Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maven
+
+import "github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+
+type MavenBuild struct {
+	rebuild.Location
+
+	// JDKVersion is the version of the JDK to use for the build.
+	JDKVersion string `json:"jdk_version" yaml:"jdk_version"`
+}
+
+var _ rebuild.Strategy = &MavenBuild{}
+
+func (b *MavenBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
+	return rebuild.Instructions{
+		Location:   rebuild.Location{},
+		Source:     "", // src
+		Deps:       "", // deps
+		Build:      "", // build
+		SystemDeps: []string{"wget", "git", "build-essential", "fakeroot", "devscripts"},
+		OutputPath: t.Artifact,
+	}, nil
+}

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/oss-rebuild/pkg/rebuild/cratesio"
 	"github.com/google/oss-rebuild/pkg/rebuild/debian"
+	"github.com/google/oss-rebuild/pkg/rebuild/maven"
 	"github.com/google/oss-rebuild/pkg/rebuild/npm"
 	"github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -36,6 +37,7 @@ type StrategyOneOf struct {
 	NPMPackBuild         *npm.NPMPackBuild              `json:"npm_pack_build,omitempty" yaml:"npm_pack_build,omitempty"`
 	NPMCustomBuild       *npm.NPMCustomBuild            `json:"npm_custom_build,omitempty" yaml:"npm_custom_build,omitempty"`
 	CratesIOCargoPackage *cratesio.CratesIOCargoPackage `json:"cratesio_cargo_package,omitempty" yaml:"cratesio_cargo_package,omitempty"`
+	MavenBuild           *maven.MavenBuild              `json:"maven_build,omitempty" yaml:"maven_build,omitempty"`
 	DebianPackage        *debian.DebianPackage          `json:"debian_package,omitempty" yaml:"debian_package,omitempty"`
 	ManualStrategy       *rebuild.ManualStrategy        `json:"manual,omitempty" yaml:"manual,omitempty"`
 	WorkflowStrategy     *rebuild.WorkflowStrategy      `json:"flow,omitempty" yaml:"flow,omitempty"`
@@ -49,6 +51,8 @@ func NewStrategyOneOf(s rebuild.Strategy) StrategyOneOf {
 		oneof.LocationHint = t
 	case *pypi.PureWheelBuild:
 		oneof.PureWheelBuild = t
+	case *maven.MavenBuild:
+		oneof.MavenBuild = t
 	case *npm.NPMPackBuild:
 		oneof.NPMPackBuild = t
 	case *npm.NPMCustomBuild:

--- a/pkg/registry/maven/maven.go
+++ b/pkg/registry/maven/maven.go
@@ -36,7 +36,7 @@ var (
 	registryURL = urlx.MustParse("https://search.maven.org")
 	// Maven path component.
 	registryContentPathURL = urlx.MustParse("remotecontent")
-	registrySearchPathURL = urlx.MustParse(path.Join("solrsearch", "select"))
+	registrySearchPathURL  = urlx.MustParse(path.Join("solrsearch", "select"))
 )
 
 // MavenPackage is a Maven package.

--- a/tools/indexscan/main.go
+++ b/tools/indexscan/main.go
@@ -346,7 +346,6 @@ func processTree(t *object.Tree, files, trees map[plumbing.Hash]int, matches []b
 		}
 	}
 	processed.Set(trees[t.Hash])
-	return
 }
 
 func main() {
@@ -363,16 +362,16 @@ func main() {
 	var published time.Time
 	switch *ecosystem {
 	case "maven":
-		mv, err := mavenreg.VersionMetadata(*pkg, *version)
+		p, err := mavenreg.HTTPRegistry{}.PackageVersion(ctx, *pkg, *version)
 		if err != nil {
 			log.Fatal(errors.Wrap(err, "fetching version metadata"))
 		}
-		f, err = mavenreg.ReleaseFile(mv.GroupID+":"+mv.ArtifactID, mv.Version, mavenreg.TypeSources)
+		f, err = mavenreg.HTTPRegistry{}.ReleaseFile(ctx, *pkg, *version, mavenreg.TypeSources)
 		if err != nil {
 			log.Fatal(errors.Wrap(err, "fetching source jar"))
 		}
 		defer f.Close()
-		published = mv.Published
+		published = p.Published
 	case "pypi":
 		p, err := pypireg.HTTPRegistry{}.Project(ctx, *pkg)
 		if err != nil {


### PR DESCRIPTION
Hi team, this is a work in progress so the description here and implementation/changeset will change as it gets closer to complete. For now I wanted to make sure I am on the right path.

It seems that the `maven` implementation in the code does not yet use the `Rebuilder` or `Registry` interfaces. To simplify the code this PR aims to port the maven code to implement these. This is starting with `Registry` as that is a dependency and far simpler.

This PR aims to keep the coding style, imports, and other important but non-functional elements the same.