### PR TITLE
Inferring source distribution and python version

### DIFF
--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -4,8 +4,10 @@
 package pypi
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -14,6 +16,7 @@ import (
 	re "regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5"
@@ -149,6 +152,9 @@ func extractPyProjectRequirements(ctx context.Context, tree *object.Tree) ([]str
 		// TODO: Some of these requirements are probably already in rbcfg.Requirements, should we skip
 		// them? To even know which package we're looking at would require parsing the dependency spec.
 		// https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers
+		if strings.Contains(r, "python_version") {
+			r = strings.Split(r, ";")[0]
+		}
 		reqs = append(reqs, strings.ReplaceAll(r, " ", ""))
 	}
 	log.Println("Added these reqs from pyproject.toml: " + strings.Join(reqs, ", "))
@@ -187,29 +193,67 @@ func FindPureWheel(artifacts []pypireg.Artifact) (*pypireg.Artifact, error) {
 	return nil, fs.ErrNotExist
 }
 
-func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
+func FindSourceDistribution(artifacts []pypireg.Artifact) (*pypireg.Artifact, error) {
+	for _, r := range artifacts {
+		if strings.HasSuffix(r.Filename, ".tar.gz") {
+			return &r, nil
+		}
+	}
+	return nil, fs.ErrNotExist
+}
+
+func inferRequirements(name, version string, zr interface{}) ([]string, error) {
 	// Name and version have "-" replaced with "_". See https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory
-	// TODO: Search for dist-info in the gzip using a regex. It sounds like many tools do varying amounts of normalization on the path name.
+	// TODO: Search for dist-info in the archive using a regex. It sounds like many tools do varying amounts of normalization on the path name.
 	wheelPath := fmt.Sprintf("%s-%s.dist-info/WHEEL", strings.ReplaceAll(name, "-", "_"), strings.ReplaceAll(version, "-", "_"))
-	wheel, err := getFile(wheelPath, zr)
+
+	var wheel []byte
+	var err error
+	var reqs []string
+
+	switch reader := zr.(type) {
+	case *zip.Reader:
+		wheel, err = getFile(wheelPath, reader)
+	case *tar.Reader:
+		return reqs, nil
+		// wheel, err = getFileFromTarGz(wheelPath, reader)
+	default:
+		return nil, errors.New("[INTERNAL] Unsupported archive reader type")
+	}
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream %s", wheelPath)
 	}
-	reqs, err := getGenerator(wheel)
+
+	reqs, err = getGenerator(wheel)
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to get upstream generator")
 	}
+
 	// Determine setuptools version.
 	if slices.ContainsFunc(reqs, func(s string) bool { return strings.HasPrefix(s, "setuptools==") }) {
 		// setuptools already set.
 		return reqs, nil
 	}
+
 	// TODO: Also find this with a regex.
 	metadataPath := fmt.Sprintf("%s-%s.dist-info/METADATA", strings.ReplaceAll(name, "-", "_"), strings.ReplaceAll(version, "-", "_"))
-	metadata, err := getFile(metadataPath, zr)
+
+	var metadata []byte
+
+	switch reader := zr.(type) {
+	case *zip.Reader:
+		metadata, err = getFile(metadataPath, reader)
+	case *tar.Reader:
+		metadata, err = getFileFromTarGz(metadataPath, reader)
+	default:
+		return nil, errors.New("[INTERNAL] Unsupported archive reader type")
+	}
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream dist-info/METADATA")
 	}
+
 	switch {
 	case !bytes.Contains(metadata, []byte("License-File")):
 		// The License-File value was introduced in later versions so this is the
@@ -224,7 +268,42 @@ func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
 	default:
 		reqs = append(reqs, "setuptools==67.7.2")
 	}
+
 	return reqs, nil
+}
+
+func inferPythonVersion(artifact pypireg.Artifact) string {
+	var pythonVersions []string
+
+	t := artifact.UploadTime
+	switch {
+	case t.After(time.Date(2023, 10, 2, 0, 0, 0, 0, time.UTC)):
+		pythonVersions = append(pythonVersions, "3.12.4") // Python 3.12 release
+	case t.After(time.Date(2022, 10, 24, 0, 0, 0, 0, time.UTC)):
+		pythonVersions = append(pythonVersions, "3.11.8") // Python 3.11 release
+	case t.After(time.Date(2021, 10, 4, 0, 0, 0, 0, time.UTC)):
+		pythonVersions = append(pythonVersions, "3.10.13") // Python 3.10 release
+	case t.After(time.Date(2020, 10, 5, 0, 0, 0, 0, time.UTC)):
+		pythonVersions = append(pythonVersions, "3.9.18") // Python 3.9 release
+	case t.After(time.Date(2019, 10, 14, 0, 0, 0, 0, time.UTC)):
+		pythonVersions = append(pythonVersions, "3.8.18") // Python 3.8 release
+	case t.After(time.Date(2018, 6, 27, 0, 0, 0, 0, time.UTC)):
+		pythonVersions = append(pythonVersions, "3.7.17") // Python 3.7 release
+	case t.After(time.Date(2014, 3, 16, 0, 0, 0, 0, time.UTC)):
+		pythonVersions = append(pythonVersions, "3.6.15") // Python 3.6 release
+
+	// Those are exluded until a proper way to support older python distributions
+	// case t.After(time.Date(2016, 12, 23, 0, 0, 0, 0, time.UTC)):
+	// 	pythonVersions = append(pythonVersions, "3.6.15") // Python 3.6 release
+	// case t.After(time.Date(2015, 9, 13, 0, 0, 0, 0, time.UTC)):
+	// 	pythonVersions = append(pythonVersions, "3.5.10") // Python 3.5 release
+	// case t.After(time.Date(2014, 3, 16, 0, 0, 0, 0, time.UTC)):
+	// 	pythonVersions = append(pythonVersions, "3.4.10") // Python 3.4 release
+	default:
+		pythonVersions = append(pythonVersions, "3.12.4") // Default to newest supported version
+	}
+
+	return pythonVersions[0]
 }
 
 func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, rcfg *rebuild.RepoConfig, hint rebuild.Strategy) (rebuild.Strategy, error) {
@@ -235,6 +314,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	}
 	// TODO: support different build types.
 	cfg := &PureWheelBuild{}
+	scfg := &SourceDistributionBuild{}
 	var ref, dir string
 	lh, ok := hint.(*rebuild.LocationHint)
 	if hint != nil && !ok {
@@ -254,10 +334,19 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 		}
 		dir = rcfg.Dir
 	}
+	zipFile := true
 	a, err := FindPureWheel(release.Artifacts)
 	if err != nil {
-		return cfg, errors.Wrap(err, "finding pure wheel")
+		zipFile = false
+		a, err = FindSourceDistribution(release.Artifacts)
+		if err != nil {
+			return scfg, errors.Wrap(err, "Failed to find pure wheel and source distribution")
+		}
 	}
+	pythonVersion := inferPythonVersion(*a)
+	// if err != nil {
+	// 	return cfg, errors.Wrap(err, "finding pure wheel")
+	// }
 	log.Printf("Downloading artifact: %s", a.URL)
 	r, err := mux.PyPI.Artifact(ctx, name, version, a.Filename)
 	if err != nil {
@@ -267,7 +356,19 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to read upstream artifact")
 	}
-	zr, err := zip.NewReader(bytes.NewReader(body), a.Size)
+	var zr interface{}
+	if zipFile {
+		zr, err = zip.NewReader(bytes.NewReader(body), a.Size)
+		if err != nil {
+			return nil, errors.Wrapf(err, "[INTERNAL] Failed to initialize upstream zip reader")
+		}
+	} else {
+		gzf, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, errors.Wrapf(err, "[INTERNAL] Failed to initialize gzip reader")
+		}
+		zr = tar.NewReader(gzf)
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to initialize upstream zip reader")
 	}
@@ -302,13 +403,26 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			}
 		}
 	}
-	return &PureWheelBuild{
+
+	if zipFile {
+		return &PureWheelBuild{
+			Location: rebuild.Location{
+				Repo: rcfg.URI,
+				Dir:  dir,
+				Ref:  ref,
+			},
+			Requirements:  reqs,
+			PythonVersion: pythonVersion,
+		}, nil
+	}
+	return &SourceDistributionBuild{
 		Location: rebuild.Location{
 			Repo: rcfg.URI,
 			Dir:  dir,
 			Ref:  ref,
 		},
-		Requirements: reqs,
+		Requirements:  reqs,
+		PythonVersion: pythonVersion,
 	}, nil
 }
 
@@ -363,5 +477,31 @@ func getFile(fname string, zr *zip.Reader) ([]byte, error) {
 			return io.ReadAll(fi)
 		}
 	}
+	return nil, fs.ErrNotExist
+}
+
+// getFileFromTarGz extracts a file with the given name from a tar.Reader.
+func getFileFromTarGz(fname string, tr *tar.Reader) ([]byte, error) {
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break // End of archive
+			}
+			return nil, err
+		}
+
+		// Check if the current file matches the requested file name
+		if header.Name == fname {
+			// Read the file contents
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, err
+			}
+			return data, nil
+		}
+	}
+
+	// File not found in the archive
 	return nil, fs.ErrNotExist
 }

--- a/pkg/rebuild/pypi/strategy.go
+++ b/pkg/rebuild/pypi/strategy.go
@@ -14,8 +14,16 @@ import (
 // PureWheelBuild aggregates the options controlling a wheel build.
 type PureWheelBuild struct {
 	rebuild.Location
-	Requirements []string  `json:"requirements"`
-	RegistryTime time.Time `json:"registry_time" yaml:"registry_time,omitempty"`
+	Requirements  []string  `json:"requirements"`
+	PythonVersion string    `json:"python_version"`
+	RegistryTime  time.Time `json:"registry_time" yaml:"registry_time,omitempty"`
+}
+
+type SourceDistributionBuild struct {
+	rebuild.Location
+	Requirements  []string  `json:"requirements"`
+	PythonVersion string    `json:"python_version"`
+	RegistryTime  time.Time `json:"registry_time" yaml:"registry_time,omitempty"`
 }
 
 var _ rebuild.Strategy = &PureWheelBuild{}
@@ -33,16 +41,17 @@ func (b *PureWheelBuild) ToWorkflow() *rebuild.WorkflowStrategy {
 		Deps: []flow.Step{{
 			Uses: "pypi/deps/basic",
 			With: map[string]string{
-				"registryTime": registryTime,
-				"requirements": flow.MustToJSON(b.Requirements),
-				"venv":         "/deps",
+				"registryTime":  registryTime,
+				"requirements":  flow.MustToJSON(b.Requirements),
+				"pythonVersion": b.PythonVersion,
+				"venv":          "deps",
 			},
 		}},
 		Build: []flow.Step{{
 			Uses: "pypi/build/wheel",
 			With: map[string]string{
 				"dir":     b.Location.Dir,
-				"locator": "/deps/bin/",
+				"locator": "deps/bin/",
 			},
 		}},
 		OutputDir: "dist",
@@ -54,15 +63,75 @@ func (b *PureWheelBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (reb
 	return b.ToWorkflow().GenerateFor(t, be)
 }
 
+func (b *SourceDistributionBuild) ToWorkflow() *rebuild.WorkflowStrategy {
+	var registryTime string
+	if !b.RegistryTime.IsZero() {
+		registryTime = b.RegistryTime.Format(time.RFC3339)
+	}
+	return &rebuild.WorkflowStrategy{
+		Location: b.Location,
+		Source: []flow.Step{{
+			Uses: "git-checkout",
+		}},
+		Deps: []flow.Step{{
+			Uses: "pypi/deps/basic",
+			With: map[string]string{
+				"registryTime":  registryTime,
+				"requirements":  flow.MustToJSON(b.Requirements),
+				"pythonVersion": b.PythonVersion,
+				"venv":          "deps",
+			},
+		}},
+		Build: []flow.Step{{
+			Uses: "pypi/build/sdist",
+			With: map[string]string{
+				"dir":     b.Location.Dir,
+				"locator": "deps/bin/",
+			},
+		}},
+		OutputDir: "dist",
+	}
+}
+
+func (b *SourceDistributionBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
+	return b.ToWorkflow().GenerateFor(t, be)
+}
+
 func init() {
 	for _, t := range toolkit {
 		flow.Tools.MustRegister(t)
 	}
 }
 
+// if ! command -v pyenv &> /dev/null; then
+//
+//		curl https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+//		export PATH="/root/.pyenv/bin:$PATH"
+//		eval "$(pyenv init -)"
+//		eval "$(pyenv virtualenv-init -)"
+//	fi
+//
+// /root/.pyenv/bin/pyenv global {{.With.version}}`)[1:],
+// "bash", "clang", "curl", "build-base", "patch", "zip", "zlib-dev", "libffi-dev", "linux-headers", "readline-dev", "openssl", "openssl-dev", "sqlite-dev", "bzip2-dev"
 // Base tools for individual operations
 var toolkit = []*flow.Tool{
+	//  Use clang to avoid issues with openssl
+	// Python versions before 3.6 cannot be compiled with openssl 3.x, they require 1.0.x
 	{
+		Name: "pypi/setup-python",
+		Steps: []flow.Step{{
+			Runs: textwrap.Dedent(`
+				if [ ! -d "/root/.pyenv" ]; then
+					if ! command -v curl &> /dev/null; then
+						apk add clang curl build-base patch zip zlib-dev libffi-dev linux-headers readline-dev openssl openssl-dev sqlite-dev bzip2-dev xz-dev
+					fi
+					curl https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+				fi
+				CC=clang /root/.pyenv/bin/pyenv install -s {{.With.version}}`)[1:],
+			Needs: []string{"bash", "clang", "curl", "build-base", "patch", "zip", "zlib-dev", "libffi-dev", "linux-headers", "readline-dev", "openssl", "openssl-dev", "sqlite-dev", "bzip2-dev"},
+		}},
+	}, {
+
 		Name: "pypi/setup-venv",
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
@@ -96,9 +165,16 @@ var toolkit = []*flow.Tool{
 		Name: "pypi/deps/basic",
 		Steps: []flow.Step{
 			{
+				Uses: "pypi/setup-python",
+				With: map[string]string{
+					"version": "{{.With.pythonVersion}}",
+				},
+			},
+			{
 				Uses: "pypi/setup-venv",
 				With: map[string]string{
-					"locator": "/usr/bin/",
+					// "locator": "/usr/bin/",
+					"locator": "/root/.pyenv/versions/{{.With.pythonVersion}}/bin/",
 					"path":    "{{.With.venv}}",
 				},
 			},
@@ -122,6 +198,14 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
 				{{.With.locator}}python3 -m build --wheel -n{{if and (ne .With.dir ".") (ne .With.dir "")}} {{.With.dir}}{{end}}`)[1:],
+			Needs: []string{"python3"},
+		}},
+	},
+	{
+		Name: "pypi/build/sdist",
+		Steps: []flow.Step{{
+			Runs: textwrap.Dedent(`
+				{{.With.locator}}python3 -m build --sdist -n{{if and (ne .With.dir ".") (ne .With.dir "")}} {{.With.dir}}{{end}}`)[1:],
 			Needs: []string{"python3"},
 		}},
 	},

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -24,16 +24,17 @@ import (
 // The strategies are pointers because omitempty does not treat an empty struct as empty, but it
 // does treat nil pointers as empty.
 type StrategyOneOf struct {
-	LocationHint         *rebuild.LocationHint          `json:"rebuild_location_hint,omitempty" yaml:"rebuild_location_hint,omitempty"`
-	PureWheelBuild       *pypi.PureWheelBuild           `json:"pypi_pure_wheel_build,omitempty" yaml:"pypi_pure_wheel_build,omitempty"`
-	NPMPackBuild         *npm.NPMPackBuild              `json:"npm_pack_build,omitempty" yaml:"npm_pack_build,omitempty"`
-	NPMCustomBuild       *npm.NPMCustomBuild            `json:"npm_custom_build,omitempty" yaml:"npm_custom_build,omitempty"`
-	CratesIOCargoPackage *cratesio.CratesIOCargoPackage `json:"cratesio_cargo_package,omitempty" yaml:"cratesio_cargo_package,omitempty"`
-	MavenBuild           *maven.MavenBuild              `json:"maven_build,omitempty" yaml:"maven_build,omitempty"`
-	DebianPackage        *debian.DebianPackage          `json:"debian_package,omitempty" yaml:"debian_package,omitempty"`
-	Debrebuild           *debian.Debrebuild             `json:"debrebuild,omitempty" yaml:"debrebuild,omitempty"`
-	ManualStrategy       *rebuild.ManualStrategy        `json:"manual,omitempty" yaml:"manual,omitempty"`
-	WorkflowStrategy     *rebuild.WorkflowStrategy      `json:"flow,omitempty" yaml:"flow,omitempty"`
+	LocationHint            *rebuild.LocationHint          `json:"rebuild_location_hint,omitempty" yaml:"rebuild_location_hint,omitempty"`
+	PureWheelBuild          *pypi.PureWheelBuild           `json:"pypi_pure_wheel_build,omitempty" yaml:"pypi_pure_wheel_build,omitempty"`
+	SourceDistributionBuild *pypi.SourceDistributionBuild  `json:"pypi_source_distribution_build,omitempty" yaml:"pypi_source_distribution_build,omitempty"`
+	NPMPackBuild            *npm.NPMPackBuild              `json:"npm_pack_build,omitempty" yaml:"npm_pack_build,omitempty"`
+	NPMCustomBuild          *npm.NPMCustomBuild            `json:"npm_custom_build,omitempty" yaml:"npm_custom_build,omitempty"`
+	CratesIOCargoPackage    *cratesio.CratesIOCargoPackage `json:"cratesio_cargo_package,omitempty" yaml:"cratesio_cargo_package,omitempty"`
+	MavenBuild              *maven.MavenBuild              `json:"maven_build,omitempty" yaml:"maven_build,omitempty"`
+	DebianPackage           *debian.DebianPackage          `json:"debian_package,omitempty" yaml:"debian_package,omitempty"`
+	Debrebuild              *debian.Debrebuild             `json:"debrebuild,omitempty" yaml:"debrebuild,omitempty"`
+	ManualStrategy          *rebuild.ManualStrategy        `json:"manual,omitempty" yaml:"manual,omitempty"`
+	WorkflowStrategy        *rebuild.WorkflowStrategy      `json:"flow,omitempty" yaml:"flow,omitempty"`
 }
 
 // NewStrategyOneOf creates a StrategyOneOf from a rebuild.Strategy, using typecasting to put the strategy in the right place.
@@ -44,6 +45,8 @@ func NewStrategyOneOf(s rebuild.Strategy) StrategyOneOf {
 		oneof.LocationHint = t
 	case *pypi.PureWheelBuild:
 		oneof.PureWheelBuild = t
+	case *pypi.SourceDistributionBuild:
+		oneof.SourceDistributionBuild = t
 	case *maven.MavenBuild:
 		oneof.MavenBuild = t
 	case *npm.NPMPackBuild:
@@ -76,6 +79,10 @@ func (oneof *StrategyOneOf) Strategy() (rebuild.Strategy, error) {
 		if oneof.PureWheelBuild != nil {
 			num++
 			s = oneof.PureWheelBuild
+		}
+		if oneof.SourceDistributionBuild != nil {
+			num++
+			s = oneof.SourceDistributionBuild
 		}
 		if oneof.NPMPackBuild != nil {
 			num++


### PR DESCRIPTION
For source distribution:
* The source distribution can be manipulated/compromised the same way of bdists. Moreover, it may help as fallback when only platform-specific wheels are available.

For Python version:
* it may be not necessary, I didn't find any specific reproducibility issue caused by python version.
* it avoids some build failures caused by no longer supported libraries
* a step is added to the strategy for rebuilding Python packages (ce3555313de511d7755bfa1e8adad21a7ea657a5)

This PR requires the `Executor` logic proposed in PR https://github.com/google/oss-rebuild/pull/427
In case that PR isn't accepted I can decouple this dependency!