### PR TITLE
Support authenticated access to bootstrap tools

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -44,6 +44,7 @@ var (
 	debugStorage          = flag.String("debug-storage", "", "if provided, the location in which rebuild debug info should be stored")
 	prebuildBucket        = flag.String("prebuild-bucket", "", "GCS bucket from which prebuilt build tools are stored")
 	prebuildVersion       = flag.String("prebuild-version", "", "golang version identifier of the prebuild binary builds")
+	prebuildAuth          = flag.Bool("prebuild-auth", false, "whether to authenticate requests to the prebuild tools bucket")
 	buildDefRepo          = flag.String("build-def-repo", "", "repository for build definitions")
 	buildDefRepoDir       = flag.String("build-def-repo-dir", ".", "relpath within the build definitions repository")
 	overwriteAttestations = flag.Bool("overwrite-attestations", false, "whether to overwrite existing attestations when writing to GCS")
@@ -127,6 +128,7 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	d.BuildProject = *project
 	d.BuildServiceAccount = *buildRemoteIdentity
 	d.UtilPrebuildBucket = *prebuildBucket
+	d.UtilPrebuildAuth = *prebuildAuth
 	d.BuildLogsBucket = *logsBucket
 	var serviceRepo string
 	if BuildRepo == "" {

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -553,6 +553,8 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--build-remote-identity=${google_service_account.builder-remote.name}",
         "--inference-url=${google_cloud_run_v2_service.inference.uri}",
         "--prebuild-bucket=${google_storage_bucket.bootstrap-tools.name}",
+        "--prebuild-version=${var.prebuild_version}",
+        "--prebuild-auth=${var.public ? "false" : "true"}",
         "--signing-key-version=${data.google_kms_crypto_key_version.signing-key-version.name}",
         "--metadata-bucket=${google_storage_bucket.metadata.name}",
         "--attestation-bucket=${google_storage_bucket.attestations.name}",
@@ -560,7 +562,6 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--debug-storage=gs://${google_storage_bucket.debug.name}",
         "--gateway-url=${google_cloud_run_v2_service.gateway.uri}",
         "--user-agent=oss-rebuild+${var.host}/0.0.0",
-        "--prebuild-version=${var.prebuild_version}",
         "--build-def-repo=https://github.com/google/oss-rebuild",
         "--build-def-repo-dir=definitions",
       ]

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -133,6 +133,7 @@ type RebuildPackageDeps struct {
 	BuildProject               string
 	BuildServiceAccount        string
 	UtilPrebuildBucket         string
+	UtilPrebuildAuth           bool
 	BuildLogsBucket            string
 	ServiceRepo                rebuild.Location
 	PrebuildRepo               rebuild.Location
@@ -227,6 +228,7 @@ func buildAndAttest(ctx context.Context, deps *RebuildPackageDeps, mux rebuild.R
 		BuildServiceAccount: deps.BuildServiceAccount,
 		UtilPrebuildBucket:  deps.UtilPrebuildBucket,
 		UtilPrebuildDir:     deps.PrebuildRepo.Ref,
+		UtilPrebuildAuth:    deps.UtilPrebuildAuth,
 		LogsBucket:          deps.BuildLogsBucket,
 		LocalMetadataStore:  deps.LocalMetadataStore,
 		DebugStore:          debugStore,

--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -36,6 +36,7 @@ type RemoteOptions struct {
 	RemoteMetadataStore LocatableAssetStore
 	UtilPrebuildBucket  string
 	UtilPrebuildDir     string
+	UtilPrebuildAuth    bool
 	// TODO: Consider moving these to Strategy.
 	UseTimewarp       bool
 	UseNetworkProxy   bool
@@ -48,6 +49,7 @@ type rebuildContainerArgs struct {
 	UseNetworkProxy    bool
 	UtilPrebuildBucket string
 	UtilPrebuildDir    string
+	UtilPrebuildAuth   bool
 }
 
 const policyYaml = `
@@ -121,10 +123,11 @@ var debuildContainerTpl = template.Must(
 		textwrap.Dedent(`
 				#syntax=docker/dockerfile:1.10
 				FROM docker.io/library/debian:trixie-20250203-slim
-				RUN <<'EOF'
+				RUN {{if .UtilPrebuildAuth}}--mount=type=secret,id=auth_header {{end}}<<'EOF'
 				 set -eux
 				{{- if .UseTimewarp}}
-				 curl https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}timewarp > timewarp
+				 curl {{if .UtilPrebuildAuth}}-H @/run/secrets/auth_header {{end -}}
+				 https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}timewarp > timewarp
 				 chmod +x timewarp
 				{{- end}}
 				 apt update
@@ -163,10 +166,11 @@ var alpineContainerTpl = template.Must(
 		textwrap.Dedent(`
 				#syntax=docker/dockerfile:1.10
 				FROM docker.io/library/alpine:3.19
-				RUN <<'EOF'
+				RUN {{if .UtilPrebuildAuth}}--mount=type=secret,id=auth_header {{end}}<<'EOF'
 				 set -eux
 				{{- if .UseTimewarp}}
-				 wget https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}timewarp
+				 {{if .UtilPrebuildAuth}}apk add curl && curl -O -H @/run/secrets/auth_header {{else}}wget {{end -}}
+				  https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}timewarp
 				 chmod +x timewarp
 				{{- end}}
 				 apk add {{join " " .Instructions.SystemDeps}}
@@ -204,7 +208,11 @@ var standardBuildTpl = template.Must(
 				export TID=$(docker run --name=tetragon --detach --pid=host --cgroupns=host --privileged -v=/workspace/tetragon.jsonl:/workspace/tetragon.jsonl -v=/workspace/tetragon_policy.yaml:/workspace/tetragon_policy.yaml -v=/sys/kernel/btf/vmlinux:/var/lib/tetragon/btf quay.io/cilium/tetragon:v1.1.2 /usr/bin/tetragon --tracing-policy=/workspace/tetragon_policy.yaml --export-filename=/workspace/tetragon.jsonl)
 				grep -q "Listening for events..." <(docker logs --follow $TID 2>&1) || (docker logs $TID && exit 1)
 				{{- end}}
-				cat <<'EOS' | docker buildx build --tag=img -
+				{{- if .UtilPrebuildAuth}}
+				apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/builder-remote@{{.Project}}.iam.gserviceaccount.com/token | jq .access_token > /tmp/token
+				(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
+				{{- end}}
+				cat <<'EOS' | docker buildx build {{if .UtilPrebuildAuth}}--secret id=auth_header,src=/tmp/auth_header {{end}}--tag=img -
 				{{.Dockerfile}}
 				EOS
 				docker run --name=container img
@@ -262,7 +270,12 @@ var proxyBuildTpl = template.Must(
 	}).Parse(
 		textwrap.Dedent(`
 				set -eux
-				curl -O https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}proxy
+				{{- if .UtilPrebuildAuth}}
+				apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/builder-remote@{{.Project}}.iam.gserviceaccount.com/token | jq .access_token > /tmp/token
+				(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
+				{{- end}}
+				curl -O {{if .UtilPrebuildAuth}}-H @/tmp/auth_header {{end -}}
+					https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}proxy
 				chmod +x proxy
 				docker network create proxynet
 				useradd --system {{.User}}
@@ -284,7 +297,11 @@ var proxyBuildTpl = template.Must(
 				'
 				proxyIP=$(docker inspect -f '{{printf "%s" "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}"}}' proxy)
 				docker network connect cloudbuild proxy
-				docker run --detach --name=build --network=proxynet --entrypoint=/bin/sh gcr.io/cloud-builders/docker -c 'sleep infinity'
+				{{- /* NOTE: File-based mounting does not appear to work here so use an env var. */ -}}
+				{{- if .UtilPrebuildAuth}}
+				(printf 'HEADER='; cat /tmp/auth_header) > /tmp/envfile
+				{{- end}}
+				docker run --detach --name=build --network=proxynet --entrypoint=/bin/sh {{if .UtilPrebuildAuth}}--env-file /tmp/envfile {{end}}gcr.io/cloud-builders/docker -c 'sleep infinity'
 				docker exec --privileged build /bin/sh -euxc '
 					iptables -t nat -A OUTPUT -p tcp --dport {{.HTTPPort}} -j ACCEPT
 					iptables -t nat -A OUTPUT -p tcp --dport {{.TLSPort}} -j ACCEPT
@@ -300,10 +317,10 @@ var proxyBuildTpl = template.Must(
 				{{- end}}
 				docker exec build /bin/sh -euxc '
 					curl http://proxy:{{.CtrlPort}}/cert | tee /etc/ssl/certs/proxy.crt >> /etc/ssl/certs/ca-certificates.crt
-					export DOCKER_HOST=tcp://proxy:{{.DockerPort}} PROXYCERT=/etc/ssl/certs/proxy.crt
+					export DOCKER_HOST=tcp://proxy:{{.DockerPort}} PROXYCERT=/etc/ssl/certs/proxy.crt{{if .UtilPrebuildAuth}} HEADER{{end}}
 					docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
 					cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs{{range .CertEnvVars}} --mount=type=secret,id=PROXYCERT,env={{.}}{{end}}|" | \
-						docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
+						docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT {{if .UtilPrebuildAuth}}--secret id=auth_header,env=HEADER {{end}}--load --tag=img -
 				{{.Dockerfile}}
 				EOS
 					docker run --name=container img
@@ -326,7 +343,12 @@ var assetUploadTpl = template.Must(
 	).Parse(
 		textwrap.Dedent(`
 				set -eux
-				wget https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}gsutil_writeonly
+				{{- if .UtilPrebuildAuth}}
+				apk add curl jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/builder-remote@{{.Project}}.iam.gserviceaccount.com/token | jq .access_token > /tmp/token
+				(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
+				{{- end}}
+				{{if .UtilPrebuildAuth}}curl -O -H @/tmp/auth_header {{else}}wget {{end -}}
+				 https://{{.UtilPrebuildBucket}}.storage.googleapis.com/{{if .UtilPrebuildDir}}{{.UtilPrebuildDir}}/{{end}}gsutil_writeonly
 				chmod +x gsutil_writeonly
 				{{- range .Uploads}}
 				./gsutil_writeonly cp {{.From}} {{.To}}
@@ -347,6 +369,8 @@ func makeBuild(t Target, dockerfile string, opts RemoteOptions) (*cloudbuild.Bui
 		err := proxyBuildTpl.Execute(&buildScript, map[string]any{
 			"UtilPrebuildBucket": opts.UtilPrebuildBucket,
 			"UtilPrebuildDir":    opts.UtilPrebuildDir,
+			"UtilPrebuildAuth":   opts.UtilPrebuildAuth,
+			"Project":            opts.Project,
 			"Dockerfile":         dockerfile,
 			"UseSyscallMonitor":  opts.UseSyscallMonitor,
 			"SyscallPolicy":      tetragonPolicyJSON,
@@ -383,6 +407,8 @@ func makeBuild(t Target, dockerfile string, opts RemoteOptions) (*cloudbuild.Bui
 			"Dockerfile":        dockerfile,
 			"UseSyscallMonitor": opts.UseSyscallMonitor,
 			"SyscallPolicy":     tetragonPolicyJSON,
+			"UtilPrebuildAuth":  opts.UtilPrebuildAuth,
+			"Project":           opts.Project,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "expanding standard build template")
@@ -392,6 +418,8 @@ func makeBuild(t Target, dockerfile string, opts RemoteOptions) (*cloudbuild.Bui
 	err := assetUploadTpl.Execute(&assetUploadScript, map[string]any{
 		"UtilPrebuildBucket": opts.UtilPrebuildBucket,
 		"UtilPrebuildDir":    opts.UtilPrebuildDir,
+		"UtilPrebuildAuth":   opts.UtilPrebuildAuth,
+		"Project":            opts.Project,
 		"Uploads":            uploads,
 	})
 	if err != nil {
@@ -460,6 +488,7 @@ func MakeDockerfile(input Input, opts RemoteOptions) (string, error) {
 			UseTimewarp:        opts.UseTimewarp,
 			UtilPrebuildBucket: opts.UtilPrebuildBucket,
 			UtilPrebuildDir:    opts.UtilPrebuildDir,
+			UtilPrebuildAuth:   opts.UtilPrebuildAuth,
 			Instructions:       instructions,
 		})
 	} else {
@@ -467,6 +496,7 @@ func MakeDockerfile(input Input, opts RemoteOptions) (string, error) {
 			UseTimewarp:        opts.UseTimewarp,
 			UtilPrebuildBucket: opts.UtilPrebuildBucket,
 			UtilPrebuildDir:    opts.UtilPrebuildDir,
+			UtilPrebuildAuth:   opts.UtilPrebuildAuth,
 			Instructions:       instructions,
 		})
 	}


### PR DESCRIPTION
This became necessary due to the recent introduction of non-public bootstrap
tools. This use of auth is not intended to be the common mode of execution as
it makes the resulting Dockerfile require an injected credential and should
primarily be used for non-public and/or test environments.