### PR TITLE
Fix whitespace error in proxy rebuild

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -304,7 +304,7 @@ var proxyBuildTpl = template.Must(
 					docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
 					cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs{{range .CertEnvVars}} --mount=type=secret,id=PROXYCERT,env={{.}}{{end}}|" | \
 						docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
-					{{.Dockerfile}}
+				{{.Dockerfile}}
 				EOS
 					docker run --name=container img
 				'

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -465,7 +465,7 @@ docker exec build /bin/sh -euxc '
 	docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
 	cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs --mount=type=secret,id=PROXYCERT,env=PIP_CERT --mount=type=secret,id=PROXYCERT,env=CURL_CA_BUNDLE --mount=type=secret,id=PROXYCERT,env=NODE_EXTRA_CA_CERTS --mount=type=secret,id=PROXYCERT,env=CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE --mount=type=secret,id=PROXYCERT,env=NIX_SSL_CERT_FILE|" | \
 		docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
-	FROM docker.io/library/alpine:3.19
+FROM docker.io/library/alpine:3.19
 EOS
 	docker run --name=container img
 '
@@ -549,7 +549,7 @@ docker exec build /bin/sh -euxc '
 	docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
 	cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs --mount=type=secret,id=PROXYCERT,env=PIP_CERT --mount=type=secret,id=PROXYCERT,env=CURL_CA_BUNDLE --mount=type=secret,id=PROXYCERT,env=NODE_EXTRA_CA_CERTS --mount=type=secret,id=PROXYCERT,env=CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE --mount=type=secret,id=PROXYCERT,env=NIX_SSL_CERT_FILE|" | \
 		docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
-	FROM docker.io/library/alpine:3.19
+FROM docker.io/library/alpine:3.19
 EOS
 	docker run --name=container img
 '


### PR DESCRIPTION
A notable consequence of this error is that the `#syntax` pragma at the start of the dockerfile was getting ignored.