### PR TITLE
Fix content summary hash buffer use

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -254,7 +254,8 @@ func NewContentSummaryFromTar(tr *tar.Reader) (*ContentSummary, error) {
 		}
 		cs.Files = append(cs.Files, header.Name)
 		cs.CRLFCount += bytes.Count(buf, []byte{'\r', '\n'})
-		cs.FileHashes = append(cs.FileHashes, hex.EncodeToString(sha256.New().Sum(buf)))
+		h := sha256.Sum256(buf)
+		cs.FileHashes = append(cs.FileHashes, hex.EncodeToString(h[:]))
 	}
 	return &cs, nil
 }

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -35,7 +35,8 @@ func NewContentSummaryFromZip(zr *zip.Reader) (*ContentSummary, error) {
 		}
 		cs.Files = append(cs.Files, f.Name)
 		cs.CRLFCount += bytes.Count(buf, []byte{'\r', '\n'})
-		cs.FileHashes = append(cs.FileHashes, hex.EncodeToString(sha256.New().Sum(buf)))
+		h := sha256.Sum256(buf)
+		cs.FileHashes = append(cs.FileHashes, hex.EncodeToString(h[:]))
 	}
 	return &cs, nil
 }


### PR DESCRIPTION
Both the zip and tar calculation of content summary were using sha256
incorrectly. Calling `sha256.New().Sum(buf)` is equivalent to
`append(buf, sha256.Sum256(nil))`.

This means our content summaries weren't actually summaries. They were
including the entire contents of the underlying files. This is a correct
way of detecting differences, but it might have contributed to OOM
events by nature of the large size of the "summaries".