### PR TITLE
Add a generic wrapper for sync.Map

### DIFF
--- a/internal/syncx/genericmap.go
+++ b/internal/syncx/genericmap.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package syncx
+
+import (
+	"iter"
+	"sync"
+)
+
+// Map is a type-safe wrapper around sync.Map for general use.
+// It also has some fun additions like enumeration, key, and value iterators.
+type Map[K comparable, V any] struct {
+	m sync.Map
+}
+
+// Clear deletes all the entries, resulting in an empty Map.
+func (m *Map[K, V]) Clear() {
+	m.m.Clear()
+}
+
+// Delete deletes the value for a key.
+func (m *Map[K, V]) Delete(key K) {
+	m.m.Delete(key)
+}
+
+// Load returns the value stored in the map for a key, or the zero value if no
+// value is present. The ok result indicates whether value was found in the map.
+func (m *Map[K, V]) Load(key K) (value V, ok bool) {
+	v, ok := m.m.Load(key)
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// LoadAndDelete deletes the value for a key, returning the previous value if any.
+// The loaded result reports whether the key was present.
+func (m *Map[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
+	v, loaded := m.m.LoadAndDelete(key)
+	if !loaded {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	a, loaded := m.m.LoadOrStore(key, value)
+	return a.(V), loaded
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+func (m *Map[K, V]) Range(f func(key K, value V) bool) {
+	m.m.Range(func(key, value any) bool {
+		return f(key.(K), value.(V))
+	})
+}
+
+// Store sets the value for a key.
+func (m *Map[K, V]) Store(key K, value V) {
+	m.m.Store(key, value)
+}
+
+// Swap swaps the value for a key and returns the previous value if any.
+// The loaded result reports whether the key was present.
+func (m *Map[K, V]) Swap(key K, value V) (previous V, loaded bool) {
+	p, loaded := m.m.Swap(key, value)
+	if !loaded {
+		var zero V
+		return zero, false
+	}
+	return p.(V), true
+}
+
+// Iter returns an iterator over key-value pairs in the map.
+// The iteration order is not specified and is not guaranteed to be the same from one call to the next.
+func (m *Map[K, V]) Iter() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		m.m.Range(func(key, value any) bool {
+			return yield(key.(K), value.(V))
+		})
+	}
+}
+
+// Keys returns an iterator over the keys in the map.
+func (m *Map[K, V]) Keys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		m.m.Range(func(key, value any) bool {
+			return yield(key.(K))
+		})
+	}
+}
+
+// Values returns an iterator over the values in the map.
+func (m *Map[K, V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		m.m.Range(func(key, value any) bool {
+			return yield(value.(V))
+		})
+	}
+}
+
+// ComparableMap is a type-safe wrapper around sync.Map where both keys and values
+// are comparable, enabling compare-and-swap/delete operations.
+type ComparableMap[K comparable, V comparable] struct {
+	Map[K, V]
+}
+
+// CompareAndDelete deletes the entry for key if its value is equal to old.
+func (m *ComparableMap[K, V]) CompareAndDelete(key K, old V) (deleted bool) {
+	return m.m.CompareAndDelete(key, old)
+}
+
+// CompareAndSwap swaps the old and new values for key
+// if the value stored in the map is equal to old.
+func (m *ComparableMap[K, V]) CompareAndSwap(key K, old, new V) (swapped bool) {
+	return m.m.CompareAndSwap(key, old, new)
+}

--- a/internal/syncx/genericmap_test.go
+++ b/internal/syncx/genericmap_test.go
@@ -1,0 +1,377 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package syncx
+
+import (
+	"maps"
+	"sync"
+	"testing"
+)
+
+func TestMap_BasicOperations(t *testing.T) {
+	m := &Map[string, int]{}
+
+	// Test Store and Load
+	m.Store("key1", 100)
+
+	value, ok := m.Load("key1")
+	if !ok {
+		t.Error("Expected key1 to exist")
+	}
+	if value != 100 {
+		t.Errorf("Expected value 100, got %d", value)
+	}
+
+	// Test Load with non-existent key
+	value, ok = m.Load("nonexistent")
+	if ok {
+		t.Error("Expected nonexistent key to not exist")
+	}
+	if value != 0 {
+		t.Errorf("Expected zero value 0, got %d", value)
+	}
+}
+
+func TestMap_Delete(t *testing.T) {
+	m := &Map[string, int]{}
+
+	m.Store("key1", 100)
+	m.Store("key2", 200)
+
+	m.Delete("key1")
+
+	_, ok := m.Load("key1")
+	if ok {
+		t.Error("Expected key1 to be deleted")
+	}
+
+	// Delete non-existent key
+	m.Delete("nonexistent")
+}
+
+func TestMap_LoadAndDelete(t *testing.T) {
+	m := &Map[string, int]{}
+
+	m.Store("key1", 100)
+
+	value, loaded := m.LoadAndDelete("key1")
+	if !loaded {
+		t.Error("Expected key1 to be loaded")
+	}
+	if value != 100 {
+		t.Errorf("Expected value 100, got %d", value)
+	}
+
+	// LoadAndDelete non-existent key
+	value, loaded = m.LoadAndDelete("nonexistent")
+	if loaded {
+		t.Error("Expected nonexistent key to not be loaded")
+	}
+	if value != 0 {
+		t.Errorf("Expected zero value 0, got %d", value)
+	}
+}
+
+func TestMap_LoadOrStore(t *testing.T) {
+	m := &Map[string, int]{}
+
+	// Store new value
+	actual, loaded := m.LoadOrStore("key1", 100)
+	if loaded {
+		t.Error("Expected key1 to not be loaded (new key)")
+	}
+	if actual != 100 {
+		t.Errorf("Expected actual value 100, got %d", actual)
+	}
+
+	// Load existing value
+	actual, loaded = m.LoadOrStore("key1", 200)
+	if !loaded {
+		t.Error("Expected key1 to be loaded (existing key)")
+	}
+	if actual != 100 {
+		t.Errorf("Expected actual value 100 (original), got %d", actual)
+	}
+}
+
+func TestMap_Swap(t *testing.T) {
+	m := &Map[string, int]{}
+
+	// Swap on non-existent key
+	previous, loaded := m.Swap("key1", 100)
+	if loaded {
+		t.Error("Expected key1 to not be loaded (new key)")
+	}
+	if previous != 0 {
+		t.Errorf("Expected zero value 0, got %d", previous)
+	}
+
+	// Swap on existing key
+	previous, loaded = m.Swap("key1", 200)
+	if !loaded {
+		t.Error("Expected key1 to be loaded (existing key)")
+	}
+	if previous != 100 {
+		t.Errorf("Expected previous value 100, got %d", previous)
+	}
+
+	// Verify new value
+	value, ok := m.Load("key1")
+	if !ok || value != 200 {
+		t.Errorf("Expected new value 200, got %d", value)
+	}
+}
+
+func TestMap_Clear(t *testing.T) {
+	m := &Map[string, int]{}
+
+	m.Store("key1", 100)
+	m.Store("key2", 200)
+	m.Store("key3", 300)
+
+	m.Clear()
+
+	_, ok := m.Load("key1")
+	if ok {
+		t.Error("Expected all keys to be cleared")
+	}
+}
+
+func TestMap_Range(t *testing.T) {
+	m := &Map[string, int]{}
+
+	expected := map[string]int{
+		"key1": 100,
+		"key2": 200,
+		"key3": 300,
+	}
+
+	for k, v := range expected {
+		m.Store(k, v)
+	}
+
+	found := make(map[string]int)
+	m.Range(func(key string, value int) bool {
+		found[key] = value
+		return true
+	})
+
+	if len(found) != len(expected) {
+		t.Errorf("Expected %d items, got %d", len(expected), len(found))
+	}
+
+	for k, v := range expected {
+		if found[k] != v {
+			t.Errorf("Expected found[%s] = %d, got %d", k, v, found[k])
+		}
+	}
+
+	// Test early termination
+	count := 0
+	m.Range(func(key string, value int) bool {
+		count++
+		return count < 2 // Stop after 2 iterations
+	})
+
+	if count != 2 {
+		t.Errorf("Expected range to stop after 2 iterations, got %d", count)
+	}
+}
+
+func TestMap_Iterators(t *testing.T) {
+	m := &Map[string, int]{}
+
+	expected := map[string]int{
+		"key1": 100,
+		"key2": 200,
+		"key3": 300,
+	}
+
+	for k, v := range expected {
+		m.Store(k, v)
+	}
+
+	// Test Iter()
+	foundPairs := maps.Collect(m.Iter())
+
+	if len(foundPairs) != len(expected) {
+		t.Errorf("Expected %d pairs from Iter(), got %d", len(expected), len(foundPairs))
+	}
+
+	for k, v := range expected {
+		if foundPairs[k] != v {
+			t.Errorf("Expected foundPairs[%s] = %d, got %d", k, v, foundPairs[k])
+		}
+	}
+
+	// Test Keys()
+	foundKeys := make(map[string]bool)
+	for k := range m.Keys() {
+		foundKeys[k] = true
+	}
+
+	if len(foundKeys) != len(expected) {
+		t.Errorf("Expected %d keys from Keys(), got %d", len(expected), len(foundKeys))
+	}
+
+	for k := range expected {
+		if !foundKeys[k] {
+			t.Errorf("Expected to find key %s", k)
+		}
+	}
+
+	// Test Values()
+	foundValues := make(map[int]bool)
+	for v := range m.Values() {
+		foundValues[v] = true
+	}
+
+	if len(foundValues) != len(expected) {
+		t.Errorf("Expected %d values from Values(), got %d", len(expected), len(foundValues))
+	}
+
+	for _, v := range expected {
+		if !foundValues[v] {
+			t.Errorf("Expected to find value %d", v)
+		}
+	}
+}
+
+func TestMap_Concurrent(t *testing.T) {
+	m := &Map[int, string]{}
+
+	var wg sync.WaitGroup
+	numGoroutines := 100
+	itemsPerGoroutine := 10
+
+	// Concurrent stores
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(start int) {
+			defer wg.Done()
+			for j := range itemsPerGoroutine {
+				key := start*itemsPerGoroutine + j
+				m.Store(key, string(rune('A'+key%26)))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Concurrent reads
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(start int) {
+			defer wg.Done()
+			for j := range itemsPerGoroutine {
+				key := start*itemsPerGoroutine + j
+				_, ok := m.Load(key)
+				if !ok {
+					t.Errorf("Expected to find key %d", key)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestComparableMap_CompareAndDelete(t *testing.T) {
+	m := &ComparableMap[string, int]{}
+
+	m.Store("key1", 100)
+	m.Store("key2", 200)
+
+	// Delete with correct value
+	deleted := m.CompareAndDelete("key1", 100)
+	if !deleted {
+		t.Error("Expected CompareAndDelete to succeed with correct value")
+	}
+
+	// Delete with incorrect value
+	deleted = m.CompareAndDelete("key2", 100)
+	if deleted {
+		t.Error("Expected CompareAndDelete to fail with incorrect value")
+	}
+
+	// Delete non-existent key
+	deleted = m.CompareAndDelete("nonexistent", 300)
+	if deleted {
+		t.Error("Expected CompareAndDelete to fail with non-existent key")
+	}
+}
+
+func TestComparableMap_CompareAndSwap(t *testing.T) {
+	m := &ComparableMap[string, int]{}
+
+	m.Store("key1", 100)
+
+	// Swap with correct old value
+	swapped := m.CompareAndSwap("key1", 100, 200)
+	if !swapped {
+		t.Error("Expected CompareAndSwap to succeed with correct old value")
+	}
+
+	value, ok := m.Load("key1")
+	if !ok || value != 200 {
+		t.Errorf("Expected value 200 after swap, got %d", value)
+	}
+
+	// Swap with incorrect old value
+	swapped = m.CompareAndSwap("key1", 100, 300)
+	if swapped {
+		t.Error("Expected CompareAndSwap to fail with incorrect old value")
+	}
+
+	value, ok = m.Load("key1")
+	if !ok || value != 200 {
+		t.Errorf("Expected value to remain 200, got %d", value)
+	}
+
+	// Swap non-existent key
+	swapped = m.CompareAndSwap("nonexistent", 0, 400)
+	if swapped {
+		t.Error("Expected CompareAndSwap to fail with non-existent key")
+	}
+}
+
+func TestMap_EdgeCases(t *testing.T) {
+	m := &Map[string, *int]{}
+
+	// Test with nil values
+	var nilPtr *int
+	m.Store("nil", nilPtr)
+
+	value, ok := m.Load("nil")
+	if !ok {
+		t.Error("Expected to load nil value")
+	}
+	if value != nil {
+		t.Error("Expected nil value")
+	}
+
+	// Test empty map operations
+	emptyMap := &Map[string, int]{}
+	count := 0
+	emptyMap.Range(func(key string, value int) bool {
+		count++
+		return true
+	})
+	if count != 0 {
+		t.Errorf("Expected 0 iterations on empty map, got %d", count)
+	}
+
+	// Test iterators on empty map
+	for range emptyMap.Iter() {
+		t.Error("Expected no iterations on empty map")
+	}
+
+	for range emptyMap.Keys() {
+		t.Error("Expected no key iterations on empty map")
+	}
+
+	for range emptyMap.Values() {
+		t.Error("Expected no value iterations on empty map")
+	}
+}


### PR DESCRIPTION
The stdlib does not yet support generics here so this layer provides a shim
until that occurs. Also included are a best-effort Len implementation as well
as a type-safe compare variant (where the value type is comparable).