### PR TITLE
Wrap python requirements with single quotes

### DIFF
--- a/pkg/rebuild/pypi/strategy.go
+++ b/pkg/rebuild/pypi/strategy.go
@@ -86,7 +86,7 @@ var toolkit = []*flow.Tool{
 			Runs: textwrap.Dedent(`
 				{{.With.locator}}pip install build
 				{{- range $req := .With.requirements | fromJSON}}
-				{{$.With.locator}}pip install {{$req}}{{end}}`)[1:],
+				{{$.With.locator}}pip install '{{regexReplace $req "'" "'\\''"}}'{{end}}`)[1:],
 			Needs: []string{"python3"},
 		}},
 	},

--- a/pkg/rebuild/pypi/strategy_test.go
+++ b/pkg/rebuild/pypi/strategy_test.go
@@ -33,8 +33,25 @@ func TestPureWheelBuild(t *testing.T) {
 				Source:   "git checkout --force 'the_ref'",
 				Deps: `/usr/bin/python3 -m venv /deps
 /deps/bin/pip install build
-/deps/bin/pip install req_1
-/deps/bin/pip install req_2`,
+/deps/bin/pip install 'req_1'
+/deps/bin/pip install 'req_2'`,
+				Build:      "/deps/bin/python3 -m build --wheel -n the_dir",
+				SystemDeps: []string{"git", "python3"},
+				OutputPath: "dist/the_artifact",
+			},
+		},
+		{
+			"DepsEscaping",
+			&PureWheelBuild{
+				Location:     defaultLocation,
+				Requirements: []string{"req_1<='1.2.3'"},
+			},
+			rebuild.Instructions{
+				Location: defaultLocation,
+				Source:   "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/python3 -m venv /deps
+/deps/bin/pip install build
+/deps/bin/pip install 'req_1<='\''1.2.3'\'''`,
 				Build:      "/deps/bin/python3 -m build --wheel -n the_dir",
 				SystemDeps: []string{"git", "python3"},
 				OutputPath: "dist/the_artifact",


### PR DESCRIPTION
This avoids < and > being interpreted as shell redirects

To support single quotes inside the requirement spec, I added bash escaping for those quotes.