### PR TITLE
Add interface for patching env vars in network proxy

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -21,19 +21,19 @@ import (
 )
 
 var (
-	verbose                 = flag.Bool("verbose", true, "whether to output log events for each request")
-	httpProxyAddr           = flag.String("http_addr", "localhost:3128", "address for HTTP proxy")
-	tlsProxyAddr            = flag.String("tls_addr", "localhost:3129", "address for TLS proxy")
-	ctrlAddr                = flag.String("ctrl_addr", "localhost:3127", "address for administrative endpoint")
-	dockerAddr              = flag.String("docker_addr", "", "address for docker proxy endpoint")
-	dockerSocket            = flag.String("docker_socket", "/var/run/docker.sock", "path to the docker socket")
-	dockerNetwork           = flag.String("docker_network", "", "if provided, the docker network to use for all proxied containers")
-	dockerEnvVars           = flag.String("docker_env_vars", "", "comma-separated key-value pair env vars to patch into containers")
-	dockerTruststoreEnvVars = flag.String("docker_truststore_env_vars", "", "comma-separated env vars to populate with the proxy cert and patch into containers")
-	dockerJavaEnvVar        = flag.Bool("docker_java_truststore", false, "whether to patch containers with Java proxy cert truststore file and env var")
-	dockerProxySocket       = flag.Bool("docker_recursive_proxy", false, "whether to patch containers with a unix domain socket which proxies docker requests from created containers")
-	policyMode              = flag.String("policy_mode", "disabled", "mode to run the proxy in. Options: disabled, enforce")
-	policyFile              = flag.String("policy_file", "", "path to a json file specifying the policy to apply to the proxy")
+	verbose                    = flag.Bool("verbose", true, "whether to output log events for each request")
+	httpProxyAddr              = flag.String("http_addr", "localhost:3128", "address for HTTP proxy")
+	tlsProxyAddr               = flag.String("tls_addr", "localhost:3129", "address for TLS proxy")
+	ctrlAddr                   = flag.String("ctrl_addr", "localhost:3127", "address for administrative endpoint")
+	dockerAddr                 = flag.String("docker_addr", "", "address for docker proxy endpoint")
+	dockerSocket               = flag.String("docker_socket", "/var/run/docker.sock", "path to the docker socket")
+	dockerNetwork              = flag.String("docker_network", "", "if provided, the docker network to use for all proxied containers")
+	dockerEnvVars              = flag.String("docker_env_vars", "", "comma-separated key-value pair env vars to patch into containers")
+	dockerTruststoreEnvVars    = flag.String("docker_truststore_env_vars", "", "comma-separated env vars to populate with the proxy cert and patch into containers")
+	dockerJavaTruststoreEnvVar = flag.Bool("docker_java_truststore", false, "whether to patch containers with Java proxy cert truststore file and env var")
+	dockerProxySocket          = flag.Bool("docker_recursive_proxy", false, "whether to patch containers with a unix domain socket which proxies docker requests from created containers")
+	policyMode                 = flag.String("policy_mode", "disabled", "mode to run the proxy in. Options: disabled, enforce")
+	policyFile                 = flag.String("policy_file", "", "path to a json file specifying the policy to apply to the proxy")
 )
 
 func main() {
@@ -81,11 +81,11 @@ func main() {
 			truststoreEnvVars = strings.Split(*dockerTruststoreEnvVars, ",")
 		}
 		ctp, err := docker.NewContainerTruststorePatcher(*ca.Leaf, docker.ContainerTruststorePatcherOpts{
-			EnvVars:           envVars,
-			TrustStoreEnvVars: truststoreEnvVars,
-			JavaEnvVar:        *dockerJavaEnvVar,
-			RecursiveProxy:    *dockerProxySocket,
-			NetworkOverride:   *dockerNetwork,
+			EnvVars:              envVars,
+			TruststoreEnvVars:    truststoreEnvVars,
+			JavaTruststoreEnvVar: *dockerJavaTruststoreEnvVar,
+			RecursiveProxy:       *dockerProxySocket,
+			NetworkOverride:      *dockerNetwork,
 		})
 		if err != nil {
 			log.Fatalf("creating docker patcher: %v", err)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -21,18 +21,19 @@ import (
 )
 
 var (
-	verbose           = flag.Bool("verbose", true, "whether to output log events for each request")
-	httpProxyAddr     = flag.String("http_addr", "localhost:3128", "address for HTTP proxy")
-	tlsProxyAddr      = flag.String("tls_addr", "localhost:3129", "address for TLS proxy")
-	ctrlAddr          = flag.String("ctrl_addr", "localhost:3127", "address for administrative endpoint")
-	dockerAddr        = flag.String("docker_addr", "", "address for docker proxy endpoint")
-	dockerSocket      = flag.String("docker_socket", "/var/run/docker.sock", "path to the docker socket")
-	dockerNetwork     = flag.String("docker_network", "", "if provided, the docker network to use for all proxied containers")
-	dockerEnvVars     = flag.String("docker_truststore_env_vars", "", "comma-separated env vars to populate with the proxy cert and patch into containers")
-	dockerJavaEnvVar  = flag.Bool("docker_java_truststore", false, "whether to patch containers with Java proxy cert truststore file and env var")
-	dockerProxySocket = flag.Bool("docker_recursive_proxy", false, "whether to patch containers with a unix domain socket which proxies docker requests from created containers")
-	policyMode        = flag.String("policy_mode", "disabled", "mode to run the proxy in. Options: disabled, enforce")
-	policyFile        = flag.String("policy_file", "", "path to a json file specifying the policy to apply to the proxy")
+	verbose                 = flag.Bool("verbose", true, "whether to output log events for each request")
+	httpProxyAddr           = flag.String("http_addr", "localhost:3128", "address for HTTP proxy")
+	tlsProxyAddr            = flag.String("tls_addr", "localhost:3129", "address for TLS proxy")
+	ctrlAddr                = flag.String("ctrl_addr", "localhost:3127", "address for administrative endpoint")
+	dockerAddr              = flag.String("docker_addr", "", "address for docker proxy endpoint")
+	dockerSocket            = flag.String("docker_socket", "/var/run/docker.sock", "path to the docker socket")
+	dockerNetwork           = flag.String("docker_network", "", "if provided, the docker network to use for all proxied containers")
+	dockerEnvVars           = flag.String("docker_env_vars", "", "comma-separated key-value pair env vars to patch into containers")
+	dockerTruststoreEnvVars = flag.String("docker_truststore_env_vars", "", "comma-separated env vars to populate with the proxy cert and patch into containers")
+	dockerJavaEnvVar        = flag.Bool("docker_java_truststore", false, "whether to patch containers with Java proxy cert truststore file and env var")
+	dockerProxySocket       = flag.Bool("docker_recursive_proxy", false, "whether to patch containers with a unix domain socket which proxies docker requests from created containers")
+	policyMode              = flag.String("policy_mode", "disabled", "mode to run the proxy in. Options: disabled, enforce")
+	policyFile              = flag.String("policy_file", "", "path to a json file specifying the policy to apply to the proxy")
 )
 
 func main() {
@@ -72,15 +73,19 @@ func main() {
 	go proxyService.ProxyTLS(*tlsProxyAddr)
 	go proxyService.ProxyHTTP(*httpProxyAddr)
 	if len(*dockerAddr) > 0 {
-		var vars []string
+		var envVars, truststoreEnvVars []string
 		if *dockerEnvVars != "" {
-			vars = strings.Split(*dockerEnvVars, ",")
+			envVars = strings.Split(*dockerEnvVars, ",")
+		}
+		if *dockerTruststoreEnvVars != "" {
+			truststoreEnvVars = strings.Split(*dockerTruststoreEnvVars, ",")
 		}
 		ctp, err := docker.NewContainerTruststorePatcher(*ca.Leaf, docker.ContainerTruststorePatcherOpts{
-			EnvVars:         vars,
-			JavaEnvVar:      *dockerJavaEnvVar,
-			RecursiveProxy:  *dockerProxySocket,
-			NetworkOverride: *dockerNetwork,
+			EnvVars:           envVars,
+			TrustStoreEnvVars: truststoreEnvVars,
+			JavaEnvVar:        *dockerJavaEnvVar,
+			RecursiveProxy:    *dockerProxySocket,
+			NetworkOverride:   *dockerNetwork,
 		})
 		if err != nil {
 			log.Fatalf("creating docker patcher: %v", err)

--- a/pkg/proxy/docker/docker.go
+++ b/pkg/proxy/docker/docker.go
@@ -55,7 +55,7 @@ const (
 	proxyCertPath    = "/var/cache/proxy.crt"
 	proxyCertJKSPath = "/var/cache/proxy.crt.jks"
 	// Official interface for providing additional args to JVMs.
-	javaEnvVar = "JAVA_TOOL_OPTIONS"
+	javaTruststoreEnvVar = "JAVA_TOOL_OPTIONS"
 	// Env var to which docker requests will be sent by the docker CLI.
 	dockerEnvVar = "DOCKER_HOST"
 	// The path to the docker proxy that can be bound within a container to make docker calls.
@@ -419,24 +419,24 @@ type patchSet struct {
 
 // ContainerTruststorePatcher provides a Docker API proxy that patches the container truststore while running.
 type ContainerTruststorePatcher struct {
-	cert              x509.Certificate
-	envVars           []string
-	trustStoreEnvVars []string
-	javaEnvVar        bool
-	networkOverride   string // TODO: Not a good fit for this abstraction
-	proxySocket       string
-	patchMap          map[string]*patchSet
-	m                 sync.Mutex
-	created           atomic.Uint32
+	cert                 x509.Certificate
+	envVars              []string
+	truststoreEnvVars    []string
+	javaTruststoreEnvVar bool
+	networkOverride      string // TODO: Not a good fit for this abstraction
+	proxySocket          string
+	patchMap             map[string]*patchSet
+	m                    sync.Mutex
+	created              atomic.Uint32
 }
 
 // ContainerTruststorePatcherOpts defines the optional parameters for creating a ContainerTruststorePatcher.
 type ContainerTruststorePatcherOpts struct {
-	EnvVars           []string
-	TrustStoreEnvVars []string
-	JavaEnvVar        bool
-	RecursiveProxy    bool
-	NetworkOverride   string
+	EnvVars              []string
+	TruststoreEnvVars    []string
+	JavaTruststoreEnvVar bool
+	RecursiveProxy       bool
+	NetworkOverride      string
 }
 
 // NewContainerTruststorePatcher creates a new ContainerTruststorePatcher with the provided certificate and options.
@@ -454,13 +454,13 @@ func NewContainerTruststorePatcher(cert x509.Certificate, opts ContainerTruststo
 	}
 
 	return &ContainerTruststorePatcher{
-		cert:              cert,
-		envVars:           opts.EnvVars,
-		trustStoreEnvVars: opts.TrustStoreEnvVars,
-		javaEnvVar:        opts.JavaEnvVar,
-		networkOverride:   opts.NetworkOverride,
-		proxySocket:       sockName,
-		patchMap:          make(map[string]*patchSet),
+		cert:                 cert,
+		envVars:              opts.EnvVars,
+		truststoreEnvVars:    opts.TruststoreEnvVars,
+		javaTruststoreEnvVar: opts.JavaTruststoreEnvVar,
+		networkOverride:      opts.NetworkOverride,
+		proxySocket:          sockName,
+		patchMap:             make(map[string]*patchSet),
 	}, nil
 }
 
@@ -564,13 +564,13 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 		for _, v := range d.envVars {
 			vars = append(vars, v)
 		}
-		for _, v := range d.trustStoreEnvVars {
+		for _, v := range d.truststoreEnvVars {
 			vars = append(vars, v+"="+proxyCertPath)
 		}
-		if d.javaEnvVar {
+		if d.javaTruststoreEnvVar {
 			// NOTE: Since other user-provided values can be set in JAVA_TOOL_OPTIONS,
 			// we merge the proxy-specific arg into the existing value, if present.
-			val, err := getEnvVar(newBody, javaEnvVar)
+			val, err := getEnvVar(newBody, javaTruststoreEnvVar)
 			if err != nil && !errors.Is(err, iofs.ErrNotExist) {
 				log.Fatalf("Failed to get env var for request %s: %s", req.URL.Path, err)
 			}
@@ -579,8 +579,8 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 				newVal = trimQuotes(val) + " "
 			}
 			newVal += "-Djavax.net.ssl.trustStore=" + proxyCertJKSPath
-			vars = append(vars, javaEnvVar+"="+newVal)
-			log.Printf("Updated %s [old=%s, new=%s]", javaEnvVar, val, newVal)
+			vars = append(vars, javaTruststoreEnvVar+"="+newVal)
+			log.Printf("Updated %s [old=%s, new=%s]", javaTruststoreEnvVar, val, newVal)
 		}
 		if d.proxySocket != "" {
 			newBody, err = addBinding(newBody, d.proxySocket, proxySocketPath, "rw")
@@ -627,7 +627,7 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 			log.Printf("Creating proxy cert: %v", err)
 			break
 		}
-		if d.javaEnvVar {
+		if d.javaTruststoreEnvVar {
 			jks, err := cert.ToJKS(&d.cert)
 			if err != nil {
 				log.Printf("Generating java proxy cert: %v", err)
@@ -663,14 +663,14 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 			log.Fatalf("failed to read body for request %s: %v", req.URL.Path, err)
 		}
 		var otherVars []string
-		if d.javaEnvVar {
-			otherVars = append(otherVars, javaEnvVar)
+		if d.javaTruststoreEnvVar {
+			otherVars = append(otherVars, javaTruststoreEnvVar)
 		}
 		if d.proxySocket != "" {
 			otherVars = append(otherVars, dockerEnvVar)
 		}
 		allVars := append(otherVars, d.envVars...)
-		allVars = append(otherVars, d.trustStoreEnvVars...)
+		allVars = append(otherVars, d.truststoreEnvVars...)
 		var newBody []byte
 		if !bytes.Equal(body, nullJSONBody) {
 			newBody, err = removeEnvVars(body, allVars)

--- a/pkg/proxy/docker/docker_test.go
+++ b/pkg/proxy/docker/docker_test.go
@@ -526,7 +526,7 @@ func TestUnpatchDuringCommit(t *testing.T) {
 }
 
 func TestPatchOnStartWithJavaEnv(t *testing.T) {
-	ctp, _ := NewContainerTruststorePatcher(CERT, ContainerTruststorePatcherOpts{JavaEnvVar: true})
+	ctp, _ := NewContainerTruststorePatcher(CERT, ContainerTruststorePatcherOpts{JavaTruststoreEnvVar: true})
 	sock := tempSocketName(t)
 	l, err := net.Listen("unix", sock)
 	if err != nil {

--- a/pkg/proxy/docker/docker_test.go
+++ b/pkg/proxy/docker/docker_test.go
@@ -813,6 +813,7 @@ func TestAddEnvVars(t *testing.T) {
 		{[]byte(`{"Env":[]}`), []string{"FOO="}, []byte(`{"Env":["FOO="]}`)},
 		{[]byte(`{"Env":["BAR="]}`), []string{"FOO="}, []byte(`{"Env":["BAR=","FOO="]}`)},
 		{[]byte(`{"Env":[]}`), []string{"FOO=", "BAR="}, []byte(`{"Env":["FOO=","BAR="]}`)},
+		{[]byte(`{"Env":[]}`), []string{"FOO=foo"}, []byte(`{"Env":["FOO=foo"]}`)},
 	} {
 		got, err := addEnvVars(tc.Body, tc.Vars)
 		if err != nil {
@@ -838,6 +839,9 @@ func TestRemoveEnvVars(t *testing.T) {
 		{[]byte(`{"Env":["BAR=","FOO="]}`), []string{"FOO", "BAR"}, []byte(`{"Env":[]}`)},
 		{[]byte(`{"Env":["BAR=old","BAR=new","FOO=new"]}`), []string{"BAR", "FOO"}, []byte(`{"Env":["BAR=old"]}`)},
 		{[]byte(`{"Env":["BAR=","BAZ=","FOO="]}`), []string{"BAR"}, []byte(`{"Env":["BAZ=","FOO="]}`)},
+		{[]byte(`{"Env":["FOO=foo"]}`), []string{"FOO=foo"}, []byte(`{"Env":[]}`)},
+		{[]byte(`{"Env":["FOO=foo"]}`), []string{"FOO=bar"}, []byte(`{"Env":["FOO=foo"]}`)},
+		{[]byte(`{"Env":["FOO=old","FOO=new"]}`), []string{"FOO=old"}, []byte(`{"Env":["FOO=new"]}`)},
 	} {
 		got, err := removeEnvVars(tc.Body, tc.Vars)
 		if err != nil {


### PR DESCRIPTION
Currently the proxy is only able to patch environment variables into the docker container by providing a key and mapping it to the certificate truststore. Allow key-value pairs through a different flag to support custom environment variables.