### PR TITLE
fix: add missing case for Maven rebuild strategy

### DIFF
--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -105,6 +105,10 @@ func (oneof *StrategyOneOf) Strategy() (rebuild.Strategy, error) {
 			num++
 			s = oneof.WorkflowStrategy
 		}
+		if oneof.MavenBuild != nil {
+			num++
+			s = oneof.MavenBuild
+		}
 	}
 	if num != 1 {
 		return nil, errors.Errorf("serialized StrategyOneOf should have exactly one strategy, found: %d", num)


### PR DESCRIPTION
The change adds the missing strategy.