### PR TITLE
Add RAVE as a related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Check out these related projects contributing to the reproducible builds effort:
   Java, Kotlin reproducibility.
 - [kpcyrd/rebuilderd](https://github.com/kpcyrd/rebuilderd): Rebuild scheduler
   with support for several distros.
+- [johnbillion/rave-wordpress](https://github.com/johnbillion/rave-wordpress): Reproduces and verifies official and unofficial WordPress packages.
 
 ## Disclaimer
 


### PR DESCRIPTION
I maintain the [RAVE for WordPress](https://github.com/johnbillion/rave-wordpress) project which reproduces WordPress from source and verifies that various official and unofficial packages, source code mirrors, and builds match it exactly.

RAVE in its current form is specific to WordPress and runs only as a set of GitHub Actions workflows, but perhaps others will be interested in its approach.