### PR TITLE
Use versioned prebuilds

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -56,6 +56,7 @@ var (
 	prebuildBucket        = flag.String("prebuild-bucket", "", "GCS bucket from which prebuilt build tools are stored")
 	serviceRepo           = flag.String("service-repo", "", "repo from which the service was built")
 	serviceVersion        = flag.String("service-version", "", "golang version identifier of the service container builds")
+	prebuildVersion       = flag.String("prebuild-version", "", "golang version identifier of the prebuild binary builds")
 	buildDefRepo          = flag.String("build-def-repo", "", "repository for build definitions")
 	buildDefRepoDir       = flag.String("build-def-repo-dir", ".", "relpath within the build definitions repository")
 	overwriteAttestations = flag.Bool("overwrite-attestations", false, "whether to overwrite existing attestations when writing to GCS")
@@ -141,6 +142,13 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	d.ServiceRepo = rebuild.Location{
 		Repo: serviceRepo,
 		Ref:  *serviceVersion,
+	}
+	if !goPseudoVersion.MatchString(*prebuildVersion) {
+		return nil, errors.New("prebuild version must be a go mod pseudo-version: https://go.dev/ref/mod#pseudo-versions")
+	}
+	d.PrebuildRepo = rebuild.Location{
+		Repo: serviceRepo,
+		Ref:  *prebuildVersion,
 	}
 	buildDefRepo, err := uri.CanonicalizeRepoURI(*buildDefRepo)
 	if err != nil {

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -566,6 +566,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--user-agent=oss-rebuild+${var.host}/0.0.0",
         "--service-repo=${var.repo}",
         "--service-version=${var.service_version}",
+        "--prebuild-version=${var.prebuild_version}",
         "--build-def-repo=https://github.com/google/oss-rebuild",
         "--build-def-repo-dir=definitions",
       ]
@@ -578,7 +579,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
     }
     max_instance_request_concurrency = 25
   }
-  depends_on = [google_project_service.run]
+  depends_on = [google_project_service.run, terraform_data.binary]
 }
 
 ## IAM Bindings

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -131,6 +131,7 @@ type RebuildPackageDeps struct {
 	UtilPrebuildBucket         string
 	BuildLogsBucket            string
 	ServiceRepo                rebuild.Location
+	PrebuildRepo               rebuild.Location
 	BuildDefRepo               rebuild.Location
 	AttestationStore           rebuild.AssetStore
 	LocalMetadataStore         rebuild.AssetStore
@@ -220,6 +221,7 @@ func buildAndAttest(ctx context.Context, deps *RebuildPackageDeps, mux rebuild.R
 		Project:             deps.BuildProject,
 		BuildServiceAccount: deps.BuildServiceAccount,
 		UtilPrebuildBucket:  deps.UtilPrebuildBucket,
+		UtilPrebuildDir:     deps.PrebuildRepo.Ref,
 		LogsBucket:          deps.BuildLogsBucket,
 		LocalMetadataStore:  deps.LocalMetadataStore,
 		DebugStore:          debugStore,
@@ -259,7 +261,7 @@ func buildAndAttest(ctx context.Context, deps *RebuildPackageDeps, mux rebuild.R
 		input.Strategy = entry.Strategy
 		buildDefRepo = entry.BuildDefLoc
 	}
-	eqStmt, buildStmt, err := verifier.CreateAttestations(ctx, input, strategy, id, rb, up, deps.LocalMetadataStore, deps.ServiceRepo, buildDefRepo)
+	eqStmt, buildStmt, err := verifier.CreateAttestations(ctx, input, strategy, id, rb, up, deps.LocalMetadataStore, deps.ServiceRepo, deps.PrebuildRepo, buildDefRepo)
 	if err != nil {
 		return errors.Wrap(err, "creating attestations")
 	}

--- a/internal/verifier/attestation.go
+++ b/internal/verifier/attestation.go
@@ -37,7 +37,7 @@ const (
 )
 
 // CreateAttestations creates the SLSA attestations associated with a rebuild.
-func CreateAttestations(ctx context.Context, input rebuild.Input, finalStrategy rebuild.Strategy, id string, rb, up ArtifactSummary, metadata rebuild.AssetStore, serviceLoc, buildDefLoc rebuild.Location) (equivalence, build *in_toto.ProvenanceStatementSLSA1, err error) {
+func CreateAttestations(ctx context.Context, input rebuild.Input, finalStrategy rebuild.Strategy, id string, rb, up ArtifactSummary, metadata rebuild.AssetStore, serviceLoc, prebuildLoc, buildDefLoc rebuild.Location) (equivalence, build *in_toto.ProvenanceStatementSLSA1, err error) {
 	t, manualStrategy := input.Target, input.Strategy
 	var dockerfile []byte
 	{
@@ -71,6 +71,10 @@ func CreateAttestations(ctx context.Context, input rebuild.Input, finalStrategy 
 		"serviceSource": map[string]string{
 			"ref":        serviceLoc.Ref,
 			"repository": serviceLoc.Repo,
+		},
+		"prebuildSource": map[string]string{
+			"ref":        prebuildLoc.Ref,
+			"repository": prebuildLoc.Repo,
 		},
 	}
 	publicRebuildURI := path.Join("rebuild", buildInfo.Target.Artifact)

--- a/internal/verifier/attestation_test.go
+++ b/internal/verifier/attestation_test.go
@@ -78,8 +78,9 @@ func TestCreateAttestations(t *testing.T) {
 		strategy := &rebuild.ManualStrategy{Location: inputStrategy.Location, Deps: "echo deps", Build: "echo build", SystemDeps: []string{"git"}, OutputPath: "foo/bar"}
 		input := rebuild.Input{Target: target, Strategy: inputStrategy}
 		serviceLoc := rebuild.Location{Repo: "https://github.com/google/oss-rebuild", Ref: "v0.0.0-202501010000-feeddeadbeef00"}
+		prebuildLoc := rebuild.Location{Repo: "https://github.com/google/oss-rebuild", Ref: "v0.0.0-202401010000-feeddeadbeef99"}
 		buildDefLoc := rebuild.Location{Repo: "https://github.com/google/oss-rebuild", Ref: "b33eec7134eff8a16cb902b80e434de58bf37e2c", Dir: "definitions/cratesio/bytes/1.0.0/bytes-1.0.0.crate/build.yaml"}
-		eqStmt, buildStmt, err := CreateAttestations(ctx, input, strategy, "test-id", rbSummary, upSummary, metadata, serviceLoc, buildDefLoc)
+		eqStmt, buildStmt, err := CreateAttestations(ctx, input, strategy, "test-id", rbSummary, upSummary, metadata, serviceLoc, prebuildLoc, buildDefLoc)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -104,6 +105,10 @@ func TestCreateAttestations(t *testing.T) {
         "target": "https://up.stream/bytes-1.0.0.crate"
       },
       "internalParameters": {
+        "prebuildSource": {
+          "ref": "v0.0.0-202401010000-feeddeadbeef99",
+          "repository": "https://github.com/google/oss-rebuild"
+        },
         "serviceSource": {
           "ref": "v0.0.0-202501010000-feeddeadbeef00",
           "repository": "https://github.com/google/oss-rebuild"
@@ -173,6 +178,10 @@ func TestCreateAttestations(t *testing.T) {
         "version": "1.0.0"
       },
       "internalParameters": {
+        "prebuildSource": {
+          "ref": "v0.0.0-202401010000-feeddeadbeef99",
+          "repository": "https://github.com/google/oss-rebuild"
+        },
         "serviceSource": {
           "ref": "v0.0.0-202501010000-feeddeadbeef00",
           "repository": "https://github.com/google/oss-rebuild"

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -115,6 +115,49 @@ ENTRYPOINT ["/bin/sh","/build"]
 `,
 		},
 		{
+			name: "With Timewarp at a Subdir",
+			input: Input{
+				Target: Target{},
+				Strategy: &ManualStrategy{
+					Location:   Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
+					SystemDeps: []string{"git", "make"},
+					Deps:       "make deps ...",
+					Build:      "make build ...",
+					OutputPath: "output/foo.tgz",
+				},
+			},
+			opts: RemoteOptions{
+				UseTimewarp:        true,
+				UtilPrebuildBucket: "my-bucket",
+				UtilPrebuildDir:    "v0.0.0-202501010000-feeddeadbeef00",
+			},
+			expected: `#syntax=docker/dockerfile:1.4
+FROM docker.io/library/alpine:3.19
+RUN <<'EOF'
+ set -eux
+ wget https://my-bucket.storage.googleapis.com/v0.0.0-202501010000-feeddeadbeef00/timewarp
+ chmod +x timewarp
+ apk add git make
+EOF
+RUN <<'EOF'
+ set -eux
+ ./timewarp -port 8080 &
+ while ! nc -z localhost 8080;do sleep 1;done
+ mkdir /src && cd /src
+ git clone github.com/example .
+ git checkout --force 'main'
+ make deps ...
+EOF
+RUN cat <<'EOF' >/build
+ set -eux
+ make build ...
+ mkdir /out && cp /src/output/foo.tgz /out/
+EOF
+WORKDIR "/src"
+ENTRYPOINT ["/bin/sh","/build"]
+`,
+		},
+		{
 			name: "Multi-Line Scripts",
 			input: Input{
 				Target: Target{},
@@ -452,6 +495,90 @@ curl http://proxy:3127/summary > /workspace/netlog.json
 						Name: "docker.io/library/alpine:3.19",
 						Script: `set -eux
 wget https://test-bootstrap.storage.googleapis.com/gsutil_writeonly
+chmod +x gsutil_writeonly
+./gsutil_writeonly cp /workspace/image.tgz file:///npm/pkg/version/pkg-version.tgz/image.tgz
+./gsutil_writeonly cp /workspace/pkg-version.tgz file:///npm/pkg/version/pkg-version.tgz/pkg-version.tgz
+./gsutil_writeonly cp /workspace/netlog.json file:///npm/pkg/version/pkg-version.tgz/netlog.json
+`,
+					},
+				},
+			},
+		},
+		{
+			name:       "proxy build at subdir",
+			target:     Target{Ecosystem: NPM, Package: "pkg", Version: "version", Artifact: "pkg-version.tgz"},
+			dockerfile: "FROM docker.io/library/alpine:3.19",
+			opts: RemoteOptions{
+				LogsBucket:          "test-logs-bucket",
+				BuildServiceAccount: "test-service-account",
+				UtilPrebuildBucket:  "test-bootstrap",
+				UtilPrebuildDir:     "v0.0.0-202501010000-feeddeadbeef00",
+				RemoteMetadataStore: NewFilesystemAssetStore(memfs.New()),
+				UseNetworkProxy:     true,
+			},
+			expected: &cloudbuild.Build{
+				LogsBucket:     "test-logs-bucket",
+				Options:        &cloudbuild.BuildOptions{Logging: "GCS_ONLY"},
+				ServiceAccount: "test-service-account",
+				Steps: []*cloudbuild.BuildStep{
+					{
+						Name: "gcr.io/cloud-builders/docker",
+						Script: `set -eux
+curl -O https://test-bootstrap.storage.googleapis.com/v0.0.0-202501010000-feeddeadbeef00/proxy
+chmod +x proxy
+docker network create proxynet
+useradd --system proxyu
+uid=$(id -u proxyu)
+docker run --detach --name=proxy --network=proxynet --privileged -v=/workspace/proxy:/workspace/proxy -v=/var/run/docker.sock:/var/run/docker.sock --entrypoint /bin/sh gcr.io/cloud-builders/docker -euxc '
+	useradd --system --non-unique --uid '$uid' proxyu
+	chown proxyu /workspace/proxy
+	chown proxyu /var/run/docker.sock
+	su - proxyu -c "/workspace/proxy \
+		-verbose=true \
+		-http_addr=:3128 \
+		-tls_addr=:3129 \
+		-ctrl_addr=:3127 \
+		-docker_addr=:3130 \
+		-docker_socket=/var/run/docker.sock \
+		-docker_truststore_env_vars=PIP_CERT,CURL_CA_BUNDLE,NODE_EXTRA_CA_CERTS,CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE,NIX_SSL_CERT_FILE \
+		-docker_network=container:build \
+		-docker_java_truststore=true"
+'
+proxyIP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' proxy)
+docker network connect cloudbuild proxy
+docker run --detach --name=build --network=proxynet --entrypoint=/bin/sh gcr.io/cloud-builders/docker -c 'sleep infinity'
+docker exec --privileged build /bin/sh -euxc '
+	iptables -t nat -A OUTPUT -p tcp --dport 3128 -j ACCEPT
+	iptables -t nat -A OUTPUT -p tcp --dport 3129 -j ACCEPT
+	iptables -t nat -A OUTPUT -p tcp -m owner --uid-owner '$uid' -j ACCEPT
+	iptables -t nat -A OUTPUT -p tcp --dport 80 -j DNAT --to-destination '$proxyIP':3128
+	iptables -t nat -A OUTPUT -p tcp --dport 443 -j DNAT --to-destination '$proxyIP':3129
+'
+docker exec build /bin/sh -euxc '
+	curl http://proxy:3127/cert | tee /etc/ssl/certs/proxy.crt >> /etc/ssl/certs/ca-certificates.crt
+	export DOCKER_HOST=tcp://proxy:3130 PROXYCERT=/etc/ssl/certs/proxy.crt
+	docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
+	cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs --mount=type=secret,id=PROXYCERT,env=PIP_CERT --mount=type=secret,id=PROXYCERT,env=CURL_CA_BUNDLE --mount=type=secret,id=PROXYCERT,env=NODE_EXTRA_CA_CERTS --mount=type=secret,id=PROXYCERT,env=CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE --mount=type=secret,id=PROXYCERT,env=NIX_SSL_CERT_FILE|" | \
+		docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
+	FROM docker.io/library/alpine:3.19
+EOS
+	docker run --name=container img
+'
+curl http://proxy:3127/summary > /workspace/netlog.json
+`,
+					},
+					{
+						Name: "gcr.io/cloud-builders/docker",
+						Args: []string{"cp", "container:/out/pkg-version.tgz", "/workspace/pkg-version.tgz"},
+					},
+					{
+						Name:   "gcr.io/cloud-builders/docker",
+						Script: "docker save img | gzip > /workspace/image.tgz",
+					},
+					{
+						Name: "docker.io/library/alpine:3.19",
+						Script: `set -eux
+wget https://test-bootstrap.storage.googleapis.com/v0.0.0-202501010000-feeddeadbeef00/gsutil_writeonly
 chmod +x gsutil_writeonly
 ./gsutil_writeonly cp /workspace/image.tgz file:///npm/pkg/version/pkg-version.tgz/image.tgz
 ./gsutil_writeonly cp /workspace/pkg-version.tgz file:///npm/pkg/version/pkg-version.tgz/pkg-version.tgz


### PR DESCRIPTION
Fixes #273, #124

This ensures that future updates to our build tools won't break already-published Dockerfiles contained in attestations.