### PR TITLE
Print the target at the start of gcb logs

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -377,6 +377,7 @@ func TestMakeBuild(t *testing.T) {
 						Name: "gcr.io/cloud-builders/docker",
 						Script: `#!/usr/bin/env bash
 set -eux
+echo 'Starting rebuild for {Ecosystem:npm Package:pkg Version:version Artifact:pkg-version.tgz}'
 cat <<'EOS' | docker buildx build --tag=img -
 FROM docker.io/library/alpine:3.19
 EOS
@@ -423,6 +424,7 @@ chmod +x gsutil_writeonly
 						Name: "gcr.io/cloud-builders/docker",
 						Script: `#!/usr/bin/env bash
 set -eux
+echo 'Starting rebuild for {Ecosystem:npm Package:pkg Version:version Artifact:pkg-version.tgz}'
 touch /workspace/tetragon.jsonl
 mkdir /workspace/tetragon/
 echo '{"apiVersion":"cilium.io/v1alpha1","kind":"TracingPolicy","metadata":{"name":"process-and-memory"},"spec":{"kprobes":[{"args":[{"index":0,"type":"file"},{"index":1,"type":"int"}],"call":"security_file_permission","return":true,"returnArg":{"index":0,"type":"int"},"returnArgAction":"Post","syscall":false},{"args":[{"index":0,"type":"file"},{"index":1,"type":"uint64"},{"index":2,"type":"uint32"}],"call":"security_mmap_file","return":true,"returnArg":{"index":0,"type":"int"},"returnArgAction":"Post","syscall":false},{"args":[{"index":0,"type":"path"}],"call":"security_path_truncate","return":true,"returnArg":{"index":0,"type":"int"},"returnArgAction":"Post","syscall":false}]}}' > "/workspace/tetragon/policy_0.json"
@@ -478,6 +480,7 @@ chmod +x gsutil_writeonly
 						Name: "gcr.io/cloud-builders/docker",
 						Script: `#!/usr/bin/env bash
 set -eux
+echo 'Starting rebuild for {Ecosystem:npm Package:pkg Version:version Artifact:pkg-version.tgz}'
 apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/builder-remote@test-project.iam.gserviceaccount.com/token | jq .access_token > /tmp/token
 (printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 cat <<'EOS' | docker buildx build --secret id=auth_header,src=/tmp/auth_header --tag=img -
@@ -527,6 +530,7 @@ chmod +x gsutil_writeonly
 					{
 						Name: "gcr.io/cloud-builders/docker",
 						Script: `set -eux
+echo 'Starting rebuild for {Ecosystem:npm Package:pkg Version:version Artifact:pkg-version.tgz}'
 curl -O https://test-bootstrap.storage.googleapis.com/proxy
 chmod +x proxy
 docker network create proxynet
@@ -611,6 +615,7 @@ chmod +x gsutil_writeonly
 					{
 						Name: "gcr.io/cloud-builders/docker",
 						Script: `set -eux
+echo 'Starting rebuild for {Ecosystem:npm Package:pkg Version:version Artifact:pkg-version.tgz}'
 curl -O https://test-bootstrap.storage.googleapis.com/v0.0.0-202501010000-feeddeadbeef00/proxy
 chmod +x proxy
 docker network create proxynet
@@ -696,6 +701,7 @@ chmod +x gsutil_writeonly
 					{
 						Name: "gcr.io/cloud-builders/docker",
 						Script: `set -eux
+echo 'Starting rebuild for {Ecosystem:npm Package:pkg Version:version Artifact:pkg-version.tgz}'
 apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/builder-remote@test-project.iam.gserviceaccount.com/token | jq .access_token > /tmp/token
 (printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 curl -O -H @/tmp/auth_header https://test-bootstrap.storage.googleapis.com/proxy


### PR DESCRIPTION
This isn't strictly necessary, but it's helpful when clicking through
active GCB executions in the UI to find what you're looking for.