### PR TITLE
Fix Dockerfile syntax usage

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -119,7 +119,7 @@ var debuildContainerTpl = template.Must(
 		// NOTE: For syntax docs, see https://docs.docker.com/build/dockerfile/release-notes/
 		// TODO: Find a base image that has build-essentials installed, that would improve startup time significantly, and it would pin the build tools we're using.
 		textwrap.Dedent(`
-				#syntax=docker/dockerfile:1.4
+				#syntax=docker/dockerfile:1.10
 				FROM docker.io/library/debian:trixie-20250203-slim
 				RUN <<'EOF'
 				 set -eux
@@ -161,7 +161,7 @@ var alpineContainerTpl = template.Must(
 	}).Parse(
 		// NOTE: For syntax docs, see https://docs.docker.com/build/dockerfile/release-notes/
 		textwrap.Dedent(`
-				#syntax=docker/dockerfile:1.4
+				#syntax=docker/dockerfile:1.10
 				FROM docker.io/library/alpine:3.19
 				RUN <<'EOF'
 				 set -eux
@@ -304,7 +304,7 @@ var proxyBuildTpl = template.Must(
 					docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
 					cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs{{range .CertEnvVars}} --mount=type=secret,id=PROXYCERT,env={{.}}{{end}}|" | \
 						docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
-					{{.Dockerfile}}
+				{{.Dockerfile}}
 				EOS
 					docker run --name=container img
 				'

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -39,7 +39,7 @@ func TestMakeDockerfile(t *testing.T) {
 			opts: RemoteOptions{
 				UseTimewarp: false,
 			},
-			expected: `#syntax=docker/dockerfile:1.4
+			expected: `#syntax=docker/dockerfile:1.10
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -77,7 +77,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 				UseTimewarp:        true,
 				UtilPrebuildBucket: "my-bucket",
 			},
-			expected: `#syntax=docker/dockerfile:1.4
+			expected: `#syntax=docker/dockerfile:1.10
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -120,7 +120,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 				UtilPrebuildBucket: "my-bucket",
 				UtilPrebuildDir:    "v0.0.0-202501010000-feeddeadbeef00",
 			},
-			expected: `#syntax=docker/dockerfile:1.4
+			expected: `#syntax=docker/dockerfile:1.10
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -165,7 +165,7 @@ python3 setup.py sdist`,
 			opts: RemoteOptions{
 				UseTimewarp: false,
 			},
-			expected: `#syntax=docker/dockerfile:1.4
+			expected: `#syntax=docker/dockerfile:1.10
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -208,7 +208,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 			opts: RemoteOptions{
 				UseTimewarp: false,
 			},
-			expected: `#syntax=docker/dockerfile:1.4
+			expected: `#syntax=docker/dockerfile:1.10
 FROM docker.io/library/debian:trixie-20250203-slim
 RUN <<'EOF'
  set -eux
@@ -465,7 +465,7 @@ docker exec build /bin/sh -euxc '
 	docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
 	cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs --mount=type=secret,id=PROXYCERT,env=PIP_CERT --mount=type=secret,id=PROXYCERT,env=CURL_CA_BUNDLE --mount=type=secret,id=PROXYCERT,env=NODE_EXTRA_CA_CERTS --mount=type=secret,id=PROXYCERT,env=CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE --mount=type=secret,id=PROXYCERT,env=NIX_SSL_CERT_FILE|" | \
 		docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
-	FROM docker.io/library/alpine:3.19
+FROM docker.io/library/alpine:3.19
 EOS
 	docker run --name=container img
 '
@@ -549,7 +549,7 @@ docker exec build /bin/sh -euxc '
 	docker buildx create --name proxied --bootstrap --driver docker-container --driver-opt network=container:build
 	cat <<EOS | sed "s|^RUN|RUN --mount=type=bind,from=certs,dst=/etc/ssl/certs --mount=type=secret,id=PROXYCERT,env=PIP_CERT --mount=type=secret,id=PROXYCERT,env=CURL_CA_BUNDLE --mount=type=secret,id=PROXYCERT,env=NODE_EXTRA_CA_CERTS --mount=type=secret,id=PROXYCERT,env=CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE --mount=type=secret,id=PROXYCERT,env=NIX_SSL_CERT_FILE|" | \
 		docker buildx build --builder proxied --build-context certs=/etc/ssl/certs --secret id=PROXYCERT --load --tag=img -
-	FROM docker.io/library/alpine:3.19
+FROM docker.io/library/alpine:3.19
 EOS
 	docker run --name=container img
 '


### PR DESCRIPTION
The proxy logic prepended a tab character which resulted in docker ignoring the
syntax pragma.

With this fixed, we were actually using features from beyond syntax version 1.4
in the existing proxy implementation so we need to update to 1.10 where support
for secret env vars was added.