### PR TITLE
feat: delete files containing git properties

### DIFF
--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -175,3 +175,15 @@ func splitPreservingQuotes(s string, sep rune) []string {
 	}
 	return result
 }
+
+var StableGitProperties = ZipArchiveStabilizer{
+	Name: "jar-git-properties",
+	Func: func(mr *MutableZipReader) {
+		for _, mf := range mr.File {
+			if strings.HasSuffix(mf.Name, "git.properties") || strings.HasSuffix(mf.Name, "git.json") {
+				mr.DeleteFile(mf.Name)
+			}
+		}
+
+	},
+}

--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -180,7 +180,17 @@ var StableGitProperties = ZipArchiveStabilizer{
 	Name: "jar-git-properties",
 	Func: func(mr *MutableZipReader) {
 		for _, mf := range mr.File {
+			// These files contain git properties set by git-commit-id-maven-plugin.
+			// They contain many unreproducible attributes as documented
+			// [here](https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/825).
+
+			// Only JSON and properties file formats are available as documented
+			// [here](https://github.com/git-commit-id/git-commit-id-maven-plugin/blob/95d616fc7e16018deff3f17e2d03a4b217e55294/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java#L454).
+			// By default, these file are created in ${project.build.outputDirectory} and are hence at the root of the jar.
+			// We assume that the file name is 'git' as this is the default value for the plugin.
+			// However, the plugin allows customizing the file name.
 			if strings.HasSuffix(mf.Name, "git.properties") || strings.HasSuffix(mf.Name, "git.json") {
+				// We remove these files to ensure reproducibility.
 				mr.DeleteFile(mf.Name)
 			}
 		}

--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -177,7 +177,6 @@ func splitPreservingQuotes(s string, sep rune) []string {
 	return result
 }
 
-var StableGitProperties = ZipArchiveStabilizer{
 var StableGitProperties = ZipEntryStabilizer{
 	Name: "jar-git-properties",
 	Func: func(zf *MutableZipFile) {

--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -5,7 +5,7 @@ package archive
 
 import (
 	"bytes"
-	"regexp"
+	"path"
 	"sort"
 	"strings"
 )
@@ -189,13 +189,11 @@ var StableGitProperties = ZipEntryStabilizer{
 		// By default, these file are created in ${project.build.outputDirectory} and are hence at the root of the jar.
 		// We assume that the file name is 'git' as this is the default value for the plugin.
 		// We don't handle the case where the file name is changed by the user.
-		gitJsonRegex := regexp.MustCompile(`\bgit\.json$`)
-		if gitJsonRegex.MatchString(zf.Name) {
+		if path.Base(zf.Name) == "git.json" {
 			zf.SetContent([]byte("{}"))
 		}
 
-		gitPropertiesRegex := regexp.MustCompile(`\bgit\.properties$`)
-		if gitPropertiesRegex.MatchString(zf.Name) {
+		if path.Base(zf.Name) == "git.properties" {
 			zf.SetContent([]byte{})
 		}
 	},

--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -5,6 +5,7 @@ package archive
 
 import (
 	"bytes"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -189,8 +190,8 @@ var StableGitProperties = ZipArchiveStabilizer{
 			// By default, these file are created in ${project.build.outputDirectory} and are hence at the root of the jar.
 			// We assume that the file name is 'git' as this is the default value for the plugin.
 			// However, the plugin allows customizing the file name.
-			if strings.HasSuffix(mf.Name, "git.properties") || strings.HasSuffix(mf.Name, "git.json") {
-				// We remove these files to ensure reproducibility.
+			gitRegex := regexp.MustCompile(`\bgit\.(json|properties)$`)
+			if gitRegex.MatchString(mf.Name) {
 				mr.DeleteFile(mf.Name)
 			}
 		}

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -389,6 +389,10 @@ func TestStableGitProperties(t *testing.T) {
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
 					[]byte("Built-By: root\r\n\r\n"),
 				},
+				{
+					&zip.FileHeader{Name: "git.properties"},
+					[]byte{},
+				},
 			},
 		},
 		{
@@ -413,6 +417,10 @@ func TestStableGitProperties(t *testing.T) {
 				{
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
 					[]byte("Built-By: root\r\n\r\n"),
+				},
+				{
+					&zip.FileHeader{Name: "git.json"},
+					[]byte("{}"),
 				},
 			},
 		},
@@ -466,6 +474,10 @@ func TestStableGitProperties(t *testing.T) {
 				{
 					&zip.FileHeader{Name: "classes/foo"},
 					[]byte("bar"),
+				},
+				{
+					&zip.FileHeader{Name: "classes/git.json"},
+					[]byte("{}"),
 				},
 			},
 		},

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -376,17 +376,17 @@ func TestStableGitProperties(t *testing.T) {
 			input: []*ZipEntry{
 				{
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
-					[]byte("Built-By: aman\r\n\r\n"),
+					[]byte("Built-By: root\r\n\r\n"),
 				},
 				{
 					&zip.FileHeader{Name: "git.properties"},
-					[]byte("git.build.user.email=mannu.poski10@gmail.com\r\ngit.build.user.name=Aman Sharma\r\n\r\n"),
+					[]byte("git.build.user.email=foo@bar.baz\r\ngit.build.user.name=foo bar\r\n\r\n"),
 				},
 			},
 			expected: []*ZipEntry{
 				{
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
-					[]byte("Built-By: aman\r\n\r\n"),
+					[]byte("Built-By: root\r\n\r\n"),
 				},
 			},
 		},
@@ -395,7 +395,7 @@ func TestStableGitProperties(t *testing.T) {
 			input: []*ZipEntry{
 				{
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
-					[]byte("Built-By: aman\r\n\r\n"),
+					[]byte("Built-By: root\r\n\r\n"),
 				},
 				{
 					&zip.FileHeader{Name: "git.json"},
@@ -410,7 +410,7 @@ func TestStableGitProperties(t *testing.T) {
 			expected: []*ZipEntry{
 				{
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
-					[]byte("Built-By: aman\r\n\r\n"),
+					[]byte("Built-By: root\r\n\r\n"),
 				},
 			},
 		},
@@ -419,7 +419,7 @@ func TestStableGitProperties(t *testing.T) {
 			input: []*ZipEntry{
 				{
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
-					[]byte("Built-By: aman\r\n\r\n"),
+					[]byte("Built-By: root\r\n\r\n"),
 				},
 				{
 					&zip.FileHeader{Name: "classes/foo"},
@@ -457,7 +457,7 @@ func TestStableGitProperties(t *testing.T) {
 			expected: []*ZipEntry{
 				{
 					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
-					[]byte("Built-By: aman\r\n\r\n"),
+					[]byte("Built-By: root\r\n\r\n"),
 				},
 				{
 					&zip.FileHeader{Name: "classes/foo"},

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -6,6 +6,7 @@ package archive
 import (
 	"archive/zip"
 	"bytes"
+	"github.com/google/oss-rebuild/internal/textwrap"
 	"io"
 	"testing"
 
@@ -399,12 +400,13 @@ func TestStableGitProperties(t *testing.T) {
 				},
 				{
 					&zip.FileHeader{Name: "git.json"},
-					[]byte("{\n" +
-						"	 \"git.branch\": \"master\",\n" +
-						"	 \"git.commit.id.abbrev\": \"e646d22\",\n" +
-						"    \"git.commit.id.describe\": \"e646d22\",\n" +
-						"    \"git.total.commit.count\": \"1\"" +
-						"\n}"),
+					[]byte(textwrap.Dedent(`
+						{
+							"git.branch": "master",
+							"git.commit.id.abbrev": "e646d22",
+							"git.commit.id.describe": "e646d22",
+							"git.total.commit.count": "1"
+						}`)),
 				},
 			},
 			expected: []*ZipEntry{
@@ -427,31 +429,33 @@ func TestStableGitProperties(t *testing.T) {
 				},
 				{
 					&zip.FileHeader{Name: "classes/git.json"},
-					[]byte("\n{\n" +
-						"    \"git.branch\": \"main\",\n" +
-						"    \"git.build.host\": \"ort\",\n" +
-						"    \"git.build.user.email\": \"jrivard@gmail.com\",\n" +
-						"    \"git.build.user.name\": \"Jason Rivard\",\n" +
-						"    \"git.build.version\": \"0.1.0\",\n" +
-						"    \"git.closest.tag.commit.count\": \"0\",\n" +
-						"    \"git.closest.tag.name\": \"v1_0_1\",\n" +
-						"    \"git.commit.author.time\": \"2022-01-06T10:16:03Z\",\n" +
-						"    \"git.commit.committer.time\": \"2022-01-06T10:16:03Z\",\n" +
-						"    \"git.commit.id\": \"b8b0e095af45ed8b3212b934ce46f2dcb54fdea6\",\n" +
-						"    \"git.commit.id.abbrev\": \"b8b0e09\",\n    \"git.commit.id.describe\": \"v1_0_1\",\n" +
-						"    \"git.commit.id.describe-short\": \"v1_0_1\",\n" +
-						"    \"git.commit.message.full\": \"0.1.0 release\",\n" +
-						"    \"git.commit.message.short\": \"0.1.0 release\",\n" +
-						"    \"git.commit.time\": \"2022-01-06T10:16:03Z\",\n" +
-						"    \"git.commit.user.email\": \"jrivard@gmail.com\",\n" +
-						"    \"git.commit.user.name\": \"Jason Rivard\",\n" +
-						"    \"git.dirty\": \"false\",\n" +
-						"    \"git.local.branch.ahead\": \"5\",\n" +
-						"    \"git.local.branch.behind\": \"0\",\n" +
-						"    \"git.remote.origin.url\": \"https://github.com/jrivard/chaixml\",\n" +
-						"    \"git.tags\": \"v1_0_1\",\n" +
-						"    \"git.total.commit.count\": \"8\"\n" +
-						"}"),
+					[]byte(textwrap.Dedent(`
+						{
+							"git.branch": "main",
+							"git.build.host": "ort",
+							"git.build.user.email": xmlchai@maven",
+							"git.build.user.name": "XMLChai Maven",
+							"git.build.version": "0.1.0",
+							"git.closest.tag.commit.count": "0",
+							"git.closest.tag.name": "v1_0_1",
+							"git.commit.author.time": "2022-01-06T10:16:03Z",
+							"git.commit.committer.time": "2022-01-06T10:16:03Z",
+							"git.commit.id": "b8b0e095af45ed8b3212b934ce46f2dcb54fdea6",
+							"git.commit.id.abbrev": "b8b0e09",
+							"git.commit.id.describe": "v1_0_1",
+							"git.commit.id.describe-short": "v1_0_1",
+							"git.commit.message.full": "0.1.0 release",
+							"git.commit.message.short": "0.1.0 release",
+							"git.commit.time": "2022-01-06T10:16:03Z",
+							"git.commit.user.email": "xmlchai@maven",
+							"git.commit.user.name": "XMLChai Maven",
+							"git.dirty": "false",
+							"git.local.branch.ahead": "5",
+							"git.local.branch.behind": "0",
+							"git.remote.origin.url": "https://github.com/jrivard/chaixml",
+							"git.tags": "v1_0_1",
+							"git.total.commit.count": "8"
+						}`)),
 				},
 			},
 			expected: []*ZipEntry{

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -6,10 +6,10 @@ package archive
 import (
 	"archive/zip"
 	"bytes"
-	"github.com/google/go-cmp/cmp"
 	"io"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/internal/textwrap"
 )
 

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -6,6 +6,7 @@ package archive
 import (
 	"archive/zip"
 	"bytes"
+	"github.com/google/go-cmp/cmp"
 	"io"
 	"testing"
 
@@ -347,7 +348,7 @@ func TestStableOrderOfAttributeValues(t *testing.T) {
 			var output bytes.Buffer
 			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
 			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
-				Stabilizers: []any{StableJAROrderOfAttributeValues},
+				Stabilizers: []Stabilizer{StableJAROrderOfAttributeValues},
 			})
 			if err != nil {
 				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
@@ -497,7 +498,7 @@ func TestStableGitProperties(t *testing.T) {
 			var output bytes.Buffer
 			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
 			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
-				Stabilizers: []any{StableGitProperties},
+				Stabilizers: []Stabilizer{StableGitProperties},
 			})
 			if err != nil {
 				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -6,11 +6,10 @@ package archive
 import (
 	"archive/zip"
 	"bytes"
-	"github.com/google/oss-rebuild/internal/textwrap"
 	"io"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/textwrap"
 )
 
 func TestStableJARBuildMetadata(t *testing.T) {
@@ -348,7 +347,7 @@ func TestStableOrderOfAttributeValues(t *testing.T) {
 			var output bytes.Buffer
 			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
 			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
-				Stabilizers: []Stabilizer{StableJAROrderOfAttributeValues},
+				Stabilizers: []any{StableJAROrderOfAttributeValues},
 			})
 			if err != nil {
 				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -113,15 +113,6 @@ func (mr MutableZipReader) WriteTo(zw *zip.Writer) error {
 	return nil
 }
 
-func (mr *MutableZipReader) DeleteFile(name string) {
-	for i, zipEntry := range mr.File {
-		if zipEntry.Name == name {
-			mr.File = append(mr.File[:i], mr.File[i+1:]...)
-			break
-		}
-	}
-}
-
 type ZipArchiveStabilizer struct {
 	Name string
 	Func func(*MutableZipReader)

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -113,6 +113,15 @@ func (mr MutableZipReader) WriteTo(zw *zip.Writer) error {
 	return nil
 }
 
+func (mr *MutableZipReader) DeleteFile(name string) {
+	for i, zipEntry := range mr.File {
+		if zipEntry.Name == name {
+			mr.File = append(mr.File[:i], mr.File[i+1:]...)
+			break
+		}
+	}
+}
+
 type ZipArchiveStabilizer struct {
 	Name string
 	Func func(*MutableZipReader)


### PR DESCRIPTION
Reference: https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/825

The files `git.json` and `git. properties` are generated by https://github.com/git-commit-id/git-commit-id-maven-plugin. We delete these files in the jar file to stabilize. We assume default configuration that the files are either called `git.json` or `git.properties`.