### PR TITLE
feat: setup Java environment for MavenBuild strategy

### DIFF
--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -4,6 +4,9 @@
 package maven
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/google/oss-rebuild/pkg/rebuild/flow"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 )
@@ -24,14 +27,52 @@ func (b *MavenBuild) ToWorkflow() *rebuild.WorkflowStrategy {
 			Uses: "git-checkout",
 		}},
 		Deps: []flow.Step{{
-			Runs: "true",
+			Uses: "maven/deps/basic",
+			With: map[string]string{
+				"version": getOnlyMajorVersion(b.JDKVersion),
+			},
 		}},
 		Build: []flow.Step{{
-			Uses: "true",
+			Runs: "echo 'Building Maven project'",
 		}},
 	}
 }
 
 func (b *MavenBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
 	return b.ToWorkflow().GenerateFor(t, be)
+}
+
+func init() {
+	for _, t := range toolkit {
+		flow.Tools.MustRegister(t)
+	}
+}
+
+var toolkit = []*flow.Tool{
+	{
+		Name: "maven/setup-java",
+		Steps: []flow.Step{{
+			Runs: "apk add openjdk{{.With.version}}",
+		}},
+	},
+
+	{
+		Name: "maven/deps/basic",
+		Steps: []flow.Step{
+			{
+				Uses: "maven/setup-java",
+				With: map[string]string{
+					"version": "{{.With.version}}",
+				},
+			},
+		},
+	},
+}
+
+func getOnlyMajorVersion(version string) string {
+	if major, err := strconv.Atoi(version); err == nil {
+		return strconv.Itoa(major)
+	}
+	parts := strings.Split(version, ".")
+	return parts[0]
 }


### PR DESCRIPTION
Parsing only the major version of JDK and then using Alpine's package manager to download the JDK. `apk add openjdk{{.With.version}}` works for the LTS 8, 11, 17, and 21, not sure about the rest. If we want to be more fine-grained, we can use links in https://wiki.openjdk.org/display/JDKUpdates/Archived+Releases to get JDK for a specific version (including patch version).