### PR TITLE
Fix terraform output dependency

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -352,35 +352,35 @@ module "prebuild_binaries" {
 data "google_artifact_registry_docker_image" "gateway" {
   location      = google_artifact_registry_repository.registry.location
   repository_id = google_artifact_registry_repository.registry.repository_id
-  image_name    = "gateway:${terraform_data.service_version.output}"
+  image_name = "gateway:${module.service_images["gateway"].image_version}"
   depends_on    = [module.service_images["gateway"]]
 }
 
 data "google_artifact_registry_docker_image" "git-cache" {
   location      = google_artifact_registry_repository.registry.location
   repository_id = google_artifact_registry_repository.registry.repository_id
-  image_name    = "git_cache:${terraform_data.service_version.output}"
+  image_name    = "git_cache:${module.service_images["git_cache"].image_version}"
   depends_on    = [module.service_images["git_cache"]]
 }
 
 data "google_artifact_registry_docker_image" "rebuilder" {
   location      = google_artifact_registry_repository.registry.location
   repository_id = google_artifact_registry_repository.registry.repository_id
-  image_name    = "rebuilder:${terraform_data.service_version.output}"
+  image_name    = "rebuilder:${module.service_images["rebuilder"].image_version}"
   depends_on    = [module.service_images["rebuilder"]]
 }
 
 data "google_artifact_registry_docker_image" "inference" {
   location      = google_artifact_registry_repository.registry.location
   repository_id = google_artifact_registry_repository.registry.repository_id
-  image_name    = "inference:${terraform_data.service_version.output}"
+  image_name    = "inference:${module.service_images["inference"].image_version}"
   depends_on    = [module.service_images["inference"]]
 }
 
 data "google_artifact_registry_docker_image" "api" {
   location      = google_artifact_registry_repository.registry.location
   repository_id = google_artifact_registry_repository.registry.repository_id
-  image_name    = "api:${terraform_data.service_version.output}"
+  image_name    = "api:${module.service_images["api"].image_version}"
   depends_on    = [module.service_images["api"]]
 }
 

--- a/deployments/modules/container_binary_upload/main.tf
+++ b/deployments/modules/container_binary_upload/main.tf
@@ -1,11 +1,19 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-resource "terraform_data" "extract" {
+resource "terraform_data" "extract_deps" {
   input = {
     source_image = var.source_image_url
     binary_name = var.binary_name
     gcs_path = var.gcs_destination
+  }
+}
+
+resource "terraform_data" "extract" {
+  input = terraform_data.extract_deps.output
+
+  lifecycle {
+    replace_triggered_by =  [terraform_data.extract_deps]
   }
 
   provisioner "local-exec" {

--- a/deployments/modules/container_build_push/main.tf
+++ b/deployments/modules/container_build_push/main.tf
@@ -25,7 +25,7 @@ locals {
   build_args_str = join(" ", [for arg in var.build_args : "--build-arg ${arg}"])
 }
 
-resource "terraform_data" "image" {
+resource "terraform_data" "image_deps" {
   input = {
     name          = var.name
     image_url     = var.image_url
@@ -33,6 +33,14 @@ resource "terraform_data" "image" {
     repo          = local.repo
     commit        = var.commit,
     # NOTE: Exclude var.build_args and var.dockerfile_path since they don't affect the image URL.
+  }
+}
+
+resource "terraform_data" "image" {
+  input = terraform_data.image_deps.output
+
+  lifecycle {
+    replace_triggered_by =  [terraform_data.image_deps]
   }
 
   provisioner "local-exec" {

--- a/deployments/modules/container_build_push/outputs.tf
+++ b/deployments/modules/container_build_push/outputs.tf
@@ -3,20 +3,20 @@
 
 output "full_image_url" {
   description = "Complete image URL with tag"
-  value       = "${var.image_url}:${var.image_version}"
+  value       = "${terraform_data.image.output.image_url}:${terraform_data.image.output.image_version}"
 }
 
 output "image_url" {
   description = "Image URL without tag"
-  value       = var.image_url
+  value       = terraform_data.image.output.image_url
 }
 
 output "image_version" {
   description = "Image version/tag"
-  value       = var.image_version
+  value       = terraform_data.image.output.image_version
 }
 
 output "name" {
   description = "Service name"
-  value       = var.name
+  value       = terraform_data.image.output.name
 }


### PR DESCRIPTION
Changing the outputs makes sure that terraform will wait for the images
to be built before proceeding.