### PR TITLE
Fix Suffix matching in URLMatchRule.Allows

### DIFF
--- a/pkg/proxy/policy/policy.go
+++ b/pkg/proxy/policy/policy.go
@@ -152,7 +152,7 @@ func (rule URLMatchRule) Allows(req *http.Request) bool {
 		// Avoid matching partial domain names and only match full domain parts.
 		// That is, notgoogle.com must not match google.com, but is.google.com matches google.com.
 		host := rule.Host
-		if !strings.HasPrefix(".", host) {
+		if !strings.HasPrefix(host, ".") {
 			host = "." + host
 		}
 		if !strings.HasSuffix(url.Hostname(), host) {

--- a/pkg/proxy/policy/policy_test.go
+++ b/pkg/proxy/policy/policy_test.go
@@ -122,6 +122,21 @@ func TestApplyOnURLMatchRule(t *testing.T) {
 			wantResp: http.StatusOK,
 		},
 		{
+			name: "host policy rule allows matching tld suffix",
+			policy: Policy{
+				AnyOf: []Rule{
+					URLMatchRule{
+						Host:      ".com",
+						HostMatch: SuffixMatch,
+						Path:      "/path",
+						PathMatch: PrefixMatch,
+					},
+				},
+			},
+			url:      "https://host.com/path/with/prefix",
+			wantResp: http.StatusOK,
+		},
+		{
 			name: "host policy rule blocks non matching domain suffix",
 			policy: Policy{
 				AnyOf: []Rule{


### PR DESCRIPTION
HasPrefix was used incorrectly in this function so suffixes that already have a . will have another . prepended to it. Newly added test fails before change and passes after change.