### PR TITLE
Move RebuildRemote into Rebuilder

### DIFF
--- a/pkg/rebuild/cratesio/rebuild.go
+++ b/pkg/rebuild/cratesio/rebuild.go
@@ -172,7 +172,15 @@ func RebuildMany(ctx context.Context, inputs []rebuild.Input, mux rebuild.Regist
 }
 
 // RebuildRemote executes the given target strategy on a remote builder.
-func RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
+func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
 	opts.UseTimewarp = false
 	return rebuild.RebuildRemote(ctx, input, id, opts)
+}
+
+func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	crate, err := mux.CratesIO.Version(ctx, t.Package, t.Version)
+	if err != nil {
+		return "", errors.Wrap(err, "fetching crate")
+	}
+	return crate.DownloadURL, nil
 }

--- a/pkg/rebuild/debian/rebuild.go
+++ b/pkg/rebuild/debian/rebuild.go
@@ -82,7 +82,15 @@ func RebuildMany(ctx context.Context, inputs []rebuild.Input, mux rebuild.Regist
 }
 
 // RebuildRemote executes the given target strategy on a remote builder.
-func RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
+func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
 	opts.UseTimewarp = false
 	return rebuild.RebuildRemote(ctx, input, id, opts)
+}
+
+func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	_, name, err := ParseComponent(t.Package)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing package name")
+	}
+	return mux.Debian.ArtifactURL(ctx, name, t.Artifact)
 }

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -31,6 +31,10 @@ func (r TestRegistry) ReleaseFile(_ context.Context, _, _, _ string) (io.ReadClo
 	return io.NopCloser(reader), nil
 }
 
+func (r TestRegistry) ReleaseURL(_ context.Context, _, _, _ string) (string, error) {
+	return "", nil
+}
+
 func TestNewPomXML(t *testing.T) {
 	tests := []struct {
 		testName string

--- a/pkg/rebuild/maven/rebuild.go
+++ b/pkg/rebuild/maven/rebuild.go
@@ -15,6 +15,11 @@ type Rebuilder struct{}
 
 var _ rebuild.Rebuilder = Rebuilder{}
 
+func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
+	opts.UseTimewarp = false
+	return rebuild.RebuildRemote(ctx, input, id, opts)
+}
+
 func (Rebuilder) Rebuild(ctx context.Context, t rebuild.Target, inst rebuild.Instructions, fs billy.Filesystem) error {
 	if _, err := rebuild.ExecuteScript(ctx, fs.Root(), inst.Source); err != nil {
 		return errors.Wrap(err, "fetching source")
@@ -30,6 +35,11 @@ func (Rebuilder) Rebuild(ctx context.Context, t rebuild.Target, inst rebuild.Ins
 
 func (Rebuilder) Compare(ctx context.Context, t rebuild.Target, rb rebuild.Asset, up rebuild.Asset, assets rebuild.AssetStore, inst rebuild.Instructions) (msg error, err error) {
 	return nil, nil
+}
+
+func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	// Assuming the primary artifact is a .jar file.
+	return mux.Maven.ReleaseURL(ctx, t.Package, t.Version, ".jar")
 }
 
 func RebuildMany(ctx context.Context, inputs []rebuild.Input, mux rebuild.RegistryMux) ([]rebuild.Verdict, error) {

--- a/pkg/rebuild/npm/rebuild.go
+++ b/pkg/rebuild/npm/rebuild.go
@@ -177,7 +177,15 @@ func RebuildMany(ctx context.Context, inputs []rebuild.Input, mux rebuild.Regist
 }
 
 // RebuildRemote executes the given target strategy on a remote builder.
-func RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
+func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
 	opts.UseTimewarp = true
 	return rebuild.RebuildRemote(ctx, input, id, opts)
+}
+
+func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	vmeta, err := mux.NPM.Version(ctx, t.Package, t.Version)
+	if err != nil {
+		return "", errors.Wrap(err, "fetching metadata failed")
+	}
+	return vmeta.Dist.URL, nil
 }

--- a/pkg/rebuild/pypi/rebuild.go
+++ b/pkg/rebuild/pypi/rebuild.go
@@ -109,7 +109,20 @@ func RebuildMany(ctx context.Context, inputs []rebuild.Input, mux rebuild.Regist
 }
 
 // RebuildRemote executes the given target strategy on a remote builder.
-func RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
+func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, id string, opts rebuild.RemoteOptions) error {
 	opts.UseTimewarp = true
 	return rebuild.RebuildRemote(ctx, input, id, opts)
+}
+
+func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	release, err := mux.PyPI.Release(ctx, t.Package, t.Version)
+	if err != nil {
+		return "", errors.Wrap(err, "fetching project failed")
+	}
+	for _, a := range release.Artifacts {
+		if a.Filename == t.Artifact {
+			return a.URL, nil
+		}
+	}
+	return "", errors.New("artifact not found")
 }

--- a/pkg/rebuild/rebuild/rebuild.go
+++ b/pkg/rebuild/rebuild/rebuild.go
@@ -17,4 +17,6 @@ type Rebuilder interface {
 	InferStrategy(context.Context, Target, RegistryMux, *RepoConfig, Strategy) (Strategy, error)
 	Rebuild(context.Context, Target, Instructions, billy.Filesystem) error
 	Compare(context.Context, Target, Asset, Asset, AssetStore, Instructions) (error, error)
+	RebuildRemote(context.Context, Input, string, RemoteOptions) error
+	UpstreamURL(context.Context, Target, RegistryMux) (string, error)
 }

--- a/pkg/registry/maven/maven.go
+++ b/pkg/registry/maven/maven.go
@@ -23,6 +23,7 @@ import (
 var (
 	// Maven Central registry.
 	registryURL = urlx.MustParse("https://search.maven.org")
+	releaseURL  = urlx.MustParse("https://repo1.maven.org/maven2")
 	// Maven path component.
 	registryContentPathURL = urlx.MustParse("remotecontent")
 	registrySearchPathURL  = urlx.MustParse(path.Join("solrsearch", "select"))
@@ -80,6 +81,7 @@ type Registry interface {
 	PackageMetadata(context.Context, string) (*MavenPackage, error)
 	PackageVersion(context.Context, string, string) (*MavenVersion, error)
 	ReleaseFile(context.Context, string, string, string) (io.ReadCloser, error)
+	ReleaseURL(context.Context, string, string, string) (string, error)
 }
 
 // HTTPRegistry is a Registry implementation that uses the search.maven.org HTTP API.
@@ -145,15 +147,11 @@ func (r HTTPRegistry) PackageMetadata(ctx context.Context, pkg string) (result *
 
 // ReleaseFile returns a release file for a Maven package version.
 func (r HTTPRegistry) ReleaseFile(ctx context.Context, pkg, version string, typ string) (io.ReadCloser, error) {
-	g, a, found := strings.Cut(pkg, ":")
-	if !found {
-		return nil, errors.New("package identifier not of form 'group:artifact'")
+	releaseURL, err := r.ReleaseURL(ctx, pkg, version, typ)
+	if err != nil {
+		return nil, err
 	}
-	pathUrl := registryURL.ResolveReference(registryContentPathURL)
-	searchPath := path.Join(strings.ReplaceAll(g, ".", "/"), a, version, fmt.Sprintf("%s-%s%s", a, version, typ))
-	// Note that search.maven expects the / tokens in the query parameter not to be HTML-encoded.
-	pathUrl.RawQuery = fmt.Sprintf("filepath=%s", searchPath)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, pathUrl.String(), nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, releaseURL, nil)
 	resp, err := r.Client.Do(req)
 	if err != nil {
 		return nil, err
@@ -163,4 +161,15 @@ func (r HTTPRegistry) ReleaseFile(ctx context.Context, pkg, version string, typ 
 	}
 
 	return resp.Body, nil
+}
+
+// ReleaseURL returns the URL for the release file for a Maven package version.
+func (r HTTPRegistry) ReleaseURL(ctx context.Context, pkg, version, typ string) (string, error) {
+	g, a, found := strings.Cut(pkg, ":")
+	if !found {
+		return "", errors.New("package identifier not of form 'group:artifact'")
+	}
+	artifactPath := path.Join(strings.ReplaceAll(g, ".", "/"), a, version, fmt.Sprintf("%s-%s%s", a, version, typ))
+	artifactURL := releaseURL.ResolveReference(urlx.MustParse(artifactPath))
+	return artifactURL.String(), nil
 }


### PR DESCRIPTION
Also adds UpstreamURL method to facilitate porting off of do<Ecosystem>Rebuild
pattern in rebuild logic.