### PR TITLE
Replace license badge with link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSS Rebuild
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/google/oss-rebuild/blob/main/LICENSE)
+[![Docs](https://img.shields.io/badge/📖%20Docs-docs.oss--rebuild.dev-informational)](https://docs.oss-rebuild.dev/)
 [![Go Report Card](https://goreportcard.com/badge/google/oss-rebuild)](https://goreportcard.com/report/google/oss-rebuild)
 [![Go Reference](https://pkg.go.dev/badge/github.com/google/oss-rebuild.svg)](https://pkg.go.dev/github.com/google/oss-rebuild)
 


### PR DESCRIPTION
Given we only have so much horizontal real estate, I think it makes
sense to prioritize the external link. We also have no existing
discoverability for the docs site so this at least gives us something,
although we should also consider adding more.

#658