### PR TITLE
Add descriptive header comments to generated Dockerfiles

### DIFF
--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -50,6 +50,7 @@ type rebuildContainerArgs struct {
 	PrebuildBucket  string
 	PrebuildDir     string
 	PrebuildAuth    bool
+	Target          Target
 }
 
 var tetragonPoliciesYaml = []string{`apiVersion: cilium.io/v1alpha1
@@ -144,6 +145,13 @@ var debuildContainerTpl = template.Must(
 		// TODO: Find a base image that has build-essentials installed, that would improve startup time significantly, and it would pin the build tools we're using.
 		textwrap.Dedent(`
 				#syntax=docker/dockerfile:1.10
+				# OSS-Rebuild Dockerfile
+				# Package: {{.Target.Package}} ({{.Target.Ecosystem}})
+				# Version: {{.Target.Version}}
+				{{- if .Target.Artifact}}
+				# Artifact: {{.Target.Artifact}}
+				{{- end}}
+				# This Dockerfile rebuilds the above package from source for supply chain verification
 				FROM docker.io/library/debian:trixie-20250203-slim
 				RUN {{if .PrebuildAuth}}--mount=type=secret,id=auth_header {{end}}<<'EOF'
 				 set -eux
@@ -185,6 +193,13 @@ var alpineContainerTpl = template.Must(
 		// NOTE: For syntax docs, see https://docs.docker.com/build/dockerfile/release-notes/
 		textwrap.Dedent(`
 				#syntax=docker/dockerfile:1.10
+				# OSS-Rebuild Dockerfile
+				# Package: {{.Target.Package}} ({{.Target.Ecosystem}})
+				# Version: {{.Target.Version}}
+				{{- if .Target.Artifact}}
+				# Artifact: {{.Target.Artifact}}
+				{{- end}}
+				# This Dockerfile rebuilds the above package from source for supply chain verification
 				FROM docker.io/library/alpine:3.19
 				RUN {{if .PrebuildAuth}}--mount=type=secret,id=auth_header {{end}}<<'EOF'
 				 set -eux
@@ -547,6 +562,7 @@ func MakeDockerfile(input Input, opts RemoteOptions) (string, error) {
 			PrebuildDir:    opts.PrebuildConfig.Dir,
 			PrebuildAuth:   opts.PrebuildConfig.Auth,
 			Instructions:   instructions,
+			Target:         input.Target,
 		})
 	} else {
 		err = alpineContainerTpl.Execute(dockerfile, rebuildContainerArgs{
@@ -555,6 +571,7 @@ func MakeDockerfile(input Input, opts RemoteOptions) (string, error) {
 			PrebuildDir:    opts.PrebuildConfig.Dir,
 			PrebuildAuth:   opts.PrebuildConfig.Auth,
 			Instructions:   instructions,
+			Target:         input.Target,
 		})
 	}
 	if err != nil {

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -28,7 +28,7 @@ func TestMakeDockerfile(t *testing.T) {
 		{
 			name: "Basic Usage",
 			input: Input{
-				Target: Target{},
+				Target: Target{Ecosystem: NPM, Package: "example-pkg", Version: "1.0.0", Artifact: "example-pkg-1.0.0.tgz"},
 				Strategy: &ManualStrategy{
 					Location:   Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
 					SystemDeps: []string{"git", "make"},
@@ -41,6 +41,11 @@ func TestMakeDockerfile(t *testing.T) {
 				UseTimewarp: false,
 			},
 			expected: `#syntax=docker/dockerfile:1.10
+# OSS-Rebuild Dockerfile
+# Package: example-pkg (npm)
+# Version: 1.0.0
+# Artifact: example-pkg-1.0.0.tgz
+# This Dockerfile rebuilds the above package from source for supply chain verification
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -65,7 +70,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 		{
 			name: "With Timewarp",
 			input: Input{
-				Target: Target{},
+				Target: Target{Ecosystem: NPM, Package: "example-pkg", Version: "1.0.0", Artifact: "example-pkg-1.0.0.tgz"},
 				Strategy: &ManualStrategy{
 					Location:   Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
 					SystemDeps: []string{"git", "make"},
@@ -79,6 +84,11 @@ ENTRYPOINT ["/bin/sh","/build"]
 				PrebuildConfig: PrebuildConfig{Bucket: "my-bucket"},
 			},
 			expected: `#syntax=docker/dockerfile:1.10
+# OSS-Rebuild Dockerfile
+# Package: example-pkg (npm)
+# Version: 1.0.0
+# Artifact: example-pkg-1.0.0.tgz
+# This Dockerfile rebuilds the above package from source for supply chain verification
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -107,7 +117,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 		{
 			name: "With Timewarp and auth",
 			input: Input{
-				Target: Target{},
+				Target: Target{Ecosystem: NPM, Package: "example-pkg", Version: "1.0.0", Artifact: "example-pkg-1.0.0.tgz"},
 				Strategy: &ManualStrategy{
 					Location:   Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
 					SystemDeps: []string{"git", "make"},
@@ -122,6 +132,11 @@ ENTRYPOINT ["/bin/sh","/build"]
 				Project:        "my-project",
 			},
 			expected: `#syntax=docker/dockerfile:1.10
+# OSS-Rebuild Dockerfile
+# Package: example-pkg (npm)
+# Version: 1.0.0
+# Artifact: example-pkg-1.0.0.tgz
+# This Dockerfile rebuilds the above package from source for supply chain verification
 FROM docker.io/library/alpine:3.19
 RUN --mount=type=secret,id=auth_header <<'EOF'
  set -eux
@@ -150,7 +165,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 		{
 			name: "With Timewarp at a Subdir",
 			input: Input{
-				Target: Target{},
+				Target: Target{Ecosystem: NPM, Package: "example-pkg", Version: "1.0.0", Artifact: "example-pkg-1.0.0.tgz"},
 				Strategy: &ManualStrategy{
 					Location:   Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
 					SystemDeps: []string{"git", "make"},
@@ -164,6 +179,11 @@ ENTRYPOINT ["/bin/sh","/build"]
 				PrebuildConfig: PrebuildConfig{Bucket: "my-bucket", Dir: "v0.0.0-202501010000-feeddeadbeef00"},
 			},
 			expected: `#syntax=docker/dockerfile:1.10
+# OSS-Rebuild Dockerfile
+# Package: example-pkg (npm)
+# Version: 1.0.0
+# Artifact: example-pkg-1.0.0.tgz
+# This Dockerfile rebuilds the above package from source for supply chain verification
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -192,7 +212,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 		{
 			name: "Multi-Line Scripts",
 			input: Input{
-				Target: Target{},
+				Target: Target{Ecosystem: PyPI, Package: "example-pkg", Version: "1.0.0", Artifact: "example-pkg-1.0.0.whl"},
 				Strategy: &ManualStrategy{
 					Location:   Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
 					SystemDeps: []string{"curl", "jq"},
@@ -209,6 +229,11 @@ python3 setup.py sdist`,
 				UseTimewarp: false,
 			},
 			expected: `#syntax=docker/dockerfile:1.10
+# OSS-Rebuild Dockerfile
+# Package: example-pkg (pypi)
+# Version: 1.0.0
+# Artifact: example-pkg-1.0.0.whl
+# This Dockerfile rebuilds the above package from source for supply chain verification
 FROM docker.io/library/alpine:3.19
 RUN <<'EOF'
  set -eux
@@ -239,6 +264,9 @@ ENTRYPOINT ["/bin/sh","/build"]
 			input: Input{
 				Target: Target{
 					Ecosystem: Debian,
+					Package:   "example-pkg",
+					Version:   "1.0.0",
+					Artifact:  "example-pkg_1.0.0_amd64.deb",
 				},
 				Strategy: &ManualStrategy{
 					Location:   Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
@@ -252,6 +280,11 @@ ENTRYPOINT ["/bin/sh","/build"]
 				UseTimewarp: false,
 			},
 			expected: `#syntax=docker/dockerfile:1.10
+# OSS-Rebuild Dockerfile
+# Package: example-pkg (debian)
+# Version: 1.0.0
+# Artifact: example-pkg_1.0.0_amd64.deb
+# This Dockerfile rebuilds the above package from source for supply chain verification
 FROM docker.io/library/debian:trixie-20250203-slim
 RUN <<'EOF'
  set -eux


### PR DESCRIPTION
## Summary
This PR adds informative header comments to all generated Dockerfiles to improve their self-documentation and make them easier to understand for maintainers, security auditors, and users.

## Changes
- Added header comment generation to both Alpine and Debian Dockerfile templates
- Headers include package name, ecosystem, version, artifact, and purpose description  
- Updated all test cases to expect the new header format
- Feature works across all supported ecosystems (NPM, PyPI, Debian, CratesIO, Maven)

## Example Output
**Before:**
```dockerfile
#syntax=docker/dockerfile:1.10
FROM docker.io/library/alpine:3.19
RUN <<'EOF'
# ... build commands
```

**After:**
```#syntax=docker/dockerfile:1.10
# OSS-Rebuild Dockerfile
# Package: express (npm)
# Version: 4.18.2
# Artifact: express-4.18.2.tgz
# This Dockerfile rebuilds the above package from source for supply chain verification
FROM docker.io/library/alpine:3.19
RUN <<'EOF'
# ... build commands
```

## Benefits
- Should be easy for anyone to immediatley understand what package is being rebuilt
- From an auditing perspective, it's clear what version, artifact, and package we intended to rebuild
- Helps with maintenance and debugging of the generated Dockerfiles

## Testing
- All existing test pass
- Updated test cases to handle header generation (this was previously assumed to be empty)
- Manually verified for PyPI and NPM.
- Build succeeded without errors.

