### PR TITLE
Use key resource name as signer-verifier param

### DIFF
--- a/analyzer/network/analyzer/main.go
+++ b/analyzer/network/analyzer/main.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	kms "cloud.google.com/go/kms/apiv1"
-	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/google/oss-rebuild/analyzer/network/analyzerservice"
 	"github.com/google/oss-rebuild/internal/api"
@@ -62,13 +61,7 @@ func AnalyzerInit(ctx context.Context) (*analyzerservice.AnalyzerDeps, error) {
 		return nil, errors.Wrap(err, "creating KMS client")
 	}
 	// Signing key
-	signingKey, err := kmsClient.GetCryptoKeyVersion(ctx, &kmspb.GetCryptoKeyVersionRequest{
-		Name: *signingKeyVersion,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "getting signing key")
-	}
-	signerVerifier, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kmsClient, signingKey)
+	signerVerifier, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kmsClient, *signingKeyVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating signer/verifier")
 	}
@@ -79,13 +72,7 @@ func AnalyzerInit(ctx context.Context) (*analyzerservice.AnalyzerDeps, error) {
 	// Verification key (if different from signing key)
 	var verifier *dsse.EnvelopeVerifier
 	if *verifyingKeyVersion != "" {
-		verifyingKey, err := kmsClient.GetCryptoKeyVersion(ctx, &kmspb.GetCryptoKeyVersionRequest{
-			Name: *verifyingKeyVersion,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "getting verifying key")
-		}
-		verifyingSignerVerifier, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kmsClient, verifyingKey)
+		verifyingSignerVerifier, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kmsClient, *verifyingKeyVersion)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating verifying signer/verifier")
 		}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -13,7 +13,6 @@ import (
 
 	"cloud.google.com/go/firestore"
 	kms "cloud.google.com/go/kms/apiv1"
-	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/oss-rebuild/internal/api"
@@ -94,11 +93,7 @@ func makeKMSSigner(ctx context.Context, cryptoKeyVersion string) (*dsse.Envelope
 	if err != nil {
 		return nil, errors.Wrap(err, "creating KMS client")
 	}
-	ckv, err := kc.GetCryptoKeyVersion(ctx, &kmspb.GetCryptoKeyVersionRequest{Name: cryptoKeyVersion})
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching CryptoKeyVersion")
-	}
-	kmsSigner, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kc, ckv)
+	kmsSigner, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kc, cryptoKeyVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating Cloud KMS signer")
 	}

--- a/cmd/oss-rebuild/verify.go
+++ b/cmd/oss-rebuild/verify.go
@@ -69,11 +69,7 @@ func makeKMSVerifier(ctx context.Context, cryptoKeyVersion string) (dsse.Verifie
 	if err != nil {
 		return nil, errors.Wrap(err, "creating KMS client")
 	}
-	ckv, err := kc.GetCryptoKeyVersion(ctx, &kmspb.GetCryptoKeyVersionRequest{Name: cryptoKeyVersion})
-	if err != nil {
-		return nil, errors.Wrap(err, "fetching CryptoKeyVersion")
-	}
-	kmsVerifier, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kc, ckv)
+	kmsVerifier, err := kmsdsse.NewCloudKMSSignerVerifier(ctx, kc, cryptoKeyVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating Cloud KMS verifier")
 	}

--- a/pkg/kmsdsse/kmsdsse_test.go
+++ b/pkg/kmsdsse/kmsdsse_test.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package kmsdsse
+
+import (
+	"testing"
+)
+
+func TestKeyRegex(t *testing.T) {
+	for _, tc := range []struct {
+		value  string
+		reject bool
+	}{
+		{
+			value: "projects/my-proj/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
+		},
+		{
+			value:  "projects/my-proj/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/",
+			reject: true,
+		},
+		{
+			value:  "projects/my-proj/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
+			reject: true,
+		},
+		{
+			value:  "https://cloudkms.googleapis.com/v1/projects/my-proj/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
+			reject: true,
+		},
+	} {
+		if matched := keyNameRegex.MatchString(tc.value); matched != !tc.reject {
+			t.Errorf("Unexpected regex result: got=%t, expected=%t", matched, !tc.reject)
+		}
+	}
+}


### PR DESCRIPTION
Requiring the key object requires external users to have the
cloudkms.cryptoKeyVersion.get permission which is not part of the
cloudkms.verifier role we grant to all users.

Accepting the resource name alone means the interface only need fetch
the public key (cloudkms.cryptoKeyVersion.getPublicKey).