### PR TITLE
Record rebuild start time

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -317,6 +317,7 @@ func rebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 }
 
 func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps *RebuildPackageDeps) (*schema.Verdict, error) {
+	started := time.Now()
 	ctx = context.WithValue(ctx, rebuild.RunID, req.ID)
 	v, err := rebuildPackage(ctx, req, deps)
 	if err != nil {
@@ -351,7 +352,8 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 		RunID:           req.ID,
 		BuildID:         bi.BuildID,
 		ObliviousID:     bi.ID,
-		Created:         time.Now().UnixMilli(),
+		Started:         started.Unix(),
+		Created:         time.Now().Unix(),
 	})
 	if err != nil {
 		log.Print(errors.Wrap(err, "storing results in firestore"))

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -256,7 +256,8 @@ type RebuildAttempt struct {
 	RunID           string          `firestore:"run_id,omitempty"`
 	BuildID         string          `firestore:"build_id,omitempty"`
 	ObliviousID     string          `firestore:"oblivious_id,omitempty"`
-	Created         int64           `firestore:"created,omitempty"`
+	Started         int64           `firestore:"started,omitempty"` // The time rebuild started
+	Created         int64           `firestore:"created,omitempty"` // The time this record was created
 }
 
 // Run stores metadata on an execution grouping.


### PR DESCRIPTION
When executing streaming-style rebuilds, we will use a fixed runID. In these cases, we will likely want to group rebuilds based on when they were started, rather than when they were completed.