### PR TITLE
Fix rundex filter pipeline

### DIFF
--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -266,6 +266,7 @@ func filterRebuilds(all <-chan Rebuild, req *FetchRebuildRequest) []Rebuild {
 	}
 	p = p.Do(func(in Rebuild, out chan<- Rebuild) {
 		in.Message = strings.ReplaceAll(in.Message, "\n", "\\n")
+		out <- in
 	})
 	var res []Rebuild
 	if req.LatestPerPackage {


### PR DESCRIPTION
Introduced in #423, this un-breaks the rundex pipeline. Without this
change the rundex was returning emtpy results.