### PR TITLE
Add regex search across logs in a verdict group

### DIFF
--- a/tools/ctl/ide/commands/commands.go
+++ b/tools/ctl/ide/commands/commands.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -11,6 +12,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -23,12 +25,18 @@ import (
 	"github.com/google/oss-rebuild/tools/ctl/ide/details"
 	"github.com/google/oss-rebuild/tools/ctl/ide/modal"
 	"github.com/google/oss-rebuild/tools/ctl/ide/rebuilder"
+	"github.com/google/oss-rebuild/tools/ctl/ide/textinput"
 	"github.com/google/oss-rebuild/tools/ctl/ide/tmux"
 	"github.com/google/oss-rebuild/tools/ctl/localfiles"
+	"github.com/google/oss-rebuild/tools/ctl/pipe"
 	"github.com/google/oss-rebuild/tools/ctl/rundex"
 	"github.com/pkg/errors"
 	"github.com/rivo/tview"
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	RundexReadParallelism = 10
 )
 
 // A modalFnType can be used to show an InputCaptureable. It returns an exit function that can be used to close the modal.
@@ -176,6 +184,66 @@ func NewRebuildCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn mod
 			},
 		},
 	}
+}
+
+func NewRebuildGroupCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, asst assistant.Assistant, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []RebuildGroupCmd {
+	return []RebuildGroupCmd{
+		{
+			Short: "Find pattern",
+			Func: func(ctx context.Context, rebuilds []rundex.Rebuild) {
+				pattern, mopts, inputChan := textinput.TextInput(textinput.TextInputOpts{Header: "Search Regex"})
+				exitFunc := modalFn(pattern, mopts)
+				input := <-inputChan
+				log.Printf("Finding pattern \"%s\"", input)
+				exitFunc()
+				regex, err := regexp.Compile(input)
+				if err != nil {
+					log.Println(err.Error())
+					return
+				}
+				p := pipe.FromSlice(rebuilds)
+				p = p.ParDo(RundexReadParallelism, func(in rundex.Rebuild, out chan<- rundex.Rebuild) {
+					_, err := butler.Fetch(context.Background(), in.RunID, in.WasSmoketest(), rebuild.DebugLogsAsset.For(in.Target()))
+					if err != nil {
+						log.Println(errors.Wrap(err, "downloading logs"))
+						return
+					}
+					out <- in
+				})
+				var found int
+				p = p.Do(func(in rundex.Rebuild, out chan<- rundex.Rebuild) {
+					assets, err := localfiles.AssetStore(in.RunID)
+					if err != nil {
+						log.Println(errors.Wrapf(err, "creating asset store for runid: %s", in.RunID))
+						return
+					}
+					r, err := assets.Reader(ctx, rebuild.DebugLogsAsset.For(in.Target()))
+					if err != nil {
+						log.Println(errors.Wrapf(err, "opening logs for %s", in.ID()))
+						return
+					}
+					defer r.Close()
+					// TODO: Maybe read the whole file into memory and do multi-line matching?
+					scanner := bufio.NewScanner(r)
+					for scanner.Scan() {
+						line := scanner.Text()
+						if regex.MatchString(line) {
+							log.Printf("%s\n\t%s", in.ID(), line)
+							out <- in
+							break
+						}
+					}
+					if err := scanner.Err(); err != nil {
+						log.Println(errors.Wrap(err, "reading logs"))
+					}
+				})
+				for range p.Out() {
+				}
+				log.Printf("Found in %d/%d (%2.0f%%)", found, len(rebuilds), float32(found)/float32(len(rebuilds))*100)
+			},
+		},
+	}
+
 }
 
 func NewGlobalCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, asst assistant.Assistant, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []GlobalCmd {

--- a/tools/ctl/ide/commands/registry.go
+++ b/tools/ctl/ide/commands/registry.go
@@ -16,6 +16,11 @@ type RebuildCmd struct {
 	Func   func(context.Context, rundex.Rebuild)
 }
 
+type RebuildGroupCmd struct {
+	Short string
+	Func  func(context.Context, []rundex.Rebuild)
+}
+
 type GlobalCmd struct {
 	Short  string
 	Hotkey rune
@@ -23,8 +28,9 @@ type GlobalCmd struct {
 }
 
 type Registry struct {
-	rebuildCmds []RebuildCmd
-	globalCmds  []GlobalCmd
+	rebuildCmds      []RebuildCmd
+	rebuildGroupCmds []RebuildGroupCmd
+	globalCmds       []GlobalCmd
 }
 
 func (reg *Registry) AddGlobals(cmds ...GlobalCmd) error {
@@ -33,6 +39,17 @@ func (reg *Registry) AddGlobals(cmds ...GlobalCmd) error {
 	err := reg.Validate()
 	if err != nil {
 		reg.globalCmds = old
+		return err
+	}
+	return nil
+}
+
+func (reg *Registry) AddRebuildGroups(cmds ...RebuildGroupCmd) error {
+	old := reg.rebuildGroupCmds
+	reg.rebuildGroupCmds = append(reg.rebuildGroupCmds, cmds...)
+	err := reg.Validate()
+	if err != nil {
+		reg.rebuildGroupCmds = old
 		return err
 	}
 	return nil
@@ -72,6 +89,10 @@ func (reg *Registry) Validate() error {
 
 func (reg *Registry) RebuildCommands() []RebuildCmd {
 	return reg.rebuildCmds
+}
+
+func (reg *Registry) RebuildGroupCommands() []RebuildGroupCmd {
+	return reg.rebuildGroupCmds
 }
 
 func (reg *Registry) GlobalCommands() []GlobalCmd {

--- a/tools/ctl/ide/explorer/explorer.go
+++ b/tools/ctl/ide/explorer/explorer.go
@@ -146,6 +146,9 @@ func (e *Explorer) makeVerdictGroupNode(vg *rundex.VerdictGroup, percent float32
 	node.SetSelectedFunc(func() {
 		children := node.GetChildren()
 		if len(children) == 0 {
+			for _, cmd := range e.cmdReg.RebuildGroupCommands() {
+				node.AddChild(tview.NewTreeNode(cmd.Short).SetColor(tcell.ColorDarkCyan).SetSelectedFunc(func() { go cmd.Func(context.Background(), vg.Examples) }))
+			}
 			for _, example := range vg.Examples {
 				node.AddChild(e.makeExampleNode(example))
 			}

--- a/tools/ctl/ide/modal/modal.go
+++ b/tools/ctl/ide/modal/modal.go
@@ -16,14 +16,19 @@ const (
 
 // Returns a new primitive which puts the provided primitive in the center and
 // adds vertical and horizontal margin.
+// vertMargin and horizMargin are total margin. If margin is odd (can't be evenly split on either side), the primitive goes to the top and left.
 func center(p tview.Primitive, vertMargin, horizMargin int) tview.Primitive {
+	topMargin := vertMargin / 2
+	bottomMargin := vertMargin - topMargin
+	leftMargin := horizMargin / 2
+	rightMargin := horizMargin - leftMargin
 	return tview.NewFlex().
-		AddItem(nil, horizMargin, 0, false).
+		AddItem(nil, leftMargin, 0, false).
 		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(nil, vertMargin, 0, false).
+			AddItem(nil, topMargin, 0, false).
 			AddItem(p, 0, 1, true).
-			AddItem(nil, vertMargin, 0, false), 0, 1, true).
-		AddItem(nil, horizMargin, 0, false)
+			AddItem(nil, bottomMargin, 0, false), 0, 1, true).
+		AddItem(nil, rightMargin, 0, false)
 }
 
 type InputCaptureable interface {
@@ -65,7 +70,7 @@ func Show(app *tview.Application, container *tview.Pages, contents InputCapturea
 	opts.Height = min(opts.Height, containerHeight-(2*opts.Margin))
 	opts.Width = min(opts.Width, containerWidth-(2*opts.Margin))
 	app.QueueUpdateDraw(func() {
-		container.AddPage(pageName, center(contents, (containerHeight-opts.Height)/2, (containerWidth-opts.Width)/2), true, true)
+		container.AddPage(pageName, center(contents, containerHeight-opts.Height, containerWidth-opts.Width), true, true)
 	})
 	return exitFunc
 }

--- a/tools/ctl/ide/textinput/textinput.go
+++ b/tools/ctl/ide/textinput/textinput.go
@@ -1,0 +1,34 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package textinput
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/google/oss-rebuild/tools/ctl/ide/modal"
+	"github.com/rivo/tview"
+)
+
+type TextInputOpts struct {
+	Header string
+}
+
+func TextInput(opts TextInputOpts) (modal.InputCaptureable, modal.ModalOpts, <-chan string) {
+	ta := tview.NewTextArea()
+	output := make(chan string, 1)
+	ta.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEnter {
+			input := ta.GetText()
+			output <- input
+			return nil
+		}
+		return event
+	})
+	// TODO: Is there a better way to set focus on the pattern input without a flex box?
+	flx := tview.NewFlex().SetDirection(tview.FlexRow).AddItem(ta, 0, 1, true)
+	flx.SetBorder(true)
+	if opts.Header != "" {
+		flx.SetTitle(opts.Header)
+	}
+	return flx, modal.ModalOpts{Width: 50, Height: 3}, output
+}

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -65,6 +65,9 @@ func NewTuiApp(dex rundex.Reader, rundexOpts rundex.FetchRebuildOpts, benches be
 	if err := cmdReg.AddGlobals(commands.NewGlobalCmds(t.app, t.rb, modalFn, butler, asst, buildDefs, dex, benches)...); err != nil {
 		log.Fatal(err)
 	}
+	if err := cmdReg.AddRebuildGroups(commands.NewRebuildGroupCmds(t.app, t.rb, modalFn, butler, asst, buildDefs, dex, benches)...); err != nil {
+		log.Fatal(err)
+	}
 	if err := cmdReg.AddRebuilds(commands.NewRebuildCmds(t.app, t.rb, modalFn, butler, asst, buildDefs, dex, benches)...); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
As part of this PR I'm also adding the RebuildGroupCmd type which is similar to RebuildCmd, except it operates over multiple rundex.Rebuild objects.