### PR TITLE
Fix capitalization of 'npm' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ of the upstream artifact and eliminating many possible sources of compromise.
 
 We currently support the following ecosystems:
 
-- NPM (JavaScript/TypeScript)
+- npm (JavaScript/TypeScript)
 - PyPI (Python)
 - Crates.io (Rust)
 


### PR DESCRIPTION
Although "npm" is commonly understood to be an abbreviation of "Node Package Manager", it is officially a recursive backronymic abbreviation for "npm is not an acronym".

https://en.wikipedia.org/wiki/Npm