### PR TITLE
Use path to detect un-warped requests and redirect

### DIFF
--- a/internal/timewarp/timewarp_test.go
+++ b/internal/timewarp/timewarp_test.go
@@ -91,22 +91,39 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			},
 		},
 		{
-			name:      "npm search request - skipped time warp",
-			url:       "http://localhost:8081/-/v1/search?text=some-package",
+			name:      "npm package request with org - successful time warp",
+			url:       "http://localhost:8081/@org/some-package",
 			basicAuth: "npm:2022-01-01T00:00:00Z",
 			client: &httpxtest.MockClient{
 				Calls: []httpxtest.Call{
 					{
 						Method: "GET",
-						URL:    "https://registry.npmjs.org/-/v1/search?text=some-package",
+						URL:    "https://registry.npmjs.org/@org/some-package",
 						Response: &http.Response{
 							StatusCode: http.StatusOK,
 							Header: http.Header{
 								"Content-Type": []string{"application/json"},
 							},
 							Body: io.NopCloser(bytes.NewBufferString(`{
-								"time": "2022-06-01T00:00:00Z",
-								"objects": []
+								"_id": "@org/some-package",
+								"time": {
+									"created": "2021-01-01T00:00:00Z",
+									"modified": "2023-01-01T00:00:00Z",
+									"1.0.0": "2021-06-01T00:00:00Z",
+									"2.0.0": "2022-06-01T00:00:00Z"
+								},
+								"versions": {
+									"1.0.0": {
+										"version": "1.0.0",
+										"description": "v1 desc",
+										"repository": "repo1"
+									},
+									"2.0.0": {
+										"version": "2.0.0",
+										"description": "v2 desc",
+										"repository": "repo2"
+									}
+								}
 							}`)),
 						},
 					},
@@ -119,9 +136,61 @@ func TestHandler_ServeHTTP(t *testing.T) {
 					"Content-Type": []string{"application/json"},
 				},
 				Body: io.NopCloser(bytes.NewBufferString(`{
-					"time": "2022-06-01T00:00:00Z",
-					"objects": []
+					"_id": "@org/some-package",
+					"time": {
+						"created": "2021-01-01T00:00:00Z",
+						"modified": "2021-06-01T00:00:00Z",
+						"1.0.0": "2021-06-01T00:00:00Z"
+					},
+					"versions": {
+						"1.0.0": {
+							"version": "1.0.0",
+							"description": "v1 desc",
+							"repository": "repo1"
+						}
+					},
+					"description": "v1 desc",
+					"repository": "repo1",
+					"dist-tags": {
+						"latest": "1.0.0"
+					}
 				}`)),
+			},
+		},
+		{
+			name:      "npm version request - skipped time warp",
+			url:       "http://localhost:8081/some-package/2.0.0",
+			basicAuth: "npm:2022-01-01T00:00:00Z",
+			client: &httpxtest.MockClient{
+				Calls:        []httpxtest.Call{},
+				URLValidator: httpxtest.NewURLValidator(t),
+			},
+			want: &http.Response{
+				StatusCode: http.StatusFound,
+				Header: http.Header{
+					"Content-Type": []string{"text/html; charset=utf-8"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`<a href="https://registry.npmjs.org/some-package/2.0.0">Found</a>.
+
+`)),
+			},
+		},
+		{
+			name:      "npm search request - skipped time warp",
+			url:       "http://localhost:8081/-/v1/search?text=some-package",
+			basicAuth: "npm:2022-01-01T00:00:00Z",
+			client: &httpxtest.MockClient{
+				Calls:        []httpxtest.Call{},
+				URLValidator: httpxtest.NewURLValidator(t),
+			},
+			want: &http.Response{
+				StatusCode: http.StatusFound,
+				Header: http.Header{
+					"Content-Type": []string{"text/html; charset=utf-8"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`<a href="https://registry.npmjs.org/-/v1/search?text=some-package">Found</a>.
+
+`)),
 			},
 		},
 		{
@@ -273,6 +342,24 @@ func TestHandler_ServeHTTP(t *testing.T) {
 					},
 					"releases": {}
 				}`)),
+			},
+		},
+		{
+			name:      "pypi version request - skipped time warp",
+			url:       "http://localhost:8081/pypi/some-package/2.0.0/json",
+			basicAuth: "pypi:2022-01-01T00:00:00Z",
+			client: &httpxtest.MockClient{
+				Calls:        []httpxtest.Call{},
+				URLValidator: httpxtest.NewURLValidator(t),
+			},
+			want: &http.Response{
+				StatusCode: http.StatusFound,
+				Header: http.Header{
+					"Content-Type": []string{"text/html; charset=utf-8"},
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`<a href="https://pypi.org/pypi/some-package/2.0.0/json">Found</a>.
+
+`)),
 			},
 		},
 		{


### PR DESCRIPTION
In addition to being more self-documenting, this offers functional benefits as
the CPU/memory cost of proxying the (often large) npm package archives is now
no longer duplicated by the timewarp binary. This should free up local
resources, especially for large and/or multitenant builds.