### PR TITLE
Add unsafe-perm for npm v6 invocations

### DIFF
--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -295,6 +295,9 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			if !(hasPrepare || hasPrepack) {
 				b.PrepackRemoveDeps = true
 			}
+			if v, _ := semver.New(npmv); v.Major <= 6 { // NOTE: PickNPMVersion guarantees a valid semver
+				b.KeepRoot = true
+			}
 			return b, nil
 		}
 	}

--- a/pkg/rebuild/npm/infer_test.go
+++ b/pkg/rebuild/npm/infer_test.go
@@ -321,6 +321,37 @@ func TestInferStrategy_NPM(t *testing.T) {
 			},
 		},
 		{
+			name:    "NPMCustomBuild - from build script",
+			pkg:     "test-package",
+			version: "1.0.0",
+			repoYAML: `commits:
+  - id: initial-commit
+  - id: version-bump
+    parent: initial-commit
+    files:
+      package.json: |
+        {"name": "test-package", "version": "1.0.0", "scripts": {"build": "tsc"}}
+`,
+			versionMetadata: `{"name":"test-package","version":"1.0.0","_npmVersion":"6.2.0","nodeVersion": "16.13.0", "dist":{"tarball":"url4"},"gitHead":"INSERT_COMMIT_ID"}`,
+			packageMetadata: `{"name":"test-package","time":{"1.0.0":"2023-02-10T10:00:00.000Z"}}`,
+			wantCommitID:    "version-bump",
+			wantStrategyFn: func(commitID string) rebuild.Strategy {
+				return &NPMCustomBuild{
+					Location: rebuild.Location{
+						Repo: "https://github.com/test-org/test-package",
+						Ref:  commitID,
+						Dir:  ".",
+					},
+					NPMVersion:        "6.2.0",
+					NodeVersion:       "10.17.0",
+					Command:           "build",
+					RegistryTime:      must(time.Parse(time.RFC3339, "2023-02-10T10:00:00.000Z")),
+					PrepackRemoveDeps: true,
+					KeepRoot:          true,
+				}
+			},
+		},
+		{
 			name:    "Error - unreadable package.json in commit",
 			pkg:     "test-package",
 			version: "1.0.0",

--- a/pkg/rebuild/npm/strategy.go
+++ b/pkg/rebuild/npm/strategy.go
@@ -54,6 +54,7 @@ type NPMCustomBuild struct {
 	Command           string    `json:"command" yaml:"command,omitempty"`
 	RegistryTime      time.Time `json:"registry_time" yaml:"registry_time"`
 	PrepackRemoveDeps bool      `json:"prepack_remove_deps,omitempty" yaml:"prepack_remove_deps,omitempty"`
+	KeepRoot          bool      `json:"keep_root,omitempty" yaml:"keep_root,omitempty"`
 }
 
 var _ rebuild.Strategy = &NPMCustomBuild{}
@@ -81,6 +82,7 @@ func (b *NPMCustomBuild) ToWorkflow() *rebuild.WorkflowStrategy {
 			With: map[string]string{
 				"npmVersion":      b.NPMVersion,
 				"versionOverride": b.VersionOverride,
+				"keepRoot":        fmt.Sprintf("%t", b.KeepRoot),
 				"removeDeps":      fmt.Sprintf("%t", b.PrepackRemoveDeps),
 				"command":         b.Command,
 			},
@@ -213,6 +215,7 @@ var toolkit = []*flow.Tool{
 				Uses: "npm/npx",
 				With: map[string]string{
 					"command": `
+						{{- if eq .With.keepRoot "true"}}npm config set unsafe-perm true && {{end -}}
 						{{- if ne .With.command ""}}npm run {{.With.command}} && {{end -}}
 						{{- if eq .With.removeDeps "true"}}rm -rf node_modules && {{end -}}
 						npm pack`,

--- a/pkg/rebuild/npm/strategy_test.go
+++ b/pkg/rebuild/npm/strategy_test.go
@@ -192,6 +192,34 @@ func TestNPMCustomBuild(t *testing.T) {
 				OutputPath: "the_dir/the_artifact",
 			},
 		},
+		{
+			"CustomBuildKeepRoot",
+			&NPMCustomBuild{
+				Location: rebuild.Location{
+					Dir:  ".",
+					Ref:  "the_ref",
+					Repo: "the_repo",
+				},
+				NPMVersion:   "red",
+				NodeVersion:  "blue",
+				Command:      "yellow",
+				RegistryTime: time.Date(2006, time.January, 2, 3, 4, 5, 0, time.UTC),
+				KeepRoot:     true,
+			},
+			rebuild.Instructions{
+				Location: rebuild.Location{
+					Dir:  ".",
+					Ref:  "the_ref",
+					Repo: "the_repo",
+				},
+				SystemDeps: []string{"git", "npm"},
+				Source:     "git checkout --force 'the_ref'",
+				Deps: `wget -O - https://unofficial-builds.nodejs.org/download/release/vblue/node-vblue-linux-x64-musl.tar.gz | tar xzf - --strip-components=1 -C /usr/local/
+/usr/local/bin/npx --package=npm@red -c 'npm_config_registry=http://npm:2006-01-02T03:04:05Z@orange npm install --force'`,
+				Build:      `/usr/local/bin/npx --package=npm@red -c 'npm config set unsafe-perm true && npm run yellow && npm pack'`,
+				OutputPath: "the_artifact",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
npm dropped privilege when running scripts in npm v6 and prior. the [v7 update](https://github.com/npm/cli/blob/e1a2837809a76896523cdfcbce7537e46f71d67e/CHANGELOG.md#:~:text=configurations%20are%20no%20longer%20relevant) uses the underlying directory owner which, in our case, will be the same as the calling user.