### PR TITLE
Move verdict messages into dedicated package

### DIFF
--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/google/oss-rebuild/internal/uri"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/verdicts"
 	"github.com/google/oss-rebuild/pkg/registry/maven"
 	"github.com/pkg/errors"
 )
@@ -42,9 +43,9 @@ func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string
 	case nil:
 		return r, nil
 	case transport.ErrAuthenticationRequired:
-		return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)
+		return r, errors.Errorf("%s [repo=%s]", verdicts.RepoInvalidOrPrivate, r.URI)
 	default:
-		return r, errors.Wrapf(err, "clone failed [repo=%s]", r.URI)
+		return r, errors.Wrapf(err, "%s [repo=%s]", verdicts.CloneFailed, r.URI)
 	}
 }
 
@@ -193,9 +194,9 @@ func findAndValidatePomXML(commit *object.Commit, name, version, dir string) (st
 	} else if err != nil {
 		return path, errors.Wrapf(err, "unknown pom.xml error")
 	} else if pomXML.Name() != name {
-		return path, errors.Errorf("mismatched name [expected=%s,actual=%s,path=%s]", name, pomXML.Name(), path)
+		return path, errors.Errorf("%s [expected=%s,actual=%s,path=%s]", verdicts.MismatchedName, name, pomXML.Name(), path)
 	} else if pomXML.Version() != version {
-		return path, errors.Errorf("mismatched version [expected=%s,actual=%s,path=%s]", version, pomXML.Version(), path)
+		return path, errors.Errorf("%s, [expected=%s,actual=%s,path=%s]", verdicts.MismatchedVersion, version, pomXML.Version(), path)
 	}
 	return path, nil
 }

--- a/pkg/rebuild/npm/rebuild.go
+++ b/pkg/rebuild/npm/rebuild.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-billy/v5/util"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/verdicts"
 	"github.com/pkg/errors"
 )
 
@@ -102,7 +103,7 @@ func (Rebuilder) Rebuild(ctx context.Context, t rebuild.Target, inst rebuild.Ins
 			return errors.Errorf("pack command not found: %s", output[startIdx+2:endIdx])
 		// TODO: Classify with newly-observed cases.
 		default:
-			return errors.Wrapf(err, "unknown npm pack failure:\n%s", output)
+			return errors.Wrap(err, verdicts.UnknownNpmPackFailure+":\n%s"+output)
 		}
 	}
 	return nil

--- a/pkg/rebuild/verdicts/verdicts.go
+++ b/pkg/rebuild/verdicts/verdicts.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package verdicts
+
+const (
+	SelectingArtifact            = "selecting artifact"
+	GettingStrategy              = "getting strategy"
+	ExecutingRebuild             = "executing rebuild"
+	CreatingDebugStore           = "creating debug store"
+	CreatingRebuildStore         = "creating rebuild store"
+	GettingStabilizers           = "getting stabilizers for target"
+	CreatingStabilizers          = "creating stabilizers"
+	GettingUpstreamURL           = "getting upstream url"
+	ComparingArtifacts           = "comparing artifacts"
+	ContentMismatch              = "rebuild content mismatch"
+	CreatingAttestations         = "creating attestations"
+	PublishingBundle             = "publishing bundle"
+	CreatingBuildDefRepoReader   = "creating build definition repo reader"
+	AccessingBuildDefinition     = "accessing build definition"
+	AccessingStrategy            = "accessing strategy"
+	FetchingInference            = "fetching inference"
+	ReadingStrategy              = "reading strategy"
+	CheckingExistingBundle       = "checking existing bundle"
+	ExistingBundle               = "conflict with existing attestation bundle"
+	UnknownEcosystem             = "unknown ecosystem"
+	UnsupportedEcosystem         = "unsupported ecosystem"
+	BadServiceRepoURL            = "bad ServiceRepo URL"
+	DisallowedFileServiceRepoURL = "disallowed file:// ServiceRepo URL"
+	MismatchedVersion            = "mismatched version"
+	MismatchedName               = "mismatched name"
+	FailedToExtractUpstream      = "Failed to extract upstream"
+	CheckoutFailed               = "Checkout failed"
+
+	// Git
+	RepoInvalidOrPrivate = "repo invalid or private"
+	CloneFailed          = "clone failed"
+
+	// NPM
+	UnknownNpmPackFailure = "unknown npm pack failure"
+	UnsupportedNPMVersion = "Unsupported NPM version"
+	PackageJSONNotFound   = "package.json file not found"
+
+	// Pypi
+	FetchingMetadata                 = "fetching metadata"
+	LocatingPureWheel                = "locating pure wheel"
+	FailedToGetUpstreamGenerator     = "Failed to get upstream generator"
+	UnsupportedGenerator             = "unsupported generator"
+	FailedToExtractReqsFromPyproject = "Failed to extract reqs from pyproject.toml."
+
+	// Debian
+	DebianRequiresArtifact = "debian requires artifact"
+
+	// Crates
+	CargoTOMLNotFound = "Cargo.toml file not found"
+)

--- a/tools/ctl/ide/commands/commands.go
+++ b/tools/ctl/ide/commands/commands.go
@@ -329,6 +329,7 @@ func NewRebuildGroupCmds(app *tview.Application, rb *rebuilder.Rebuilder, modalF
 						{Text: "Please summarize this rebuild failure in one sentence."},
 						{Text: logs},
 					}
+					// if strings.Contains(in.Message, "
 					<-ticker
 					txt, err := llm.GenerateTextContent(ctx, aiClient, llm.GeminiFlash, config, parts...)
 					if err != nil {


### PR DESCRIPTION
This makes it easier for processing code to check for certain verdict
failure types. I went with strings instead of Error types because
frequently we're checking verdict.Message contents. Using strings also
works better with Wrap() because they can be applied to existing errors,
like: `return errors.Wrap(err, verdicts.SomeClassOfFailures)` on an
unknown err value. If the constants were Error types, that would not be
possible unless we did errors.Join() which I think we're trying to avoid
at least for now.