### PR TITLE
Set posix mode on bootstrap-tools

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -381,7 +381,8 @@ resource "terraform_data" "binary" {
         docker save ${each.value.image}:${each.value.version} | \
           tar -xO --wildcards "*/layer.tar" | \
           tar -xO ${each.value.name} | \
-          gcloud storage cp - $path
+          gcloud storage cp - $path && \
+          gcloud storage objects update $path --custom-metadata=goog-reserved-posix-mode=750
       fi
     EOT
   }


### PR DESCRIPTION
The gsutil cp command supports -P to copy the posix mode of the source
filesystem, but we're reading the file from a pipe so that's not
available. Instead we can set the posix mode after it's uploaded.