### PR TITLE
refactor: add `Stabilize(any)` method to interface

### DIFF
--- a/pkg/archive/common.go
+++ b/pkg/archive/common.go
@@ -16,7 +16,9 @@ const (
 	RawFormat
 )
 
-type Stabilizer any
+type Stabilizer interface {
+	Stabilize(any)
+}
 
 // StabilizeOpts aggregates stabilizers to be used in stabilization.
 type StabilizeOpts struct {

--- a/pkg/archive/gzip.go
+++ b/pkg/archive/gzip.go
@@ -48,9 +48,6 @@ type GzipStabilizer struct {
 }
 
 func (g GzipStabilizer) Stabilize(arg any) {
-	if g.Func == nil {
-		panic(g.Name + " stabilizer not implemented")
-	}
 	g.Func(arg.(*MutableGzipHeader))
 }
 

--- a/pkg/archive/gzip.go
+++ b/pkg/archive/gzip.go
@@ -48,9 +48,10 @@ type GzipStabilizer struct {
 }
 
 func (g GzipStabilizer) Stabilize(arg any) {
-	if g.Func != nil {
-		g.Func(arg.(*MutableGzipHeader))
+	if g.Func == nil {
+		panic(g.Name + " stabilizer not implemented")
 	}
+	g.Func(arg.(*MutableGzipHeader))
 }
 
 var AllGzipStabilizers = []Stabilizer{

--- a/pkg/archive/gzip.go
+++ b/pkg/archive/gzip.go
@@ -26,7 +26,7 @@ func NewStabilizedGzipWriter(gr *gzip.Reader, w io.Writer, opts StabilizeOpts) (
 	for _, s := range opts.Stabilizers {
 		switch s.(type) {
 		case GzipStabilizer:
-			s.(GzipStabilizer).Func(&mh)
+			s.(GzipStabilizer).Stabilize(&mh)
 		}
 	}
 	gw, err := gzip.NewWriterLevel(w, mh.Compression)
@@ -45,6 +45,12 @@ type MutableGzipHeader struct {
 type GzipStabilizer struct {
 	Name string
 	Func func(*MutableGzipHeader)
+}
+
+func (g GzipStabilizer) Stabilize(arg any) {
+	if g.Func != nil {
+		g.Func(arg.(*MutableGzipHeader))
+	}
 }
 
 var AllGzipStabilizers = []Stabilizer{

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -46,9 +46,21 @@ type TarArchiveStabilizer struct {
 	Func func(*TarArchive)
 }
 
+func (t TarArchiveStabilizer) Stabilize(arg any) {
+	if t.Func != nil {
+		t.Func(arg.(*TarArchive))
+	}
+}
+
 type TarEntryStabilizer struct {
 	Name string
 	Func func(*TarEntry)
+}
+
+func (t TarEntryStabilizer) Stabilize(arg any) {
+	if t.Func != nil {
+		t.Func(arg.(*TarEntry))
+	}
 }
 
 var AllTarStabilizers = []Stabilizer{
@@ -146,10 +158,10 @@ func StabilizeTar(tr *tar.Reader, tw *tar.Writer, opts StabilizeOpts) error {
 	for _, s := range opts.Stabilizers {
 		switch s.(type) {
 		case TarArchiveStabilizer:
-			s.(TarArchiveStabilizer).Func(&f)
+			s.(TarArchiveStabilizer).Stabilize(&f)
 		case TarEntryStabilizer:
 			for _, ent := range f.Files {
-				s.(TarEntryStabilizer).Func(ent)
+				s.(TarEntryStabilizer).Stabilize(ent)
 			}
 		}
 	}

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -47,9 +47,6 @@ type TarArchiveStabilizer struct {
 }
 
 func (t TarArchiveStabilizer) Stabilize(arg any) {
-	if t.Func == nil {
-		panic(t.Name + " stabilizer not implemented")
-	}
 	t.Func(arg.(*TarArchive))
 }
 
@@ -59,9 +56,6 @@ type TarEntryStabilizer struct {
 }
 
 func (t TarEntryStabilizer) Stabilize(arg any) {
-	if t.Func == nil {
-		panic(t.Name + " stabilizer not implemented")
-	}
 	t.Func(arg.(*TarEntry))
 }
 

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -47,9 +47,10 @@ type TarArchiveStabilizer struct {
 }
 
 func (t TarArchiveStabilizer) Stabilize(arg any) {
-	if t.Func != nil {
-		t.Func(arg.(*TarArchive))
+	if t.Func == nil {
+		panic(t.Name + " stabilizer not implemented")
 	}
+	t.Func(arg.(*TarArchive))
 }
 
 type TarEntryStabilizer struct {
@@ -58,9 +59,10 @@ type TarEntryStabilizer struct {
 }
 
 func (t TarEntryStabilizer) Stabilize(arg any) {
-	if t.Func != nil {
-		t.Func(arg.(*TarEntry))
+	if t.Func == nil {
+		panic(t.Name + " stabilizer not implemented")
 	}
+	t.Func(arg.(*TarEntry))
 }
 
 var AllTarStabilizers = []Stabilizer{

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -119,9 +119,7 @@ type ZipArchiveStabilizer struct {
 }
 
 func (z ZipArchiveStabilizer) Stabilize(arg any) {
-	if z.Func != nil {
-		z.Func(arg.(*MutableZipReader))
-	}
+	z.Func(arg.(*MutableZipReader))
 }
 
 type ZipEntryStabilizer struct {
@@ -130,9 +128,10 @@ type ZipEntryStabilizer struct {
 }
 
 func (z ZipEntryStabilizer) Stabilize(arg any) {
-	if z.Func != nil {
-		z.Func(arg.(*MutableZipFile))
+	if z.Func == nil {
+		panic(z.Name + " stabilizer not implemented")
 	}
+	z.Func(arg.(*MutableZipFile))
 }
 
 var AllZipStabilizers = []Stabilizer{

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -128,9 +128,6 @@ type ZipEntryStabilizer struct {
 }
 
 func (z ZipEntryStabilizer) Stabilize(arg any) {
-	if z.Func == nil {
-		panic(z.Name + " stabilizer not implemented")
-	}
 	z.Func(arg.(*MutableZipFile))
 }
 

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -118,9 +118,21 @@ type ZipArchiveStabilizer struct {
 	Func func(*MutableZipReader)
 }
 
+func (z ZipArchiveStabilizer) Stabilize(arg any) {
+	if z.Func != nil {
+		z.Func(arg.(*MutableZipReader))
+	}
+}
+
 type ZipEntryStabilizer struct {
 	Name string
 	Func func(*MutableZipFile)
+}
+
+func (z ZipEntryStabilizer) Stabilize(arg any) {
+	if z.Func != nil {
+		z.Func(arg.(*MutableZipFile))
+	}
 }
 
 var AllZipStabilizers = []Stabilizer{
@@ -209,10 +221,10 @@ func StabilizeZip(zr *zip.Reader, zw *zip.Writer, opts StabilizeOpts) error {
 	for _, s := range opts.Stabilizers {
 		switch s.(type) {
 		case ZipArchiveStabilizer:
-			s.(ZipArchiveStabilizer).Func(&mr)
+			s.(ZipArchiveStabilizer).Stabilize(&mr)
 		case ZipEntryStabilizer:
 			for _, mf := range mr.File {
-				s.(ZipEntryStabilizer).Func(mf)
+				s.(ZipEntryStabilizer).Stabilize(mf)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #425 

The changes mark `Stabilizer` as an interface. For each of its implementations,  I added a method `Stabilize` for example
```go
func (g GzipStabilizer) Stabilize(arg any) {
	if g.Func != nil {
		g.Func(arg.(*MutableGzipHeader))
	}
}
```
Now instead of `Func`, `Stabilize` is invoked everywhere. We could also make `Func` and `Name` fields private but I let them be for now.