### PR TITLE
Add httpxtest.NewURLValidator

### DIFF
--- a/internal/api/apiservice/rebuild_test.go
+++ b/internal/api/apiservice/rebuild_test.go
@@ -298,12 +298,8 @@ RLpmHHG1JOVdOA==
 			ctx := context.Background()
 			var d RebuildPackageDeps
 			d.HTTPClient = &httpxtest.MockClient{
-				Calls: tc.calls,
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Errorf("URL mismatch: diff\n%v", diff)
-					}
-				},
+				Calls:        tc.calls,
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			d.Signer = must(dsse.NewEnvelopeSigner(&FakeSigner{}))
 			fs := memfs.New()

--- a/internal/httpx/httpxtest/mockclient.go
+++ b/internal/httpx/httpxtest/mockclient.go
@@ -5,6 +5,9 @@ package httpxtest
 
 import (
 	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type Call struct {
@@ -46,4 +49,13 @@ func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
 
 func (m *MockClient) CallCount() int {
 	return m.callCount
+}
+
+func NewURLValidator(t *testing.T) func(string, string) {
+	return func(expected, actual string) {
+		t.Helper()
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Fatalf("URL mismatch (-want +got):\n%s", diff)
+		}
+	}
 }

--- a/internal/proxy/dockerfs/dockerfs_test.go
+++ b/internal/proxy/dockerfs/dockerfs_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/internal/httpx/httpxtest"
 )
 
@@ -61,11 +60,7 @@ func TestOpen(t *testing.T) {
 		Calls: []httpxtest.Call{
 			{Method: "GET", URL: "/containers/abc/archive?path=/etc/release", Response: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(osTarBytes))}},
 		},
-		URLValidator: func(expected, actual string) {
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-			}
-		},
+		URLValidator: httpxtest.NewURLValidator(t),
 	}
 	f := Filesystem{Client: &c, Container: "abc"}
 	got := must(f.Open("/etc/release"))
@@ -90,11 +85,7 @@ func TestStat(t *testing.T) {
 		Calls: []httpxtest.Call{
 			{Method: "HEAD", URL: "/containers/abc/archive?path=/etc/release", Response: &http.Response{StatusCode: http.StatusOK, Header: withHeader(statHeader, makeStat(t, want))}},
 		},
-		URLValidator: func(expected, actual string) {
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-			}
-		},
+		URLValidator: httpxtest.NewURLValidator(t),
 	}
 	f := Filesystem{Client: &c, Container: "abc"}
 	got := must(f.Stat("/etc/release"))
@@ -114,11 +105,7 @@ func TestOpenAndResolve(t *testing.T) {
 			{Method: "HEAD", URL: "/containers/abc/archive?path=/os-release", Response: &http.Response{StatusCode: http.StatusOK, Header: withHeader(statHeader, makeStat(t, wantStat))}},
 			{Method: "GET", URL: "/containers/abc/archive?path=/os-release", Response: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(osTarBytes))}},
 		},
-		URLValidator: func(expected, actual string) {
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-			}
-		},
+		URLValidator: httpxtest.NewURLValidator(t),
 	}
 	f := Filesystem{Client: &c, Container: "abc"}
 	got := must(f.OpenAndResolve("/etc/release"))
@@ -148,11 +135,7 @@ func TestResolve(t *testing.T) {
 			{Method: "GET", URL: "/containers/abc/archive?path=/etc/release", Response: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(symTarBytes))}},
 			{Method: "GET", URL: "/containers/abc/archive?path=/os-release", Response: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(osTarBytes))}},
 		},
-		URLValidator: func(expected, actual string) {
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-			}
-		},
+		URLValidator: httpxtest.NewURLValidator(t),
 	}
 	f := Filesystem{Client: &c, Container: "abc"}
 	got := must(f.Open("/etc/release"))
@@ -184,11 +167,7 @@ func TestWriteFile(t *testing.T) {
 			{Method: "GET", URL: "/containers/abc/archive?path=/etc/release", Response: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(osTarBytes))}},
 			{Method: "PUT", URL: "/containers/abc/archive?path=/etc", Response: &http.Response{StatusCode: http.StatusOK}},
 		},
-		URLValidator: func(expected, actual string) {
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-			}
-		},
+		URLValidator: httpxtest.NewURLValidator(t),
 	}
 	f := Filesystem{Client: &c, Container: "abc"}
 	got := must(f.Open("/etc/release"))

--- a/internal/timewarp/timewarp_test.go
+++ b/internal/timewarp/timewarp_test.go
@@ -60,11 +60,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 						},
 					},
 				},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				URLValidator: httpxtest.NewURLValidator(t),
 			},
 			want: &http.Response{
 				StatusCode: http.StatusOK,
@@ -147,11 +143,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 						},
 					},
 				},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				URLValidator: httpxtest.NewURLValidator(t),
 			},
 			want: &http.Response{
 				StatusCode: http.StatusOK,
@@ -230,11 +222,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 						},
 					},
 				},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				URLValidator: httpxtest.NewURLValidator(t),
 			},
 			want: &http.Response{
 				StatusCode: http.StatusOK,

--- a/internal/verifier/summary_test.go
+++ b/internal/verifier/summary_test.go
@@ -51,11 +51,7 @@ func TestSummarizeArtifacts(t *testing.T) {
 					},
 				},
 			},
-			URLValidator: func(expected, actual string) {
-				if diff := cmp.Diff(expected, actual); diff != "" {
-					t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-				}
-			},
+			URLValidator: httpxtest.NewURLValidator(t),
 		})
 		stabilizedHash := hashext.NewMultiHash(crypto.SHA256)
 		stabilizedZip := must(archivetest.ZipFile([]archive.ZipEntry{

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -236,11 +236,7 @@ func TestInferStrategy(t *testing.T) {
 						},
 					},
 				},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			mux := rebuild.RegistryMux{CratesIO: cratesio.HTTPRegistry{Client: &client}}
 			s, err := Rebuilder{}.InferStrategy(ctx, target, mux, &rcfg, nil)

--- a/pkg/registry/cratesio/cratesio_test.go
+++ b/pkg/registry/cratesio/cratesio_test.go
@@ -86,12 +86,8 @@ func TestHTTPRegistry_Crate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{tc.call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{tc.call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Crate(context.Background(), tc.pkg)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
@@ -167,12 +163,8 @@ func TestHTTPRegistry_Version(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{tc.call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{tc.call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Version(context.Background(), tc.pkg, tc.version)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
@@ -267,12 +259,8 @@ func TestHTTPRegistry_Artifact(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: tc.calls,
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        tc.calls,
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Artifact(context.Background(), tc.pkg, tc.version)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {

--- a/pkg/registry/debian/debian_test.go
+++ b/pkg/registry/debian/debian_test.go
@@ -138,12 +138,8 @@ func TestHTTPRegistry_Artifact(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{tc.call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{tc.call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Artifact(context.Background(), tc.component, tc.pkg, tc.artifact)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
@@ -285,12 +281,8 @@ RLpmHHG1JOVdOA==
 				},
 			}
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			DSCURI, actual, err := HTTPRegistry{Client: mockClient}.DSC(context.Background(), tc.component, tc.pkg, tc.version)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {

--- a/pkg/registry/npm/npm_test.go
+++ b/pkg/registry/npm/npm_test.go
@@ -101,12 +101,8 @@ func TestHTTPRegistry_Package(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{tc.call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{tc.call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Package(context.Background(), tc.pkg)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
@@ -208,12 +204,8 @@ func TestHTTPRegistry_Version(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{tc.call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{tc.call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Version(context.Background(), tc.pkg, tc.version)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
@@ -310,12 +302,8 @@ func TestHTTPRegistry_Artifact(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: tc.calls,
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        tc.calls,
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Artifact(context.Background(), tc.pkg, tc.version)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {

--- a/pkg/registry/pypi/pypi_test.go
+++ b/pkg/registry/pypi/pypi_test.go
@@ -86,12 +86,8 @@ func TestHTTPRegistry_Project(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{tc.call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{tc.call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Project(context.Background(), tc.pkg)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
@@ -181,12 +177,8 @@ func TestHTTPRegistry_Release(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: []httpxtest.Call{tc.call},
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        []httpxtest.Call{tc.call},
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Release(context.Background(), tc.pkg, tc.version)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
@@ -305,12 +297,8 @@ func TestHTTPRegistry_Artifact(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls: tc.calls,
-				URLValidator: func(expected, actual string) {
-					if diff := cmp.Diff(expected, actual); diff != "" {
-						t.Fatalf("URL mismatch (-want +got):\n%s", diff)
-					}
-				},
+				Calls:        tc.calls,
+				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Artifact(context.Background(), tc.pkg, tc.version, tc.filename)
 			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {


### PR DESCRIPTION
This abbreviates the setup necessary to use the httpxtest.MockClient while
still allowing for customization, when necessary.