### PR TITLE
Split command registry and implementation

### DIFF
--- a/tools/ctl/ide/commandreg/registry.go
+++ b/tools/ctl/ide/commandreg/registry.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package commands
+package commandreg
 
 import (
 	"context"

--- a/tools/ctl/ide/commands/commands.go
+++ b/tools/ctl/ide/commands/commands.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/oss-rebuild/tools/ctl/ide/assistant"
 	"github.com/google/oss-rebuild/tools/ctl/ide/chatbox"
 	"github.com/google/oss-rebuild/tools/ctl/ide/choice"
+	"github.com/google/oss-rebuild/tools/ctl/ide/commandreg"
 	"github.com/google/oss-rebuild/tools/ctl/ide/details"
 	"github.com/google/oss-rebuild/tools/ctl/ide/modal"
 	"github.com/google/oss-rebuild/tools/ctl/ide/rebuilder"
@@ -47,8 +48,8 @@ const (
 // A modalFnType can be used to show an InputCaptureable. It returns an exit function that can be used to close the modal.
 type modalFnType func(modal.InputCaptureable, modal.ModalOpts) func()
 
-func NewRebuildCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, aiClient *genai.Client, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []RebuildCmd {
-	return []RebuildCmd{
+func NewRebuildCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, aiClient *genai.Client, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []commandreg.RebuildCmd {
+	return []commandreg.RebuildCmd{
 		{
 			Short: "run local",
 			Func: func(ctx context.Context, example rundex.Rebuild) {
@@ -208,8 +209,8 @@ func NewRebuildCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn mod
 	}
 }
 
-func NewRebuildGroupCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, aiClient *genai.Client, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []RebuildGroupCmd {
-	return []RebuildGroupCmd{
+func NewRebuildGroupCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, aiClient *genai.Client, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []commandreg.RebuildGroupCmd {
+	return []commandreg.RebuildGroupCmd{
 		{
 			Short: "Find pattern",
 			Func: func(ctx context.Context, rebuilds []rundex.Rebuild) {
@@ -359,8 +360,8 @@ func NewRebuildGroupCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalF
 
 }
 
-func NewGlobalCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, aiClient *genai.Client, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []GlobalCmd {
-	return []GlobalCmd{
+func NewGlobalCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalFn modalFnType, butler localfiles.Butler, aiClient *genai.Client, buildDefs rebuild.LocatableAssetStore, dex rundex.Reader, benches benchmark.Repository) []commandreg.GlobalCmd {
+	return []commandreg.GlobalCmd{
 		{
 			Short:  "restart rebuilder",
 			Hotkey: 'r',

--- a/tools/ctl/ide/explorer/explorer.go
+++ b/tools/ctl/ide/explorer/explorer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/google/oss-rebuild/tools/benchmark"
-	"github.com/google/oss-rebuild/tools/ctl/ide/commands"
+	"github.com/google/oss-rebuild/tools/ctl/ide/commandreg"
 	detailsui "github.com/google/oss-rebuild/tools/ctl/ide/details"
 	"github.com/google/oss-rebuild/tools/ctl/ide/modal"
 	"github.com/google/oss-rebuild/tools/ctl/rundex"
@@ -53,11 +53,11 @@ type Explorer struct {
 	rundexOpts rundex.FetchRebuildOpts
 	runs       map[string]rundex.Run
 	benches    benchmark.Repository
-	cmdReg     commands.Registry
+	cmdReg     commandreg.Registry
 	modalFn    modalFnType
 }
 
-func NewExplorer(app *tview.Application, modalFn modalFnType, dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.FetchRebuildOpts, benches benchmark.Repository, cmdReg commands.Registry) *Explorer {
+func NewExplorer(app *tview.Application, modalFn modalFnType, dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.FetchRebuildOpts, benches benchmark.Repository, cmdReg commandreg.Registry) *Explorer {
 	e := Explorer{
 		app:        app,
 		container:  tview.NewPages(),

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/tools/benchmark"
+	"github.com/google/oss-rebuild/tools/ctl/ide/commandreg"
 	"github.com/google/oss-rebuild/tools/ctl/ide/commands"
 	"github.com/google/oss-rebuild/tools/ctl/ide/explorer"
 	"github.com/google/oss-rebuild/tools/ctl/ide/modal"
@@ -61,7 +62,7 @@ func NewTuiApp(dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.Fetc
 	modalFn := func(input modal.InputCaptureable, opts modal.ModalOpts) func() {
 		return modal.Show(t.app, t.root, input, opts)
 	}
-	cmdReg := commands.Registry{}
+	cmdReg := commandreg.Registry{}
 	if err := cmdReg.AddGlobals(commands.NewGlobalCmds(t.app, t.rb, modalFn, butler, aiClient, buildDefs, dex, benches)...); err != nil {
 		log.Fatal(err)
 	}
@@ -71,7 +72,7 @@ func NewTuiApp(dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.Fetc
 	if err := cmdReg.AddRebuilds(commands.NewRebuildCmds(t.app, t.rb, modalFn, butler, aiClient, buildDefs, dex, benches)...); err != nil {
 		log.Fatal(err)
 	}
-	err := cmdReg.AddGlobals([]commands.GlobalCmd{
+	err := cmdReg.AddGlobals([]commandreg.GlobalCmd{
 		{
 			Short:  "logs up",
 			Hotkey: '^',


### PR DESCRIPTION
This allows UI elements to iterate over a registry and display commands,
while the command implementations can reference those same UI elements
when building modal UI objects