### PR TITLE
Move npm custom build commands into npx call

### DIFF
--- a/pkg/rebuild/npm/strategy.go
+++ b/pkg/rebuild/npm/strategy.go
@@ -97,7 +97,7 @@ wget -O - https://unofficial-builds.nodejs.org/download/release/v{{.NodeVersion}
 {{- /* NOTE: Prefer builtin npm for 'npm version' as it wasn't introduced until NPM v6. */ -}}
 PATH=/usr/bin:/bin:/usr/local/bin npm version --prefix {{.Location.Dir}} --no-git-tag-version {{.VersionOverride}}
 {{end -}}
-/usr/local/bin/npx --package=npm@{{.NPMVersion}} -c '{{if ne .Location.Dir "."}}cd {{.Location.Dir}} && {{end}}npm run {{.Command}}' && rm -rf node_modules && npm pack
+/usr/local/bin/npx --package=npm@{{.NPMVersion}} -c '{{if ne .Location.Dir "."}}cd {{.Location.Dir}} && {{end}}npm run {{.Command}} && rm -rf node_modules && npm pack'
 `, b)
 	if err != nil {
 		return rebuild.Instructions{}, err

--- a/pkg/rebuild/npm/strategy_test.go
+++ b/pkg/rebuild/npm/strategy_test.go
@@ -111,7 +111,7 @@ trap '/usr/bin/npm config --location-global delete registry' EXIT
 wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/local/
 /usr/local/bin/npx --package=npm@red -c 'cd the_dir && npm install --force'`,
 				Build: `PATH=/usr/bin:/bin:/usr/local/bin npm version --prefix the_dir --no-git-tag-version green
-/usr/local/bin/npx --package=npm@red -c 'cd the_dir && npm run yellow' && rm -rf node_modules && npm pack`,
+/usr/local/bin/npx --package=npm@red -c 'cd the_dir && npm run yellow && rm -rf node_modules && npm pack'`,
 				OutputPath: "the_dir/the_artifact",
 			},
 		},
@@ -133,7 +133,7 @@ wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue
 trap '/usr/bin/npm config --location-global delete registry' EXIT
 wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/local/
 /usr/local/bin/npx --package=npm@red -c 'cd the_dir && npm install --force'`,
-				Build:      `/usr/local/bin/npx --package=npm@red -c 'cd the_dir && npm run yellow' && rm -rf node_modules && npm pack`,
+				Build:      `/usr/local/bin/npx --package=npm@red -c 'cd the_dir && npm run yellow && rm -rf node_modules && npm pack'`,
 				OutputPath: "the_dir/the_artifact",
 			},
 		},
@@ -163,7 +163,7 @@ wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue
 trap '/usr/bin/npm config --location-global delete registry' EXIT
 wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/local/
 /usr/local/bin/npx --package=npm@red -c 'npm install --force'`,
-				Build:      `/usr/local/bin/npx --package=npm@red -c 'npm run yellow' && rm -rf node_modules && npm pack`,
+				Build:      `/usr/local/bin/npx --package=npm@red -c 'npm run yellow && rm -rf node_modules && npm pack'`,
 				OutputPath: "the_artifact",
 			},
 		},


### PR DESCRIPTION
This new form should be equivalent but has a few nice properties:

* uses the same version of npm for `npm pack` as for `npm run`
* uses a single top-level command, encapsulating the logic in the npx invocation