### PR TITLE
Use native time.Time types in firestore and rundex

### DIFF
--- a/internal/api/apiservice/createrun.go
+++ b/internal/api/apiservice/createrun.go
@@ -26,7 +26,7 @@ func CreateRun(ctx context.Context, req schema.CreateRunRequest, deps *CreateRun
 		Type:          req.Type,
 	}
 	err := deps.FirestoreClient.RunTransaction(ctx, func(ctx context.Context, t *firestore.Transaction) error {
-		run.Created = time.Now().UTC().UnixMilli()
+		run.Created = time.Now().UTC()
 		return t.Create(deps.FirestoreClient.Collection("runs").Doc(run.ID), run)
 	})
 	if err != nil {

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -354,7 +354,7 @@ func rebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 }
 
 func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps *RebuildPackageDeps) (*schema.Verdict, error) {
-	started := time.Now()
+	started := time.Now().UTC()
 	ctx = context.WithValue(ctx, rebuild.RunID, req.ID)
 	var timeout time.Duration
 	if req.BuildTimeout == 0 {
@@ -397,8 +397,8 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 		RunID:           req.ID,
 		BuildID:         bi.BuildID,
 		ObliviousID:     bi.ID,
-		Started:         started.Unix(),
-		Created:         time.Now().Unix(),
+		Started:         started,
+		Created:         time.Now().UTC(),
 	})
 	if err != nil {
 		log.Print(errors.Wrap(err, "storing results in firestore"))

--- a/internal/api/apiservice/smoketest.go
+++ b/internal/api/apiservice/smoketest.go
@@ -64,8 +64,9 @@ func rebuildSmoketest(ctx context.Context, sreq schema.SmoketestRequest, deps *R
 	}
 }
 func RebuildSmoketest(ctx context.Context, sreq schema.SmoketestRequest, deps *RebuildSmoketestDeps) (*schema.SmoketestResponse, error) {
+	started := time.Now().UTC()
 	if sreq.ID == "" {
-		sreq.ID = time.Now().UTC().Format(time.RFC3339)
+		sreq.ID = started.Format(time.RFC3339)
 	}
 	resp, err := rebuildSmoketest(ctx, sreq, deps)
 	for _, v := range resp.Verdicts {
@@ -80,7 +81,8 @@ func RebuildSmoketest(ctx context.Context, sreq schema.SmoketestRequest, deps *R
 			Timings:         v.Timings,
 			ExecutorVersion: resp.Executor,
 			RunID:           sreq.ID,
-			Created:         time.Now().UnixMilli(),
+			Started:         started,
+			Created:         time.Now().UTC(),
 		})
 		if err != nil {
 			return nil, api.AsStatus(codes.Internal, errors.Wrapf(err, "writing record for %s@%s", sreq.Package, v.Target.Version))

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -257,17 +257,17 @@ type RebuildAttempt struct {
 	RunID           string          `firestore:"run_id,omitempty"`
 	BuildID         string          `firestore:"build_id,omitempty"`
 	ObliviousID     string          `firestore:"oblivious_id,omitempty"`
-	Started         int64           `firestore:"started,omitempty"` // The time rebuild started
-	Created         int64           `firestore:"created,omitempty"` // The time this record was created
+	Started         time.Time       `firestore:"started,omitempty"` // The time rebuild started
+	Created         time.Time       `firestore:"created,omitempty"` // The time this record was created
 }
 
 // Run stores metadata on an execution grouping.
 type Run struct {
-	ID            string `firestore:"id,omitempty"`
-	BenchmarkName string `firestore:"benchmark_name,omitempty"`
-	BenchmarkHash string `firestore:"benchmark_hash,omitempty"`
-	Type          string `firestore:"run_type,omitempty"`
-	Created       int64  `firestore:"created,omitempty"`
+	ID            string    `firestore:"id,omitempty"`
+	BenchmarkName string    `firestore:"benchmark_name,omitempty"`
+	BenchmarkHash string    `firestore:"benchmark_hash,omitempty"`
+	Type          string    `firestore:"run_type,omitempty"`
+	Created       time.Time `firestore:"created,omitempty"`
 }
 
 type ReleaseEvent struct {

--- a/tools/ctl/ide/explorer/explorer.go
+++ b/tools/ctl/ide/explorer/explorer.go
@@ -311,15 +311,18 @@ func (e *Explorer) RunBenchmark(ctx context.Context, bench string) {
 		log.Println(errors.Wrap(err, "reading benchmark"))
 		return
 	}
-	ts := time.Now().UTC()
-	runID := ts.Format(time.RFC3339)
-	wdex.WriteRun(ctx, rundex.FromRun(schema.Run{
-		ID:            runID,
-		BenchmarkName: filepath.Base(bench),
-		BenchmarkHash: hex.EncodeToString(set.Hash(sha256.New())),
-		Type:          string(schema.SmoketestMode),
-		Created:       ts.UnixMilli(),
-	}))
+	var runID string
+	{
+		now := time.Now().UTC()
+		runID = now.Format(time.RFC3339)
+		wdex.WriteRun(ctx, rundex.FromRun(schema.Run{
+			ID:            runID,
+			BenchmarkName: filepath.Base(bench),
+			BenchmarkHash: hex.EncodeToString(set.Hash(sha256.New())),
+			Type:          string(schema.SmoketestMode),
+			Created:       now,
+		}))
+	}
 	verdictChan, err := e.rb.RunBench(ctx, set, runID)
 	if err != nil {
 		log.Println(err.Error())
@@ -330,7 +333,7 @@ func (e *Explorer) RunBenchmark(ctx context.Context, bench string) {
 		if v.Message == "" {
 			successes += 1
 		}
-		now := time.Now().UnixMilli()
+		now := time.Now().UTC()
 		wdex.WriteRebuild(ctx, rundex.Rebuild{
 			RebuildAttempt: schema.RebuildAttempt{
 				Ecosystem:       string(v.Target.Ecosystem),
@@ -345,7 +348,6 @@ func (e *Explorer) RunBenchmark(ctx context.Context, bench string) {
 				RunID:           runID,
 				Created:         now,
 			},
-			Created: time.UnixMilli(now),
 		})
 	}
 	log.Printf("Finished benchmark %s with %d successes.", bench, successes)

--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -30,7 +30,6 @@ import (
 // Rebuild represents the result of a specific rebuild.
 type Rebuild struct {
 	schema.RebuildAttempt
-	Created time.Time
 }
 
 // NewRebuildFromFirestore creates a Rebuild instance from a "attempt" collection document.
@@ -41,11 +40,6 @@ func NewRebuildFromFirestore(doc *firestore.DocumentSnapshot) Rebuild {
 	}
 	var rb Rebuild
 	rb.RebuildAttempt = sa
-	rb.Created = time.Unix(sa.Created, 0)
-	if rb.Created.After(time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)) {
-		rb.Created = time.UnixMilli(sa.Created)
-	}
-
 	return rb
 }
 
@@ -80,7 +74,7 @@ func FromRun(r schema.Run) Run {
 	var rb Run
 	rb.Run = r
 	rb.Type = schema.ExecutionMode(r.Type)
-	rb.Created = time.UnixMilli(r.Created)
+	rb.Created = r.Created
 	return rb
 }
 


### PR DESCRIPTION
We were inconsistent with timezone and Unix vs UnixMilli previously, causing a lot of bad data in our metadata storage.

After doing some data migrations, firestore contains the data as native time.Time types now.

I also removed the rundex.Rebuild.Created field, because that's now directly handled in embed schema.Attempt