### PR TITLE
Add schema.ExecutionMode to generalize BenchmarkMode

### DIFF
--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -268,3 +268,11 @@ type Run struct {
 	Type          string `firestore:"run_type,omitempty"`
 	Created       int64  `firestore:"created,omitempty"`
 }
+
+// Execution mode describes the manner in which a rebuild happens.
+type ExecutionMode string
+
+const (
+	SmoketestMode ExecutionMode = "smoketest" // No attestations, faster.
+	AttestMode    ExecutionMode = "attest"    // Creates attestations, slower.
+)

--- a/tools/benchmark/run_test.go
+++ b/tools/benchmark/run_test.go
@@ -7,6 +7,7 @@ import (
 	taskspb "cloud.google.com/go/cloudtasks/apiv2/cloudtaskspb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/internal/urlx"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/pkg/errors"
 )
 
@@ -27,13 +28,13 @@ func (q *mockQueue) Add(ctx context.Context, url, body string) (*taskspb.Task, e
 func TestRunBenchAsync(t *testing.T) {
 	testCases := []struct {
 		name     string
-		mode     BenchmarkMode
+		mode     schema.ExecutionMode
 		set      PackageSet
 		expected []queueCall
 	}{
 		{
 			name: "attest",
-			mode: AttestMode,
+			mode: schema.AttestMode,
 			set: PackageSet{
 				Packages: []Package{
 					{
@@ -56,7 +57,7 @@ func TestRunBenchAsync(t *testing.T) {
 		},
 		{
 			name: "smoketest",
-			mode: SmoketestMode,
+			mode: schema.SmoketestMode,
 			set: PackageSet{
 				Packages: []Package{
 					{

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -243,8 +243,8 @@ var runBenchmark = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		mode := benchmark.BenchmarkMode(args[0])
-		if mode != benchmark.SmoketestMode && mode != benchmark.AttestMode {
+		mode := schema.ExecutionMode(args[0])
+		if mode != schema.SmoketestMode && mode != schema.AttestMode {
 			log.Fatalf("Unknown mode: %s. Expected one of 'smoketest' or 'attest'", string(mode))
 		}
 		if *apiUri == "" {
@@ -356,8 +356,8 @@ var runOne = &cobra.Command{
 		if *ecosystem == "" || *pkg == "" || *version == "" {
 			log.Fatal("ecosystem, package, and version must be provided")
 		}
-		mode := benchmark.BenchmarkMode(args[0])
-		if mode != benchmark.SmoketestMode && mode != benchmark.AttestMode {
+		mode := schema.ExecutionMode(args[0])
+		if mode != schema.SmoketestMode && mode != schema.AttestMode {
 			log.Fatalf("Unknown mode: %s. Expected one of 'smoketest' or 'attest'", string(mode))
 		}
 		if *apiUri == "" {
@@ -384,7 +384,7 @@ var runOne = &cobra.Command{
 		var strategy *schema.StrategyOneOf
 		{
 			if *strategyPath != "" {
-				if mode == benchmark.AttestMode {
+				if mode == schema.AttestMode {
 					log.Fatal("--strategy not supported in attest mode, use --strategy-from-repo")
 				}
 				f, err := os.Open(*strategyPath)
@@ -401,7 +401,7 @@ var runOne = &cobra.Command{
 		}
 		var verdicts []schema.Verdict
 		{
-			if mode == benchmark.SmoketestMode {
+			if mode == schema.SmoketestMode {
 				stub := api.Stub[schema.SmoketestRequest, schema.SmoketestResponse](client, *apiURL.JoinPath("smoketest"))
 				resp, err := stub(ctx, schema.SmoketestRequest{
 					Ecosystem: rebuild.Ecosystem(*ecosystem),

--- a/tools/ctl/ide/rebuilder.go
+++ b/tools/ctl/ide/rebuilder.go
@@ -254,7 +254,7 @@ func (rb *Rebuilder) RunBench(ctx context.Context, set benchmark.PackageSet, run
 		return nil, errors.Wrap(err, "getting running instance")
 	}
 	return benchmark.RunBench(ctx, http.DefaultClient, inst.URL, set, benchmark.RunBenchOpts{
-		Mode:           benchmark.SmoketestMode,
+		Mode:           schema.SmoketestMode,
 		RunID:          runID,
 		MaxConcurrency: 1,
 	})

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -491,9 +491,9 @@ func (e *explorer) makeVerdictGroupNode(vg *rundex.VerdictGroup, percent float32
 
 func (e *explorer) makeRunNode(runid string) *tview.TreeNode {
 	var title string
-	if run, ok := e.runs[runid]; ok && run.Type == benchmark.AttestMode {
+	if run, ok := e.runs[runid]; ok && run.Type == schema.AttestMode {
 		title = fmt.Sprintf("%s (publish)", runid)
-	} else if run, ok := e.runs[runid]; ok && run.Type == benchmark.SmoketestMode {
+	} else if run, ok := e.runs[runid]; ok && run.Type == schema.SmoketestMode {
 		title = fmt.Sprintf("%s (evaluate)", runid)
 	} else {
 		title = fmt.Sprintf("%s (unknown)", runid)
@@ -755,7 +755,7 @@ func (t *TuiApp) runBenchmark(bench string) {
 		ID:            runID,
 		BenchmarkName: filepath.Base(bench),
 		BenchmarkHash: hex.EncodeToString(set.Hash(sha256.New())),
-		Type:          string(benchmark.SmoketestMode),
+		Type:          string(schema.SmoketestMode),
 		Created:       ts.UnixMilli(),
 	}))
 	verdictChan, err := t.rb.RunBench(t.Ctx, set, runID)

--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -78,14 +78,14 @@ func (r Rebuild) WasSmoketest() bool {
 // Run represents a group of one or more rebuild executions.
 type Run struct {
 	schema.Run
-	Type    benchmark.BenchmarkMode
+	Type    schema.ExecutionMode
 	Created time.Time
 }
 
 func FromRun(r schema.Run) Run {
 	var rb Run
 	rb.Run = r
-	rb.Type = benchmark.BenchmarkMode(r.Type)
+	rb.Type = schema.ExecutionMode(r.Type)
 	rb.Created = time.UnixMilli(r.Created)
 	return rb
 }


### PR DESCRIPTION
The type of execution is not directly tied to benchmarks. This change helps decouple the benchmark construct from code locations that switch between execution modes.