### PR TITLE
Treat HEAD requests like GET requests in the proxy

### DIFF
--- a/pkg/proxy/proxy/transparent.go
+++ b/pkg/proxy/proxy/transparent.go
@@ -279,7 +279,7 @@ func (t *TransparentProxyService) policyHandler(w http.ResponseWriter, r *http.R
 	t.mx.Lock()
 	defer t.mx.Unlock()
 	switch r.Method {
-	case http.MethodGet:
+	case http.MethodGet, http.MethodHead:
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(t.Policy); err != nil {


### PR DESCRIPTION
This is required to use buildkit behind the proxy as it makes a HEAD request to the docker registry