### PR TITLE
Move truncated message to beginning

### DIFF
--- a/tools/ctl/ide/assistant/session.go
+++ b/tools/ctl/ide/assistant/session.go
@@ -142,7 +142,8 @@ func (a *session) evidence(ctx context.Context, attempt rundex.Rebuild) *attempt
 			}
 		}
 		if len(logs) > uploadBytesLimit {
-			logs = logs[len(logs)-uploadBytesLimit:] + "...(truncated)"
+			offset := len(logs) - uploadBytesLimit
+			logs = fmt.Sprintf("...(truncated %d bytes)...\n%s", offset, logs[offset:])
 		}
 	}
 	var diff string
@@ -158,7 +159,8 @@ func (a *session) evidence(ctx context.Context, attempt rundex.Rebuild) *attempt
 			}
 		}
 		if len(diff) > uploadBytesLimit {
-			diff = diff[len(diff)-uploadBytesLimit:] + "...(truncated)"
+			offset := len(diff) - uploadBytesLimit
+			diff = fmt.Sprintf("...(truncated %d bytes)...\n%s", offset, diff[offset:])
 		}
 	}
 	return &attemptEvidence{metadata: metadata, builddef: builddef, logs: logs, diff: diff}


### PR DESCRIPTION
The truncation behavior is to take the last X bytes, so really the "...truncated..." message should go at the start not the end.