### PR TITLE
Change command registry to pointer

### DIFF
--- a/tools/ctl/ide/explorer/explorer.go
+++ b/tools/ctl/ide/explorer/explorer.go
@@ -37,11 +37,11 @@ type Explorer struct {
 	watcher    rundex.Watcher
 	rundexOpts rundex.FetchRebuildOpts
 	benches    benchmark.Repository
-	cmdReg     commandreg.Registry
+	cmdReg     *commandreg.Registry
 	modalFn    modal.Fn
 }
 
-func NewExplorer(app *tview.Application, modalFn modal.Fn, dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.FetchRebuildOpts, benches benchmark.Repository, cmdReg commandreg.Registry) *Explorer {
+func NewExplorer(app *tview.Application, modalFn modal.Fn, dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.FetchRebuildOpts, benches benchmark.Repository, cmdReg *commandreg.Registry) *Explorer {
 	e := Explorer{
 		app:        app,
 		container:  tview.NewPages(),

--- a/tools/ctl/ide/rebuildhistory/rebuildhistory.go
+++ b/tools/ctl/ide/rebuildhistory/rebuildhistory.go
@@ -31,7 +31,7 @@ func verdictAsEmoji(r rundex.Rebuild) string {
 }
 
 // New creates a new RebuildHistory viewer.
-func New(modalFn modal.Fn, cmdReg commandreg.Registry, rebuilds []rundex.Rebuild) modal.InputCaptureable {
+func New(modalFn modal.Fn, cmdReg *commandreg.Registry, rebuilds []rundex.Rebuild) modal.InputCaptureable {
 	slices.SortFunc(rebuilds, func(a, b rundex.Rebuild) int {
 		return -strings.Compare(a.RunID, b.RunID)
 	})

--- a/tools/ctl/ide/rundextable/rundextable.go
+++ b/tools/ctl/ide/rundextable/rundextable.go
@@ -33,7 +33,7 @@ func addRow(table *tview.Table, row int, elems []string) {
 	}
 }
 
-func New(rebuilds []rundex.Rebuild, cmdReg commandreg.Registry, onSelect func(rebuild rundex.Rebuild)) (*tview.Table, error) {
+func New(rebuilds []rundex.Rebuild, cmdReg *commandreg.Registry, onSelect func(rebuild rundex.Rebuild)) (*tview.Table, error) {
 	table := tview.NewTable().SetBorders(true)
 	addHeader(table, []string{"ID", "Success", "Run"})
 	for i, r := range rebuilds {

--- a/tools/ctl/ide/rundextree/rundextree.go
+++ b/tools/ctl/ide/rundextree/rundextree.go
@@ -28,11 +28,11 @@ type Tree struct {
 	rundexOpts rundex.FetchRebuildOpts
 	runs       map[string]rundex.Run
 	benches    benchmark.Repository
-	cmdReg     commandreg.Registry
+	cmdReg     *commandreg.Registry
 	modalFn    modal.Fn
 }
 
-func New(app *tview.Application, modalFn modal.Fn, dex rundex.Reader, rundexOpts rundex.FetchRebuildOpts, benches benchmark.Repository, cmdReg commandreg.Registry) *Tree {
+func New(app *tview.Application, modalFn modal.Fn, dex rundex.Reader, rundexOpts rundex.FetchRebuildOpts, benches benchmark.Repository, cmdReg *commandreg.Registry) *Tree {
 	root := tview.NewTreeNode("root").SetColor(tcell.ColorRed)
 	t := &Tree{
 		TreeView:   tview.NewTreeView().SetRoot(root).SetCurrentNode(root),

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -62,7 +62,7 @@ func NewTuiApp(dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.Fetc
 	modalFn := func(input modal.InputCaptureable, opts modal.ModalOpts) func() {
 		return modal.Show(t.app, t.root, input, opts)
 	}
-	cmdReg := commandreg.Registry{}
+	cmdReg := &commandreg.Registry{}
 	if err := cmdReg.AddGlobals(commands.NewGlobalCmds(t.app, t.rb, modalFn, butler, aiClient, buildDefs, dex, benches)...); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
We update the registry in a handful of places, most of the time we want
all references to point to the same registry. If that changes in the
future we can make a Copy() method.