### PR TITLE
Create BufferedPipe abstraction for log streaming

### DIFF
--- a/internal/bufiox/linebuffer.go
+++ b/internal/bufiox/linebuffer.go
@@ -1,0 +1,201 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package bufiox
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+)
+
+// LineBuffer is a thread-safe ring buffer for lines of text.
+// Its capacity is defined in bytes, and it operates on a single underlying
+// byte slice to minimize memory allocations. It implements io.ReadWriter.
+type LineBuffer struct {
+	buf           []byte // The circular byte buffer.
+	capacity      int    // The total size of buf.
+	mu            sync.Mutex
+	size          int   // The number of bytes currently in use.
+	head          int   // The read pointer (start of the oldest line).
+	tail          int   // The write pointer (next available write position).
+	lineLengths   []int // A queue of line lengths, corresponding to data in buf.
+	pendingLength int   // The length of the unfinished line at the end of the buf.
+}
+
+// NewLineBuffer creates a new LineBuffer with the specified capacity in bytes.
+func NewLineBuffer(capacity int) *LineBuffer {
+	if capacity <= 0 {
+		panic("capacity must be positive")
+	}
+	return &LineBuffer{
+		buf:         make([]byte, capacity),
+		capacity:    capacity,
+		lineLengths: make([]int, 0),
+	}
+}
+
+// Write implements io.Writer. It writes data to the buffer, splitting it into lines.
+// When the buffer is full, it evicts complete lines from the beginning to make space.
+func (lb *LineBuffer) Write(p []byte) (n int, err error) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	if len(p) == 0 {
+		return 0, nil
+	}
+	totalWritten := 0
+	data := p
+	for len(data) > 0 {
+		// Find the next newline
+		newlineIdx := bytes.IndexByte(data, '\n')
+		var toWrite []byte
+		if newlineIdx >= 0 {
+			// Include the newline in the line
+			toWrite = data[:newlineIdx+1]
+			data = data[newlineIdx+1:]
+		} else {
+			// No newline found, write the rest as a pending line
+			toWrite = data
+			data = nil
+		}
+		// Check if we need to make space
+		bytesNeeded := len(toWrite)
+		for lb.size+bytesNeeded > lb.capacity {
+			if !lb.evictOldestLine() {
+				// Can't evict any more lines (buffer too small for current data)
+				if totalWritten == 0 {
+					return 0, errors.New("buffer too small for data")
+				}
+				return totalWritten, nil
+			}
+		}
+		// Write the data to the buffer
+		written := lb.writeToBuffer(toWrite)
+		totalWritten += written
+		// Update line tracking
+		if newlineIdx >= 0 {
+			// Complete line written
+			if lb.pendingLength > 0 {
+				// Combine with pending data
+				lb.lineLengths = append(lb.lineLengths, lb.pendingLength+written)
+				lb.pendingLength = 0
+			} else {
+				// New complete line
+				lb.lineLengths = append(lb.lineLengths, written)
+			}
+		} else {
+			// Partial line
+			lb.pendingLength += written
+		}
+	}
+	return totalWritten, nil
+}
+
+// Read implements io.Reader. It reads available data from the buffer.
+func (lb *LineBuffer) Read(p []byte) (n int, err error) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	if lb.size == 0 {
+		// NOTE: Empty buffer does not return an error.
+		return 0, nil
+	}
+	n = min(len(p), lb.size)
+	// Read from the circular buffer
+	if lb.head+n <= lb.capacity {
+		// Simple case: no wrap around
+		copy(p, lb.buf[lb.head:lb.head+n])
+	} else {
+		// Wrap around case
+		firstPart := lb.capacity - lb.head
+		copy(p[:firstPart], lb.buf[lb.head:])
+		copy(p[firstPart:n], lb.buf[:n-firstPart])
+	}
+	// Update read pointer
+	lb.head = (lb.head + n) % lb.capacity
+	lb.size -= n
+	lb.updateLineLengthsAfterRead(n)
+	return n, nil
+}
+
+// writeToBuffer writes data to the circular buffer starting at tail.
+func (lb *LineBuffer) writeToBuffer(data []byte) int {
+	n := len(data)
+	if n == 0 {
+		return 0
+	}
+	if lb.tail+n <= lb.capacity {
+		// Simple case: no wrap around
+		copy(lb.buf[lb.tail:], data)
+	} else {
+		// Wrap around case
+		firstPart := lb.capacity - lb.tail
+		copy(lb.buf[lb.tail:], data[:firstPart])
+		copy(lb.buf[:n-firstPart], data[firstPart:])
+	}
+	// Update write pointer
+	lb.tail = (lb.tail + n) % lb.capacity
+	lb.size += n
+	return n
+}
+
+// evictOldestLine removes the oldest complete line from the buffer.
+// Returns true if a line was evicted, false if no complete lines exist.
+func (lb *LineBuffer) evictOldestLine() bool {
+	if len(lb.lineLengths) == 0 {
+		return false
+	}
+	// Remove the oldest line
+	lineLen := lb.lineLengths[0]
+	lb.lineLengths = lb.lineLengths[1:]
+	// Update read pointer
+	lb.head = (lb.head + lineLen) % lb.capacity
+	lb.size -= lineLen
+	return true
+}
+
+// updateLineLengthsAfterRead updates line lengths after a read operation.
+func (lb *LineBuffer) updateLineLengthsAfterRead(bytesRead int) {
+	remaining := bytesRead
+	for remaining > 0 && len(lb.lineLengths) > 0 {
+		if lb.lineLengths[0] <= remaining {
+			// Complete line was read
+			remaining -= lb.lineLengths[0]
+			lb.lineLengths = lb.lineLengths[1:]
+		} else {
+			// Partial line was read
+			lb.lineLengths[0] -= remaining
+			remaining = 0
+		}
+	}
+	// Update pending length if necessary
+	if remaining > 0 && lb.pendingLength > 0 {
+		if lb.pendingLength <= remaining {
+			lb.pendingLength = 0
+		} else {
+			lb.pendingLength -= remaining
+		}
+	}
+}
+
+// Len returns the current number of bytes in the buffer.
+func (lb *LineBuffer) Len() int {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	return lb.size
+}
+
+// Capacity returns the total capacity of the buffer.
+func (lb *LineBuffer) Capacity() int {
+	return lb.capacity
+}
+
+// Clear empties the buffer.
+func (lb *LineBuffer) Clear() {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	lb.size = 0
+	lb.head = 0
+	lb.tail = 0
+	lb.lineLengths = lb.lineLengths[:0]
+	lb.pendingLength = 0
+}

--- a/internal/bufiox/linebuffer_test.go
+++ b/internal/bufiox/linebuffer_test.go
@@ -1,0 +1,259 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package bufiox
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLineBuffer(t *testing.T) {
+	t.Run("WriteAndRead", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			capacity int
+			writes   []string
+			expected string
+		}{
+			{
+				name:     "single line",
+				capacity: 100,
+				writes:   []string{"Hello, World!\n"},
+				expected: "Hello, World!\n",
+			},
+			{
+				name:     "multiple lines",
+				capacity: 100,
+				writes:   []string{"First line\n", "Second line\n", "Third line\n"},
+				expected: "First line\nSecond line\nThird line\n",
+			},
+			{
+				name:     "empty writes",
+				capacity: 50,
+				writes:   []string{"", "Hello\n", "", "World\n"},
+				expected: "Hello\nWorld\n",
+			},
+			{
+				name:     "no newlines",
+				capacity: 100,
+				writes:   []string{"no", "newline", "here"},
+				expected: "nonewlinehere",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				// Write all data
+				for _, write := range tc.writes {
+					_, err := lb.Write([]byte(write))
+					if err != nil {
+						t.Fatalf("Write failed: %v", err)
+					}
+				}
+				// Read back
+				buf := make([]byte, tc.capacity*2)
+				n, err := lb.Read(buf)
+				if err != nil {
+					t.Fatalf("Read failed: %v", err)
+				}
+				if string(buf[:n]) != tc.expected {
+					t.Errorf("Expected %q, got %q", tc.expected, string(buf[:n]))
+				}
+			})
+		}
+	})
+
+	t.Run("EmptyBuffer", func(t *testing.T) {
+		capacities := []int{10, 50, 100, 1000}
+
+		for _, capacity := range capacities {
+			t.Run(fmt.Sprintf("capacity_%d", capacity), func(t *testing.T) {
+				lb := NewLineBuffer(capacity)
+				buf := make([]byte, 10)
+				n, err := lb.Read(buf)
+				if n != 0 || err != nil {
+					t.Errorf("Expected (0, nil), got (%d, %v)", n, err)
+				}
+			})
+		}
+	})
+
+	t.Run("LineEviction", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			capacity      int
+			lines         []string
+			expectedLines []string // Lines that should remain after eviction
+		}{
+			{
+				name:          "evict first line",
+				capacity:      20,
+				lines:         []string{"Line1\n", "Line2\n", "Line3\n", "Line4\n"},
+				expectedLines: []string{"Line2\n", "Line3\n", "Line4\n"},
+			},
+			{
+				name:          "evict multiple lines",
+				capacity:      6,
+				lines:         []string{"A\n", "B\n", "C\n", "D\n", "E\n", "F\n"},
+				expectedLines: []string{"D\n", "E\n", "F\n"},
+			},
+			{
+				name:          "no eviction needed",
+				capacity:      50,
+				lines:         []string{"Short\n", "Lines\n"},
+				expectedLines: []string{"Short\n", "Lines\n"},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				// Write all lines
+				for _, line := range tc.lines {
+					lb.Write([]byte(line))
+				}
+				// Read all content
+				buf := make([]byte, tc.capacity*2)
+				n, _ := lb.Read(buf)
+				expected := ""
+				for _, line := range tc.expectedLines {
+					expected += line
+				}
+				if string(buf[:n]) != expected {
+					t.Errorf("Expected %q, got %q", expected, string(buf[:n]))
+				}
+			})
+		}
+	})
+
+	t.Run("PartialLines", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			capacity int
+			parts    []string
+			expected string
+		}{
+			{
+				name:     "simple partial",
+				capacity: 100,
+				parts:    []string{"Partial", " line\n"},
+				expected: "Partial line\n",
+			},
+			{
+				name:     "multiple parts",
+				capacity: 100,
+				parts:    []string{"A", "B", "C", "D", "\n", "E", "F\nG", "\n"},
+				expected: "ABCD\nEF\nG\n",
+			},
+			{
+				name:     "mixed complete and partial",
+				capacity: 100,
+				parts:    []string{"Complete\n", "Part", "ial\n"},
+				expected: "Complete\nPartial\n",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				// Write all parts
+				for _, part := range tc.parts {
+					lb.Write([]byte(part))
+				}
+				// Read back
+				buf := make([]byte, tc.capacity)
+				n, _ := lb.Read(buf)
+				if string(buf[:n]) != tc.expected {
+					t.Errorf("Expected %q, got %q", tc.expected, string(buf[:n]))
+				}
+			})
+		}
+	})
+
+	t.Run("WrapAround", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			capacity      int
+			initialWrites []string
+			readSize      int
+			laterWrites   []string
+			expectedReads []string
+		}{
+			{
+				name:          "basic wrap",
+				capacity:      20,
+				initialWrites: []string{"12345678\n", "abcdefgh\n"},
+				readSize:      9,
+				laterWrites:   []string{"WRAP\n"},
+				expectedReads: []string{"abcdefgh\n", "WRAP\n"},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				// Initial writes
+				for _, write := range tc.initialWrites {
+					lb.Write([]byte(write))
+				}
+				// First read
+				buf := make([]byte, tc.readSize)
+				lb.Read(buf)
+				// Later writes
+				for _, write := range tc.laterWrites {
+					lb.Write([]byte(write))
+				}
+				// Read remaining data
+				for i, expected := range tc.expectedReads {
+					n, _ := lb.Read(buf)
+					if string(buf[:n]) != expected {
+						t.Errorf("Read %d: expected %q, got %q", i, expected, string(buf[:n]))
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("BufferTooSmall", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			capacity int
+			data     string
+			wantErr  bool
+		}{
+			{
+				name:     "line too large",
+				capacity: 10,
+				data:     "This line is too long\n",
+				wantErr:  true,
+			},
+			{
+				name:     "exactly fits",
+				capacity: 10,
+				data:     "1234567890",
+				wantErr:  false,
+			},
+			{
+				name:     "fits with newline",
+				capacity: 11,
+				data:     "1234567890\n",
+				wantErr:  false,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				_, err := lb.Write([]byte(tc.data))
+				if tc.wantErr && err == nil {
+					t.Error("Expected error but got none")
+				}
+				if !tc.wantErr && err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			})
+		}
+	})
+}

--- a/internal/bufiox/pipe.go
+++ b/internal/bufiox/pipe.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package bufiox
+
+import (
+	"io"
+	"sync"
+)
+
+// BufferedPipe provides a synchronized pipe with buffering.
+// It supports a single reader and single writer.
+type BufferedPipe struct {
+	buf      io.ReadWriter
+	mu       sync.Mutex
+	readCond *sync.Cond
+
+	closed bool
+}
+
+// NewBufferedPipe creates a new BufferedPipe using the provided buffer.
+func NewBufferedPipe(buf io.ReadWriter) *BufferedPipe {
+	bp := &BufferedPipe{buf: buf}
+	bp.readCond = sync.NewCond(&bp.mu)
+	return bp
+}
+
+// Write writes data to the pipe. It never blocks.
+// Returns io.ErrClosedPipe if the reader has closed.
+func (bp *BufferedPipe) Write(p []byte) (n int, err error) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	if bp.closed {
+		return 0, io.ErrClosedPipe
+	}
+	n, err = bp.buf.Write(p)
+	if n > 0 {
+		// Wake up any waiting reader
+		bp.readCond.Signal()
+	}
+	return n, err
+}
+
+// Read reads data from the pipe. It blocks until data is available,
+// the writer closes, or the reader closes.
+// Returns io.EOF when the writer has closed and the buffer is empty.
+func (bp *BufferedPipe) Read(p []byte) (n int, err error) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	for {
+		n, err = bp.buf.Read(p)
+		if err != nil {
+			return n, err
+		}
+		if n > 0 {
+			return n, nil
+		}
+		// Buffer is empty
+		if bp.closed {
+			return 0, io.EOF
+		}
+		// Wait for data or close
+		bp.readCond.Wait()
+	}
+}
+
+// Close closes the write side of the pipe.
+// Any blocked Read calls will return io.EOF once the buffer is empty.
+func (bp *BufferedPipe) Close() error {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	if bp.closed {
+		return io.ErrClosedPipe
+	}
+	bp.closed = true
+	bp.readCond.Broadcast() // Wake all waiting readers
+	return nil
+}

--- a/internal/bufiox/pipe_test.go
+++ b/internal/bufiox/pipe_test.go
@@ -1,0 +1,276 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package bufiox
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBufferedPipe(t *testing.T) {
+	t.Run("BasicReadWrite", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			capacity int
+			writes   []string
+			expected string
+		}{
+			{
+				name:     "simple data",
+				capacity: 100,
+				writes:   []string{"Hello\n", "World\n"},
+				expected: "Hello\nWorld\n",
+			},
+			{
+				name:     "single write",
+				capacity: 50,
+				writes:   []string{"Single line\n"},
+				expected: "Single line\n",
+			},
+			{
+				name:     "multiple small writes",
+				capacity: 200,
+				writes:   []string{"A\n", "B\n", "C\n", "D\n"},
+				expected: "A\nB\nC\nD\n",
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				pipe := NewBufferedPipe(lb)
+
+				// Write in goroutine
+				go func() {
+					for _, write := range tc.writes {
+						pipe.Write([]byte(write))
+					}
+					pipe.Close()
+				}()
+
+				// Read all data
+				data, err := io.ReadAll(pipe)
+				if err != nil {
+					t.Fatalf("ReadAll failed: %v", err)
+				}
+
+				if string(data) != tc.expected {
+					t.Errorf("Expected %q, got %q", tc.expected, string(data))
+				}
+			})
+		}
+	})
+
+	t.Run("BlockingRead", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			capacity  int
+			writeData string
+			readSize  int
+			delay     time.Duration
+		}{
+			{
+				name:      "short delay",
+				capacity:  100,
+				writeData: "test\n",
+				readSize:  10,
+				delay:     10 * time.Millisecond,
+			},
+			{
+				name:      "longer delay",
+				capacity:  50,
+				writeData: "delayed\n",
+				readSize:  20,
+				delay:     50 * time.Millisecond,
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				pipe := NewBufferedPipe(lb)
+
+				done := make(chan bool)
+
+				// Start reader
+				go func() {
+					buf := make([]byte, tc.readSize)
+					n, err := pipe.Read(buf)
+					if err != nil || string(buf[:n]) != tc.writeData {
+						t.Errorf("Read failed: n=%d, err=%v, data=%q", n, err, string(buf[:n]))
+					}
+					done <- true
+				}()
+
+				// Wait for reader to block
+				time.Sleep(tc.delay)
+
+				// Write data
+				pipe.Write([]byte(tc.writeData))
+
+				// Reader should unblock
+				select {
+				case <-done:
+					// Success
+				case <-time.After(100 * time.Millisecond):
+					t.Error("Read did not unblock")
+				}
+			})
+		}
+	})
+
+	t.Run("EOFAfterClose", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			capacity int
+			data     string
+		}{
+			{
+				name:     "with data",
+				capacity: 100,
+				data:     "data\n",
+			},
+			{
+				name:     "empty buffer",
+				capacity: 50,
+				data:     "",
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				pipe := NewBufferedPipe(lb)
+
+				if tc.data != "" {
+					pipe.Write([]byte(tc.data))
+				}
+				pipe.Close()
+
+				buf := make([]byte, 10)
+
+				if tc.data != "" {
+					// First read gets data
+					n, err := pipe.Read(buf)
+					if err != nil || string(buf[:n]) != tc.data {
+						t.Errorf("First read failed: n=%d, err=%v, data=%q", n, err, string(buf[:n]))
+					}
+				}
+
+				// Next read gets EOF
+				n, err := pipe.Read(buf)
+				if err != io.EOF || n != 0 {
+					t.Errorf("Expected EOF, got n=%d, err=%v", n, err)
+				}
+			})
+		}
+	})
+
+	t.Run("ClosedPipeErrors", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			closeFunc func(*BufferedPipe) error
+			testWrite bool
+			testRead  bool
+		}{
+			{
+				name:      "writer closed",
+				closeFunc: (*BufferedPipe).Close,
+				testWrite: false,
+				testRead:  false,
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(100)
+				pipe := NewBufferedPipe(lb)
+
+				tc.closeFunc(pipe)
+
+				if tc.testWrite {
+					_, err := pipe.Write([]byte("test"))
+					if err != io.ErrClosedPipe {
+						t.Errorf("Expected ErrClosedPipe for write, got %v", err)
+					}
+				}
+
+				if tc.testRead {
+					buf := make([]byte, 10)
+					_, err := pipe.Read(buf)
+					if err != io.ErrClosedPipe {
+						t.Errorf("Expected ErrClosedPipe for read, got %v", err)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("ConcurrentOperations", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			capacity     int
+			messageCount int
+			messageSize  int
+		}{
+			{
+				name:         "small messages",
+				capacity:     1000,
+				messageCount: 50,
+				messageSize:  10,
+			},
+			{
+				name:         "many small messages",
+				capacity:     2000,
+				messageCount: 200,
+				messageSize:  5,
+			},
+			{
+				name:         "fewer large messages",
+				capacity:     5000,
+				messageCount: 20,
+				messageSize:  50,
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				lb := NewLineBuffer(tc.capacity)
+				pipe := NewBufferedPipe(lb)
+				var wg sync.WaitGroup
+				wg.Add(2)
+				// Writer
+				go func() {
+					defer wg.Done()
+					for range tc.messageCount {
+						msg := fmt.Sprintf("%s\n", strings.Repeat("A", tc.messageSize-1))
+						pipe.Write([]byte(msg))
+					}
+					pipe.Close()
+				}()
+				// Reader
+				received := 0
+				go func() {
+					defer wg.Done()
+					buf := make([]byte, tc.messageSize*10)
+					for {
+						n, err := pipe.Read(buf)
+						if err == io.EOF {
+							break
+						}
+						if err != nil {
+							t.Errorf("Read error: %v", err)
+							break
+						}
+						received += bytes.Count(buf[:n], []byte{'\n'})
+					}
+				}()
+				wg.Wait()
+				if received != tc.messageCount {
+					t.Errorf("Expected %d messages, got %d", tc.messageCount, received)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
This construct gives us a number of nice properties in implementing the build output streaming. For one, the ring buffer allows us to bound the memory cost of logs streaming for each build. Second, the line-based buffering helps us ensure logs remain human-readable even when eviction is necessary (mid-line breaks don't happen). Additionally, the use of the pipe means that the build invoker need not call `OutputStream()` to drain the output if they don't need it. And if they are interested in observing some failure after the build completes, the buffer is in a state to provide the last portion of the build output (although we currently close and free the buffer on termination).