### PR TITLE
rundex.FetchRebuilds should return slice not map

### DIFF
--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -75,7 +75,7 @@ mkdir /out && cp /src/{{.OutputPath}} /out/
 `)[1:], // remove leading newline
 	))
 
-func buildFetchRebuildRequest(bench, run, prefix, pattern string, clean bool) (*rundex.FetchRebuildRequest, error) {
+func buildFetchRebuildRequest(bench, run, prefix, pattern string, clean, latestOnly bool) (*rundex.FetchRebuildRequest, error) {
 	var runs []string
 	if run != "" {
 		runs = strings.Split(run, ",")
@@ -87,6 +87,7 @@ func buildFetchRebuildRequest(bench, run, prefix, pattern string, clean bool) (*
 			Pattern: pattern,
 			Clean:   clean,
 		},
+		LatestOnly: latestOnly,
 	}
 	if len(req.Runs) == 0 {
 		return nil, errors.New("'run' must be supplied")
@@ -192,7 +193,7 @@ var getResults = &cobra.Command{
 	Short: "Analyze rebuild results",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		req, err := buildFetchRebuildRequest(*bench, *runFlag, *prefix, *pattern, *clean)
+		req, err := buildFetchRebuildRequest(*bench, *runFlag, *prefix, *pattern, *clean, true)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -411,7 +411,7 @@ func (e *explorer) makeRunNode(runid string) *tview.TreeNode {
 		children := node.GetChildren()
 		if len(children) == 0 {
 			log.Printf("Fetching rebuilds...")
-			rebuilds, err := e.firestore.FetchRebuilds(e.ctx, &rundex.FetchRebuildRequest{Runs: []string{runid}, Opts: e.firestoreOpts})
+			rebuilds, err := e.firestore.FetchRebuilds(e.ctx, &rundex.FetchRebuildRequest{Runs: []string{runid}, Opts: e.firestoreOpts, LatestOnly: true})
 			if err != nil {
 				log.Println(errors.Wrapf(err, "failed to get rebuilds for runid: %s", runid))
 				return

--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -187,10 +187,11 @@ type FetchRebuildOpts struct {
 
 // FetchRebuildRequest describes which Rebuild results you would like to fetch from firestore.
 type FetchRebuildRequest struct {
-	Bench     *benchmark.PackageSet
-	Executors []string
-	Runs      []string
-	Opts      FetchRebuildOpts
+	Bench      *benchmark.PackageSet
+	Executors  []string
+	Runs       []string
+	Opts       FetchRebuildOpts
+	LatestOnly bool
 }
 
 // FetchRunsOpts describes which Runs you would like to fetch from firestore.
@@ -201,7 +202,7 @@ type FetchRunsOpts struct {
 
 type Reader interface {
 	FetchRuns(context.Context, FetchRunsOpts) ([]Run, error)
-	FetchRebuilds(context.Context, *FetchRebuildRequest) (map[string]Rebuild, error)
+	FetchRebuilds(context.Context, *FetchRebuildRequest) ([]Rebuild, error)
 }
 
 type Writer interface {
@@ -229,7 +230,7 @@ func NewFirestore(ctx context.Context, project string) (*FirestoreClient, error)
 	return &FirestoreClient{Client: client}, nil
 }
 
-func filterRebuilds(all <-chan Rebuild, req *FetchRebuildRequest) map[string]Rebuild {
+func filterRebuilds(all <-chan Rebuild, req *FetchRebuildRequest) []Rebuild {
 	p := pipe.From(all)
 	if req.Bench != nil {
 		benchMap := make(map[string]benchmark.Package)
@@ -263,19 +264,31 @@ func filterRebuilds(all <-chan Rebuild, req *FetchRebuildRequest) map[string]Reb
 			out <- in
 		})
 	}
-	rebuilds := make(map[string]Rebuild)
-	for r := range p.Out() {
-		if existing, seen := rebuilds[r.ID()]; seen && existing.Created.After(r.Created) {
-			continue
+	p = p.Do(func(in Rebuild, out chan<- Rebuild) {
+		in.Message = strings.ReplaceAll(in.Message, "\n", "\\n")
+	})
+	var res []Rebuild
+	if req.LatestOnly {
+		rebuilds := make(map[string]Rebuild)
+		for r := range p.Out() {
+			if existing, seen := rebuilds[r.ID()]; seen && existing.Created.After(r.Created) {
+				continue
+			}
+			rebuilds[r.ID()] = r
 		}
-		r.Message = strings.ReplaceAll(r.Message, "\n", "\\n")
-		rebuilds[r.ID()] = r
+		for _, r := range rebuilds {
+			res = append(res, r)
+		}
+	} else {
+		for r := range p.Out() {
+			res = append(res, r)
+		}
 	}
-	return rebuilds
+	return res
 }
 
 // FetchRebuilds fetches the Rebuild objects out of firestore.
-func (f *FirestoreClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest) (map[string]Rebuild, error) {
+func (f *FirestoreClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest) ([]Rebuild, error) {
 	if len(req.Executors) != 0 && len(req.Runs) != 0 {
 		return nil, errors.New("only provide one of executors and runs")
 	}
@@ -377,7 +390,7 @@ func (f *LocalClient) FetchRuns(ctx context.Context, opts FetchRunsOpts) ([]Run,
 }
 
 // FetchRebuilds fetches the Rebuild objects out of firestore.
-func (f *LocalClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest) (map[string]Rebuild, error) {
+func (f *LocalClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest) ([]Rebuild, error) {
 	walkErr := make(chan error, 1)
 	all := make(chan Rebuild, 1)
 	go func() {
@@ -455,7 +468,7 @@ type VerdictGroup struct {
 }
 
 // GroupRebuilds will create VerdictGroup objects, grouping rebuilds by Message.
-func GroupRebuilds(rebuilds map[string]Rebuild) (byCount []*VerdictGroup) {
+func GroupRebuilds(rebuilds []Rebuild) (byCount []*VerdictGroup) {
 	msgs := make(map[string]*VerdictGroup)
 	for _, r := range rebuilds {
 		if _, seen := msgs[r.Message]; !seen {

--- a/tools/medic/main.go
+++ b/tools/medic/main.go
@@ -267,7 +267,7 @@ func main() {
 	}
 
 	// Query rebuilds
-	rebuilds := must(dex.FetchRebuilds(ctx, &rundex.FetchRebuildRequest{Runs: []string{run.ID}}))
+	rebuilds := must(dex.FetchRebuilds(ctx, &rundex.FetchRebuildRequest{Runs: []string{run.ID}, LatestOnly: true}))
 	c := make(chan rundex.Rebuild, 50)
 	go func() {
 		defer close(c)


### PR DESCRIPTION
This more closely matches rundex.FetchRuns. It also allows FetchRebuilds
to return multiple Rebuild objects for a given target.