### PR TITLE
Change CachedClient to store non-200 responses

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -42,14 +42,14 @@ import (
 )
 
 func doDebianRebuild(ctx context.Context, t rebuild.Target, id string, mux rebuild.RegistryMux, s rebuild.Strategy, opts rebuild.RemoteOptions) (upstreamURL string, err error) {
-	component, name, err := debianrb.ParseComponent(t.Package)
+	_, name, err := debianrb.ParseComponent(t.Package)
 	if err != nil {
 		return "", err
 	}
 	if err := debianrb.RebuildRemote(ctx, rebuild.Input{Target: t, Strategy: s}, id, opts); err != nil {
 		return "", errors.Wrap(err, "rebuild failed")
 	}
-	return debianreg.PoolURL(component, name, t.Artifact), nil
+	return mux.Debian.ArtifactURL(ctx, name, t.Artifact)
 }
 
 func doNPMRebuild(ctx context.Context, t rebuild.Target, id string, mux rebuild.RegistryMux, s rebuild.Strategy, opts rebuild.RemoteOptions) (upstreamURL string, err error) {

--- a/internal/api/apiservice/rebuild_test.go
+++ b/internal/api/apiservice/rebuild_test.go
@@ -204,7 +204,14 @@ func TestRebuildPackage(t *testing.T) {
 			target: rebuild.Target{Ecosystem: rebuild.Debian, Package: "main/xz-utils", Version: "5.2.4-1+b1", Artifact: "xz-utils_5.2.4-1+b1_amd64.deb"},
 			calls: []httpxtest.Call{
 				{
-					URL: "https://deb.debian.org/debian/pool/main/x/xz-utils/xz-utils_5.2.4-1+b1_amd64.deb",
+					URL: "https://snapshot.debian.org/mr/package/xz-utils/5.2.4-1/binfiles/xz-utils/5.2.4-1+b1?fileinfo=1",
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewReader([]byte(`{"fileinfo":{"deadbeef":[{"name":"xz-utils_5.2.4-1+b1_amd64.deb"}]},"result":[{"architecture":"amd64","hash":"deadbeef"}]}`))),
+					},
+				},
+				{
+					URL: "https://snapshot.debian.org/file/deadbeef",
 					Response: &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(bytes.NewReader([]byte("deb_contents"))),
@@ -262,7 +269,14 @@ RLpmHHG1JOVdOA==
 			target: rebuild.Target{Ecosystem: rebuild.Debian, Package: "main/xz-utils", Version: "5.2.4", Artifact: "xz-utils_5.2.4_amd64.deb"},
 			calls: []httpxtest.Call{
 				{
-					URL: "https://deb.debian.org/debian/pool/main/x/xz-utils/xz-utils_5.2.4_amd64.deb",
+					URL: "https://snapshot.debian.org/mr/package/xz-utils/5.2.4/binfiles/xz-utils/5.2.4?fileinfo=1",
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewReader([]byte(`{"fileinfo":{"deadbeef":[{"name":"xz-utils_5.2.4_amd64.deb"}]},"result":[{"architecture":"amd64","hash":"deadbeef"}]}`))),
+					},
+				},
+				{
+					URL: "https://snapshot.debian.org/file/deadbeef",
 					Response: &http.Response{
 						StatusCode: 200,
 						Body:       io.NopCloser(bytes.NewReader([]byte("deb_contents"))),

--- a/internal/httpx/http.go
+++ b/internal/httpx/http.go
@@ -7,7 +7,6 @@ package httpx
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"net/http"
 	"time"
 
@@ -55,9 +54,6 @@ func (cc *CachedClient) Do(req *http.Request) (*http.Response, error) {
 		resp, err := cc.BasicClient.Do(req)
 		if err != nil {
 			return nil, err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, errors.New(resp.Status)
 		}
 		defer resp.Body.Close()
 		foo := new(bytes.Buffer)

--- a/pkg/registry/debian/debian.go
+++ b/pkg/registry/debian/debian.go
@@ -6,6 +6,7 @@ package debian
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 var (
 	registryURL           = urlx.MustParse("https://deb.debian.org/debian/pool/")
 	buildinfoURL          = urlx.MustParse("https://buildinfos.debian.net/buildinfo-pool/")
+	snapshotURL           = urlx.MustParse("https://snapshot.debian.org/")
 	debRegex              = regexp.MustCompile(`^(?P<name>[^_]+)_(?P<version>[^_]+)_(?P<arch>[^_]+)\.deb$`)
 	nativeVersionRegex    = regexp.MustCompile(`^((?P<epoch>[0-9]+):)?(?P<upstream_version>[0-9][A-Za-z0-9\.\+\~]*)$`)
 	nonNativeVersionRegex = regexp.MustCompile(`^((?P<epoch>[0-9]+):)?(?P<upstream_version>[0-9][A-Za-z0-9\.\+\~\-]*)\-(?P<debian_revision>[A-Za-z0-9\+\.\~]+)$`) // upstream_version is only allowed to contain "-" if debian_revision is non-empty
@@ -145,6 +147,7 @@ type DSC struct {
 
 // Registry is a debian package registry.
 type Registry interface {
+	ArtifactURL(context.Context, string, string) (string, error)
 	Artifact(context.Context, string, string, string) (io.ReadCloser, error)
 	DSC(context.Context, string, string, string) (string, *DSC, error)
 }
@@ -266,9 +269,90 @@ func (r HTTPRegistry) DSC(ctx context.Context, component, name, version string) 
 	return DSCURI, d, err
 }
 
+// fileInfo is the response from the binfiles endpoint on the snapshot service.
+type fileInfo struct {
+	// FileInfo is a map from file hash to extra info, such as name, first time seen, file size, and which archive it was seen as part of.
+	// We are only interested in Name at the moment.
+	FileInfo map[string][]struct {
+		Name string
+	}
+	// Result maps the architecture to a file hash, allowing you to look up the FileInfo or fetch the file itself.
+	Result []struct {
+		Architecture string
+		Hash         string
+	}
+}
+
+func (r HTTPRegistry) ArtifactURL(ctx context.Context, name, artifact string) (string, error) {
+	// To determine the ArtifactURL, there are a few steps. The following is an example of fetching an artifact from the acl package at version 2.3.2-1+b1
+	// First you might need to fetch a list of all versions:
+	// https://snapshot.debian.org/mr/binary/acl/
+	// However in our case, we already know the version.
+	// Next, you need to determine the hash of the correct artifact (architecture and artifact name), which can be found using the /binfiles/ endpoint:
+	// https://snapshot.debian.org/mr/package/acl/2.3.2-2/binfiles/libacl1/2.3.2-2+b1?fileinfo=1
+	// Finally you have the URL of the artifact directly:
+	// https://snapshot.debian.org/file/53f2b0612c8ed8a60970f9a206ae65eb84681f6e
+	a, err := ParseDebianArtifact(artifact)
+	if err != nil {
+		return "", err
+	}
+	var response fileInfo
+	fileinfoURL := urlx.Copy(snapshotURL)
+	{
+		fileinfoURL.Path = path.Join(fileinfoURL.Path, "mr/package", name, a.Version.BinaryIndependentString(), "binfiles", a.Name, a.Version.String())
+		query := fileinfoURL.Query()
+		query.Add("fileinfo", "1")
+		fileinfoURL.RawQuery = query.Encode()
+	}
+	{
+		r, err := r.get(ctx, fileinfoURL.String())
+		if err != nil {
+			return "", err
+		}
+		defer r.Close()
+		if err = json.NewDecoder(r).Decode(&response); err != nil {
+			return "", err
+		}
+	}
+	var hash string
+	for _, f := range response.Result {
+		if f.Architecture == a.Arch {
+			hash = f.Hash
+			break
+		}
+	}
+	if hash == "" {
+		return "", errors.New("no matching architecture found")
+	}
+	// Verify we found the correct artifact
+	{
+		verified := false
+		found, ok := response.FileInfo[hash]
+		if !ok {
+			return "", errors.Errorf("no fileinfo at %s, for the hash %s", fileinfoURL, hash)
+		}
+		for i := range found {
+			if found[i].Name == artifact {
+				verified = true
+				break
+			}
+		}
+		if !verified {
+			return "", errors.Errorf("artifact name %s not found in fileinfo:%+v", artifact, response.FileInfo)
+		}
+	}
+	artifactURL := urlx.Copy(snapshotURL)
+	artifactURL.Path += path.Join("file", hash)
+	return artifactURL.String(), nil
+}
+
 // Artifact returns the package artifact for the given package version.
 func (r HTTPRegistry) Artifact(ctx context.Context, component, name, artifact string) (io.ReadCloser, error) {
-	return r.get(ctx, PoolURL(component, name, artifact))
+	url, err := r.ArtifactURL(ctx, name, artifact)
+	if err != nil {
+		return nil, err
+	}
+	return r.get(ctx, url)
 }
 
 var _ Registry = &HTTPRegistry{}

--- a/pkg/registry/debian/debian_test.go
+++ b/pkg/registry/debian/debian_test.go
@@ -120,7 +120,7 @@ func TestHTTPRegistry_Artifact(t *testing.T) {
 		component   string
 		pkg         string
 		artifact    string
-		call        httpxtest.Call
+		calls       []httpxtest.Call
 		expected    string
 		expectedErr error
 	}{
@@ -129,11 +129,20 @@ func TestHTTPRegistry_Artifact(t *testing.T) {
 			component: "main",
 			pkg:       "xz-utils",
 			artifact:  "xz-utils_5.4.1-0.2_amd64.deb",
-			call: httpxtest.Call{
-				URL: "https://deb.debian.org/debian/pool/main/x/xz-utils/xz-utils_5.4.1-0.2_amd64.deb",
-				Response: &http.Response{
-					StatusCode: 200,
-					Body:       io.NopCloser(bytes.NewReader([]byte("artifact_contents"))),
+			calls: []httpxtest.Call{
+				{
+					URL: "https://snapshot.debian.org/mr/package/xz-utils/5.4.1-0.2/binfiles/xz-utils/5.4.1-0.2?fileinfo=1",
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewReader([]byte(`{"fileinfo":{"deadbeef":[{"name":"xz-utils_5.4.1-0.2_amd64.deb"}]}","result":[{"architecture":"amd64","hash":"deadbeef"}]`))),
+					},
+				},
+				{
+					URL: "https://snapshot.debian.org/file/deadbeef",
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewReader([]byte("artifact_contents"))),
+					},
 				},
 			},
 			expected:    "artifact_contents",
@@ -143,7 +152,7 @@ func TestHTTPRegistry_Artifact(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &httpxtest.MockClient{
-				Calls:        []httpxtest.Call{tc.call},
+				Calls:        tc.calls,
 				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			actual, err := HTTPRegistry{Client: mockClient}.Artifact(context.Background(), tc.component, tc.pkg, tc.artifact)


### PR DESCRIPTION
I don't really have a strong preference on whether these responses are actually stored. The more important thing is to avoid throwing away the non-200 responses (as is done currently by converting them to error strings). By doing so, the current implementation prevents any caller from parsing these non-200 response messages.

See this snippet from the standard library:

```
// An error is returned if caused by client policy (such as
// CheckRedirect), or failure to speak HTTP (such as a network
// connectivity problem). A non-2xx status code doesn't cause an
// error.
```