### PR TITLE
stabilize: fix error when stabilizing tars

### DIFF
--- a/cmd/stabilize/main.go
+++ b/cmd/stabilize/main.go
@@ -182,7 +182,9 @@ func eligiblePasses(filename string) ([]archive.Stabilizer, error) {
 		}
 		if i == 0 {
 			result = stabs
-		} else if !slices.Equal(result, stabs) {
+		} else if !slices.EqualFunc(result, stabs, func(s1, s2 archive.Stabilizer) bool {
+			return getName(s1) == getName(s2)
+		}) {
 			return nil, errors.Wrapf(ErrAmbiguousEcosystem, "ecosystem %s suggests different stabilizers than %s", candidates[0], e)
 		}
 	}


### PR DESCRIPTION
Before this patch, `stabilize /path/to/a/tar.gz` would fail:

```
panic: runtime error: comparing uncomparable type archive.TarArchiveStabilizer

goroutine 1 [running]:
slices.Equal[...](...)
        slices/slices.go:25
main.eligiblePasses({0x7fffffffe1ae, 0x10})
        github.com/google/oss-rebuild/cmd/stabilize/main.go:185 +0x2fb
main.run()
        github.com/google/oss-rebuild/cmd/stabilize/main.go:212 +0x198
main.main()
        github.com/google/oss-rebuild/cmd/stabilize/main.go:246 +0x13
```