### PR TITLE
feat: add stabilizer for pom.properties

### DIFF
--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -197,3 +197,19 @@ var StableGitProperties = ZipEntryStabilizer{
 		}
 	},
 }
+
+var StablePomProperties = ZipEntryStabilizer{
+	Name: "jar-pom-properties",
+	Func: func(zf *MutableZipFile) {
+		// pom.properties files contain attributes set by Maven Archiver.
+		// Source: https://maven.apache.org/shared/maven-archiver/#pom-properties-content
+		// They contain two unreproducible features:
+		// 1) The timestamp of generation is set to the time of build
+		// 2) The order of attributes "groupId", "artifactId", and "version" is not stable.
+		// It is created under META-INF/maven/${groupId}/${artifactId}/pom.properties so we delete that specifically.
+		// And not any pom.properties file in the jar (for example, ones under src/main/resources).
+		if strings.Contains(zf.Name, "META-INF/") && path.Base(zf.Name) == "pom.properties" {
+			zf.SetContent([]byte{})
+		}
+	},
+}

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -528,3 +528,80 @@ func TestStableGitProperties(t *testing.T) {
 		})
 	}
 }
+
+func TestStablePomProperties(t *testing.T) {
+	testCases := []struct {
+		test     string
+		input    []*ZipEntry
+		expected []*ZipEntry
+	}{
+		{
+			test: "delete_correct_pom_properties",
+			input: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/maven/foo.bar/baz/pom.properties"},
+					[]byte("#Fri Oct 18 03:03:44 UTC 2024\r\ngroupId=foo.bar\r\nartifactId=baz\r\nversion=1.0.0\r\npackaging=jar\r\n\r\n"),
+				},
+				{
+					&zip.FileHeader{Name: "pom.properties"},
+					[]byte("debug=true"),
+				},
+			},
+			expected: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/maven/foo.bar/baz/pom.properties"},
+					[]byte{},
+				},
+				{
+					&zip.FileHeader{Name: "pom.properties"},
+					[]byte("debug=true"),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			// Create input zip
+			var input bytes.Buffer
+			{
+				zw := zip.NewWriter(&input)
+				for _, entry := range tc.input {
+					orDie(entry.WriteTo(zw))
+				}
+				orDie(zw.Close())
+			}
+
+			// Process with stabilizer
+			var output bytes.Buffer
+			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
+			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
+				Stabilizers: []Stabilizer{StablePomProperties},
+			})
+			if err != nil {
+				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
+			}
+
+			// Check output
+			var got []ZipEntry
+			{
+				zr := must(zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len())))
+				for _, ent := range zr.File {
+					got = append(got, ZipEntry{&ent.FileHeader, must(io.ReadAll(must(ent.Open())))})
+				}
+			}
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("StabilizeZip(%v) got %v entries, want %v", tc.test, len(got), len(tc.expected))
+			}
+
+			for i := range got {
+				if !all(
+					got[i].FileHeader.Name == tc.expected[i].FileHeader.Name,
+					bytes.Equal(got[i].Body, tc.expected[i].Body),
+				) {
+					t.Errorf("Entry %d of %v:\r\ngot:  %+v\r\nwant: %+v", i, tc.test, got[i], tc.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Here comes the stabilizer for `pom.properties` which zeroes out this file. `pom.properties` file is an autogenerated file that is created at `META-INF/maven/${groupId}/${artifactId}/pom.properties` inside the JAR file. It is created using [Maven Archiver](https://maven.apache.org/shared/maven-archiver/index.html) which in turn is used by `maven-jar-plugin`.

In my analysis, I found two ways that this file could be unreproducible
1. The change is timestamp of this file
	```diff
	-#Wed Apr 20 20:27:41 CEST 2022\r
	+#Fri Oct 18 03:03:44 UTC 2024\r
	```
	Example Maven Project: ch.qos.logback.db:logback-parent-db:1.2.11.1 
2. Changes in order of the attributes
	```diff
	-version=4.1.20
	 groupId=io.dropwizard.metrics
	 artifactId=metrics-jcache
	+version=4.1.20
	```
	Observed in a version of `io.dropwizard.metrics:metrics-parent`.

Although the documentation says that [`pom.properites` file can be overridden (see `pomPropertiesFile`)](https://maven.apache.org/shared/maven-archiver/#archive), I am not sure whether it is the content or the path or both. If it is the path, we can use some similar logic as #413 .

Note that we do not remote any `pom.properties` file as they may be a resource of the JAR and are require for execution later. For example, `pom.properties` could be stored inside `src/main/resources`.
	