### PR TITLE
Create new build abstraction

### DIFF
--- a/pkg/build/baseimage.go
+++ b/pkg/build/baseimage.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import "github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+
+type BaseImageConfig struct {
+	Default    string                       `json:"default"`
+	Ecosystems map[rebuild.Ecosystem]string `json:"ecosystems"`
+}
+
+func (c BaseImageConfig) SelectFor(input rebuild.Input) string {
+	if img, ok := c.Ecosystems[input.Target.Ecosystem]; ok {
+		return img
+	}
+	return c.Default
+}
+
+func DefaultBaseImageConfig() BaseImageConfig {
+	return BaseImageConfig{
+		Default: "docker.io/library/alpine:3.19",
+		Ecosystems: map[rebuild.Ecosystem]string{
+			rebuild.Debian: "docker.io/library/debian:trixie-20250203-slim",
+		},
+	}
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"context"
+	"io"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// ToolType represents types of tools used during builds
+type ToolType string
+
+const (
+	TimewarpTool ToolType = "timewarp"
+	ProxyTool    ToolType = "proxy"
+	GSUtilTool   ToolType = "gsutil_writeonly"
+)
+
+// Executor manages build execution for a specific backend
+type Executor interface {
+	Start(ctx context.Context, input rebuild.Input, opts Options) (Handle, error)
+	Status() ExecutorStatus
+	Close(ctx context.Context) error
+}
+
+// Handle represents an active or completed build
+type Handle interface {
+	BuildID() string
+	Wait(ctx context.Context) (Result, error)
+	OutputStream() io.Reader
+	Status() BuildState
+}
+
+// Result represents the completed build result
+type Result struct {
+	// Error represents a build-time failure (i.e. after build setup)
+	Error error
+	// Timings describes execution duration of various aspects of the build
+	Timings rebuild.Timings
+}
+
+// ExecutorStatus represents the overall executor status
+type ExecutorStatus struct {
+	// InProgress is the number of builds currently executing
+	InProgress int
+	// Capacity is the max number of builds that can be exected simultanously
+	Capacity int
+	// Healthy is whether the executor is accepting new builds
+	Healthy bool
+}
+
+// BuildState represents the current state of a build
+type BuildState int
+
+const (
+	BuildStateStarting BuildState = iota
+	BuildStateRunning
+	BuildStateCompleted
+	BuildStateCancelled
+)
+
+func (s BuildState) String() string {
+	switch s {
+	case BuildStateStarting:
+		return "starting"
+	case BuildStateRunning:
+		return "running"
+	case BuildStateCompleted:
+		return "completed"
+	case BuildStateCancelled:
+		return "cancelled"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"time"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// Resources configures URLs and authentication for build resources
+type Resources struct {
+	// AssetStore provides URLs and writing capabilities for build assets
+	AssetStore rebuild.LocatableAssetStore
+	// ToolURLs maps tool types to their download URLs
+	ToolURLs map[ToolType]string
+	// ToolAuthRequired lists URL prefixes that require authentication for tools
+	ToolAuthRequired []string
+	// BaseImageConfig defines the selection criteria for base images
+	BaseImageConfig BaseImageConfig
+}
+
+// Options configures build execution behavior
+type Options struct {
+	// CancelPolicy determines how cancellation is handled
+	CancelPolicy CancelPolicy
+	// Timeout for the build execution
+	// TODO: Consider changing to Deadline
+	Timeout time.Duration
+	// BuildID allows specifying a custom build identifier
+	BuildID string
+	// UseTimewarp enables timewarp functionality for builds
+	UseTimewarp bool
+	// UseNetworkProxy enables network proxy functionality
+	UseNetworkProxy bool
+	// UseSyscallMonitor enables syscall monitoring
+	UseSyscallMonitor bool
+	// Resources configures URLs and authentication for build resources
+	Resources Resources
+}
+
+// PlanOptions configures plan generation behavior and resources
+type PlanOptions struct {
+	// UseTimewarp enables timewarp functionality for builds
+	UseTimewarp bool
+	// UseNetworkProxy enables network proxy functionality
+	UseNetworkProxy bool
+	// UseSyscallMonitor enables syscall monitoring
+	UseSyscallMonitor bool
+	// PreferPreciseToolchain indicates whether to use precise toolchain versions
+	PreferPreciseToolchain bool
+	// Resources configures URLs and authentication for build resources
+	Resources Resources
+}
+
+// CancelPolicy determines how build cancellation is handled
+type CancelPolicy int
+
+const (
+	// CancelImmediate terminates the build immediately
+	CancelImmediate CancelPolicy = iota
+	// CancelGraceful allows the build to finish current step before cancelling
+	CancelGraceful
+	// CancelDetached allows the build to continue running but detaches the handle
+	CancelDetached
+)
+
+func (p CancelPolicy) String() string {
+	switch p {
+	case CancelImmediate:
+		return "immediate"
+	case CancelGraceful:
+		return "graceful"
+	case CancelDetached:
+		return "detached"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/build/packagemanager.go
+++ b/pkg/build/packagemanager.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"slices"
+	"strings"
+)
+
+// OS represents a supported operating system/distribution
+type OS string
+
+const (
+	Alpine OS = "alpine"
+	Debian OS = "debian"
+	Ubuntu OS = "ubuntu"
+	CentOS OS = "centos"
+)
+
+// PackageManagerCommands contains the commands needed for package management on a specific OS
+type PackageManagerCommands struct {
+	UpdateCmd   string
+	InstallCmd  string
+	InstallArgs []string
+}
+
+// InstallCommand generates the full package installation command for the given packages
+func (p PackageManagerCommands) InstallCommand(packages []string) string {
+	cmdArgs := slices.Concat([]string{p.InstallCmd}, p.InstallArgs, packages)
+	return strings.Join(cmdArgs, " ")
+}
+
+// osPackageManagers maps operating systems to their package manager commands
+var osPackageManagers = map[OS]PackageManagerCommands{
+	Alpine: {
+		UpdateCmd:  "apk update",
+		InstallCmd: "apk add",
+		// TODO: Add --no-cache
+		InstallArgs: []string{},
+	},
+	Debian: {
+		UpdateCmd:  "apt update",
+		InstallCmd: "apt install",
+		// TODO: Add --no-install-recommends
+		InstallArgs: []string{"-y"},
+	},
+	Ubuntu: {
+		UpdateCmd:   "apt update",
+		InstallCmd:  "apt install",
+		InstallArgs: []string{"-y"},
+	},
+	CentOS: {
+		UpdateCmd:   "yum update -y",
+		InstallCmd:  "yum install",
+		InstallArgs: []string{"-y"},
+	},
+}
+
+// GetPackageManagerCommands returns the package manager commands for the given OS
+func GetPackageManagerCommands(os OS) PackageManagerCommands {
+	if cmd, ok := osPackageManagers[os]; ok {
+		return cmd
+	}
+	return osPackageManagers[Alpine] // Not necessarily accurate but generally a safe assumption
+}
+
+// DetectOS detects the OS from a base image name
+func DetectOS(baseImage string) OS {
+	switch {
+	case strings.Contains(baseImage, "alpine"):
+		return Alpine
+	case strings.Contains(baseImage, "debian"):
+		return Debian
+	case strings.Contains(baseImage, "ubuntu"):
+		return Ubuntu
+	case strings.Contains(baseImage, "centos"), strings.Contains(baseImage, "rhel"):
+		return CentOS
+	default:
+		return Alpine // safe default
+	}
+}

--- a/pkg/build/packagemanager_test.go
+++ b/pkg/build/packagemanager_test.go
@@ -1,0 +1,266 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"testing"
+)
+
+func TestPackageManagerCommands_InstallCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      PackageManagerCommands
+		packages []string
+		want     string
+	}{
+		{
+			name: "Alpine with single package",
+			cmd: PackageManagerCommands{
+				InstallCmd:  "apk add",
+				InstallArgs: []string{},
+			},
+			packages: []string{"curl"},
+			want:     "apk add curl",
+		},
+		{
+			name: "Alpine with multiple packages",
+			cmd: PackageManagerCommands{
+				InstallCmd:  "apk add",
+				InstallArgs: []string{},
+			},
+			packages: []string{"curl", "wget", "git"},
+			want:     "apk add curl wget git",
+		},
+		{
+			name: "Ubuntu with packages",
+			cmd: PackageManagerCommands{
+				InstallCmd:  "apt install",
+				InstallArgs: []string{"-y"},
+			},
+			packages: []string{"python3", "python3-pip"},
+			want:     "apt install -y python3 python3-pip",
+		},
+		{
+			name: "Empty package list",
+			cmd: PackageManagerCommands{
+				InstallCmd:  "apk add",
+				InstallArgs: []string{},
+			},
+			packages: []string{},
+			want:     "apk add",
+		},
+		{
+			name: "No install args",
+			cmd: PackageManagerCommands{
+				InstallCmd:  "pacman -S",
+				InstallArgs: []string{},
+			},
+			packages: []string{"vim"},
+			want:     "pacman -S vim",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cmd.InstallCommand(tt.packages)
+			if got != tt.want {
+				t.Errorf("InstallCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPackageManagerCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		os   OS
+		want PackageManagerCommands
+	}{
+		{
+			name: "Alpine",
+			os:   Alpine,
+			want: PackageManagerCommands{
+				UpdateCmd:   "apk update",
+				InstallCmd:  "apk add",
+				InstallArgs: []string{},
+			},
+		},
+		{
+			name: "Debian",
+			os:   Debian,
+			want: PackageManagerCommands{
+				UpdateCmd:   "apt update",
+				InstallCmd:  "apt install",
+				InstallArgs: []string{"-y"},
+			},
+		},
+		{
+			name: "Ubuntu",
+			os:   Ubuntu,
+			want: PackageManagerCommands{
+				UpdateCmd:   "apt update",
+				InstallCmd:  "apt install",
+				InstallArgs: []string{"-y"},
+			},
+		},
+		{
+			name: "CentOS",
+			os:   CentOS,
+			want: PackageManagerCommands{
+				UpdateCmd:   "yum update -y",
+				InstallCmd:  "yum install",
+				InstallArgs: []string{"-y"},
+			},
+		},
+		{
+			name: "Unknown OS defaults to Alpine",
+			os:   OS("unknown"),
+			want: PackageManagerCommands{
+				UpdateCmd:   "apk update",
+				InstallCmd:  "apk add",
+				InstallArgs: []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPackageManagerCommands(tt.os)
+			if got.UpdateCmd != tt.want.UpdateCmd {
+				t.Errorf("GetPackageManagerCommands().UpdateCmd = %v, want %v", got.UpdateCmd, tt.want.UpdateCmd)
+			}
+			if got.InstallCmd != tt.want.InstallCmd {
+				t.Errorf("GetPackageManagerCommands().InstallCmd = %v, want %v", got.InstallCmd, tt.want.InstallCmd)
+			}
+			if len(got.InstallArgs) != len(tt.want.InstallArgs) {
+				t.Errorf("GetPackageManagerCommands().InstallArgs length = %v, want %v", len(got.InstallArgs), len(tt.want.InstallArgs))
+			}
+			for i, arg := range got.InstallArgs {
+				if i < len(tt.want.InstallArgs) && arg != tt.want.InstallArgs[i] {
+					t.Errorf("GetPackageManagerCommands().InstallArgs[%d] = %v, want %v", i, arg, tt.want.InstallArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDetectOS(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseImage string
+		want      OS
+	}{
+		{
+			name:      "Alpine latest",
+			baseImage: "alpine:latest",
+			want:      Alpine,
+		},
+		{
+			name:      "Alpine with version",
+			baseImage: "alpine:3.19",
+			want:      Alpine,
+		},
+		{
+			name:      "Alpine in compound name",
+			baseImage: "node:18-alpine",
+			want:      Alpine,
+		},
+		{
+			name:      "Debian latest",
+			baseImage: "debian:latest",
+			want:      Debian,
+		},
+		{
+			name:      "Debian with version",
+			baseImage: "debian:bullseye",
+			want:      Debian,
+		},
+		{
+			name:      "Ubuntu latest",
+			baseImage: "ubuntu:latest",
+			want:      Ubuntu,
+		},
+		{
+			name:      "Ubuntu with version",
+			baseImage: "ubuntu:22.04",
+			want:      Ubuntu,
+		},
+		{
+			name:      "Ubuntu in compound name",
+			baseImage: "python:3.11-ubuntu",
+			want:      Ubuntu,
+		},
+		{
+			name:      "CentOS",
+			baseImage: "centos:7",
+			want:      CentOS,
+		},
+		{
+			name:      "CentOS latest",
+			baseImage: "centos:latest",
+			want:      CentOS,
+		},
+		{
+			name:      "RHEL",
+			baseImage: "rhel:8",
+			want:      CentOS,
+		},
+		{
+			name:      "RHEL UBI",
+			baseImage: "registry.redhat.io/ubi8/rhel",
+			want:      CentOS,
+		},
+		{
+			name:      "Unknown image defaults to Alpine",
+			baseImage: "scratch",
+			want:      Alpine,
+		},
+		{
+			name:      "Random image defaults to Alpine",
+			baseImage: "busybox:latest",
+			want:      Alpine,
+		},
+		{
+			name:      "Empty string defaults to Alpine",
+			baseImage: "",
+			want:      Alpine,
+		},
+		{
+			name:      "Case sensitivity test",
+			baseImage: "ALPINE:latest",
+			want:      Alpine,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectOS(tt.baseImage)
+			if got != tt.want {
+				t.Errorf("DetectOS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOSConstants(t *testing.T) {
+	// Test that OS constants have expected values
+	tests := []struct {
+		name string
+		os   OS
+		want string
+	}{
+		{"Alpine constant", Alpine, "alpine"},
+		{"Debian constant", Debian, "debian"},
+		{"Ubuntu constant", Ubuntu, "ubuntu"},
+		{"CentOS constant", CentOS, "centos"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.os) != tt.want {
+				t.Errorf("OS constant %v = %v, want %v", tt.name, string(tt.os), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/build/plan.go
+++ b/pkg/build/plan.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"context"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// Plan represents any execution plan type.
+type Plan any
+
+// Planner is a generic interface for generating execution plans from rebuild inputs.
+// Each executor type expects a specific Plan type so any conformant planner can be used.
+type Planner[T Plan] interface {
+	GeneratePlan(ctx context.Context, input rebuild.Input, opts PlanOptions) (T, error)
+}

--- a/pkg/build/url.go
+++ b/pkg/build/url.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// gsToHTTP converts a gs:// URL to an HTTP URL
+func gsToHTTP(gsURL string) (string, error) {
+	if !strings.HasPrefix(gsURL, "gs://") {
+		return "", fmt.Errorf("not a gs:// URL: %s", gsURL)
+	}
+	u, err := url.Parse(gsURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid gs:// URL: %w", err)
+	}
+	bucket := u.Host
+	object := strings.TrimPrefix(u.Path, "/")
+	httpURL := fmt.Sprintf("https://storage.googleapis.com/%s/%s", bucket, object)
+	return httpURL, nil
+}
+
+// NeedsAuth determines if a URL requires authentication based on configured prefixes
+func NeedsAuth(url string, authPrefixes []string) bool {
+	for _, prefix := range authPrefixes {
+		if strings.HasPrefix(url, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ConvertURLForRuntime converts a storage URL to a runtime-appropriate URL
+// For example, converts gs:// URLs to HTTP URLs
+func ConvertURLForRuntime(originalURL string) (string, error) {
+	if strings.HasPrefix(originalURL, "gs://") {
+		return gsToHTTP(originalURL)
+	}
+	// For other URL schemes, return as-is
+	return originalURL, nil
+}

--- a/pkg/build/url_test.go
+++ b/pkg/build/url_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"testing"
+)
+
+func TestGSToHTTP(t *testing.T) {
+	tests := []struct {
+		name     string
+		gsURL    string
+		wantHTTP string
+		wantErr  bool
+	}{
+		{
+			name:     "basic gs URL",
+			gsURL:    "gs://bucket/object",
+			wantHTTP: "https://storage.googleapis.com/bucket/object",
+			wantErr:  false,
+		},
+		{
+			name:    "non-gs URL",
+			gsURL:   "http://example.com/file",
+			wantErr: true,
+		},
+		{
+			name:     "invalid URL",
+			gsURL:    "gs://",
+			wantHTTP: "https://storage.googleapis.com//",
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpURL, err := gsToHTTP(tt.gsURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GSToHTTP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if httpURL != tt.wantHTTP {
+				t.Errorf("GSToHTTP() httpURL = %v, want %v", httpURL, tt.wantHTTP)
+			}
+		})
+	}
+}
+
+func TestNeedsAuth(t *testing.T) {
+	authPrefixes := []string{"gs://", "https://private.example.com/"}
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{
+			name: "gs URL needs auth",
+			url:  "gs://bucket/object",
+			want: true,
+		},
+		{
+			name: "private URL needs auth",
+			url:  "https://private.example.com/file",
+			want: true,
+		},
+		{
+			name: "public URL no auth",
+			url:  "https://public.example.com/file",
+			want: false,
+		},
+		{
+			name: "http URL no auth",
+			url:  "http://example.com/file",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NeedsAuth(tt.url, authPrefixes); got != tt.want {
+				t.Errorf("NeedsAuth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertURLForRuntime(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalURL string
+		wantURL     string
+		wantErr     bool
+	}{
+		{
+			name:        "gs URL converted",
+			originalURL: "gs://bucket/object",
+			wantURL:     "https://storage.googleapis.com/bucket/object",
+			wantErr:     false,
+		},
+		{
+			name:        "http URL unchanged",
+			originalURL: "http://example.com/file",
+			wantURL:     "http://example.com/file",
+			wantErr:     false,
+		},
+		{
+			name:        "https URL unchanged",
+			originalURL: "https://example.com/file",
+			wantURL:     "https://example.com/file",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, err := ConvertURLForRuntime(tt.originalURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertURLForRuntime() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotURL != tt.wantURL {
+				t.Errorf("ConvertURLForRuntime() gotURL = %v, want %v", gotURL, tt.wantURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The upshot is we can split and reuse methods of executing builds from the way
we compose the builds themselves. This should give us cleaner abstractions to
express our existing builds as well as allow for greater reuse in developing
future build types.