### PR TITLE
Remove obsolete npm flow tool

### DIFF
--- a/pkg/rebuild/rebuild/workflowstrategy.go
+++ b/pkg/rebuild/rebuild/workflowstrategy.go
@@ -102,16 +102,6 @@ func init() {
 			Needs: []string{"git"},
 		}},
 	})
-	flow.Tools.MustRegister(&flow.Tool{
-		Name: "npm/install",
-		Steps: []flow.Step{{
-			Runs: textwrap.Dedent(`
-				PATH=/usr/local/bin:/usr/bin npx --package=npm{{if ne .With.npmVersion ""}}@{{.With.npmVersion}}{{end}} -c '
-						{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}cd {{.Location.Dir}} && {{end -}}
-						npm install --force'`)[1:],
-			Needs: []string{"npm"},
-		}},
-	})
 }
 
 type Flowable interface {


### PR DESCRIPTION
Ecosystem-specific tools are defined alongside rebuild strategies instead of
centrally as this npm tool was. An equivalent exists for npm so this tool is no
longer necessary.