### PR TITLE
Resolve source repository URL from parent

### DIFF
--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -32,45 +32,13 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 	if err != nil {
 		return "", err
 	}
-	for pom.Repo() == "" && pom.Parent.ArtifactID != "" {
-		pom, err = resolveParentPom(ctx, pom, t, mux)
+	for pom.SCMURL == "" && pom.Parent.ArtifactID != "" {
+		pom, err = ResolveParentPom(ctx, pom, mux)
 		if err != nil {
 			return "", errors.Errorf("failed to resolve parent POM for %s: %v", t.Package, err)
 		}
 	}
 	return uri.CanonicalizeRepoURI(pom.Repo())
-}
-
-func resolveParentPom(ctx context.Context, pom PomXML, t rebuild.Target, mux rebuild.RegistryMux) (PomXML, error) {
-	if pom.Parent.ArtifactID == "" {
-		return pom, nil
-	}
-	parent, err := NewPomXML(ctx, rebuild.Target{
-		Ecosystem: t.Ecosystem,
-		Package:   fmt.Sprintf("%s:%s", getGroupID(pom, pom.Parent), pom.Parent.ArtifactID),
-		Version:   getVersionID(pom, pom.Parent),
-		Artifact:  t.Artifact,
-	}, mux)
-	if err != nil {
-		return PomXML{}, err
-	}
-	return parent, nil
-}
-
-func getGroupID(pom PomXML, parent Parent) string {
-	// prioritize the groupID of parent
-	if parent.GroupID != "" {
-		return parent.GroupID
-	}
-	return pom.GroupID
-}
-
-func getVersionID(pom PomXML, parent Parent) string {
-	// prioritize the versionID of parent
-	if parent.VersionID != "" {
-		return parent.VersionID
-	}
-	return pom.VersionID
 }
 
 func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, fs billy.Filesystem, s storage.Storer) (r rebuild.RepoConfig, err error) {

--- a/pkg/rebuild/maven/infer_test.go
+++ b/pkg/rebuild/maven/infer_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/google/oss-rebuild/pkg/archive"
@@ -19,15 +18,15 @@ import (
 
 type mockMavenRegistry struct {
 	maven.Registry
-	releaseFileContent io.ReadCloser
-	releaseFileError   error
+	artifactCoordinates map[struct{ PackageName, VersionID, FileType string }][]byte
+	releaseFileError    error
 }
 
 func (m *mockMavenRegistry) ReleaseFile(ctx context.Context, name string, version string, fileType string) (io.ReadCloser, error) {
 	if m.releaseFileError != nil {
 		return nil, m.releaseFileError
 	}
-	return m.releaseFileContent, nil
+	return io.NopCloser(bytes.NewReader(m.artifactCoordinates[struct{ PackageName, VersionID, FileType string }{PackageName: name, VersionID: version, FileType: fileType}])), nil
 }
 
 func TestJDKVersionInference(t *testing.T) {
@@ -101,7 +100,9 @@ func TestJDKVersionInference(t *testing.T) {
 
 			mockMux := rebuild.RegistryMux{
 				Maven: &mockMavenRegistry{
-					releaseFileContent: io.NopCloser(bytes.NewReader(buf.Bytes())),
+					artifactCoordinates: map[struct{ PackageName, VersionID, FileType string }][]byte{
+						{"dummy", "dummy", maven.TypeJar}: buf.Bytes(),
+					},
 				},
 			}
 			got, err := getJarJDK(context.Background(), "dummy", "dummy", mockMux)
@@ -163,9 +164,11 @@ func TestGetClassFileMajorVersion(t *testing.T) {
 
 func TestSourceRepositoryURLInference(t *testing.T) {
 	testCases := []struct {
-		name string
-		pom  []PomXML
-		url  string
+		name        string
+		pom         []PomXML
+		targetPom   rebuild.Target
+		expectedURL string
+		wantErr     bool
 	}{
 		{
 			name: "get SCM URL",
@@ -178,7 +181,12 @@ func TestSourceRepositoryURLInference(t *testing.T) {
 					URL:        "https://example.com/child",
 				},
 			},
-			url: "https://github.com/example/child",
+			targetPom: rebuild.Target{
+				Package: "org.example:child",
+				Version: "1.0.0",
+			},
+			expectedURL: "https://github.com/example/child",
+			wantErr:     false,
 		},
 		{
 			name: "get URL",
@@ -190,7 +198,12 @@ func TestSourceRepositoryURLInference(t *testing.T) {
 					URL:        "https://example.com/child",
 				},
 			},
-			url: "https://example.com/child",
+			targetPom: rebuild.Target{
+				Package: "com.example:child",
+				Version: "1.0.0",
+			},
+			expectedURL: "https://example.com/child",
+			wantErr:     false,
 		},
 		{
 			name: "get parent SCM URL",
@@ -212,7 +225,12 @@ func TestSourceRepositoryURLInference(t *testing.T) {
 					SCMURL:     "https://github.com/example/parent",
 				},
 			},
-			url: "https://github.com/example/parent",
+			targetPom: rebuild.Target{
+				Package: "com.example:child",
+				Version: "1.0.0",
+			},
+			expectedURL: "https://github.com/example/parent",
+			wantErr:     false,
 		},
 		{
 			name: "get URL of parent and not child",
@@ -231,34 +249,84 @@ func TestSourceRepositoryURLInference(t *testing.T) {
 				{
 					GroupID:    "com.example.parent",
 					ArtifactID: "parent",
-					VersionID:  "2.0.0",
+					VersionID:  "1.0.0",
 					URL:        "https://example.com/parent",
 				},
 			},
-			url: "https://example.com/parent",
+			targetPom: rebuild.Target{
+				Package: "com.example:child",
+				Version: "1.0.0",
+			},
+			expectedURL: "https://example.com/parent",
+			wantErr:     false,
+		},
+		{
+			name: "should throw an error for no valid URL",
+			pom: []PomXML{
+				{
+					GroupID:    "com.example",
+					ArtifactID: "child",
+					VersionID:  "1.0.0",
+					Parent: Parent{
+						GroupID:    "com.example.parent",
+						ArtifactID: "parent",
+						VersionID:  "1.0.0",
+					},
+				},
+				{
+					GroupID:    "com.example.parent",
+					ArtifactID: "parent",
+					VersionID:  "1.0.0",
+				},
+			},
+			targetPom: rebuild.Target{
+				Package: "com.example:child",
+				Version: "1.0.0",
+			},
+			expectedURL: "",
+			wantErr:     true,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			for idx, pom := range tc.pom {
-				mockMux := rebuild.RegistryMux{
-					Maven: &mockMavenRegistry{
-						releaseFileContent: io.NopCloser(strings.NewReader("<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\"><groupId>" + pom.GroupID + "</groupId><artifactId>" + pom.ArtifactID + "</artifactId><version>" + pom.VersionID + "</version><url>" + pom.URL + "</url><scm><url>" + pom.SCMURL + "</url></scm></project>")),
-					},
+			mockRegistry := &mockMavenRegistry{
+				artifactCoordinates: make(map[struct{ PackageName, VersionID, FileType string }][]byte),
+			}
+			for _, pom := range tc.pom {
+				addPomArtifact(mockRegistry, &pom)
+			}
+			mockMux := rebuild.RegistryMux{
+				Maven: mockRegistry,
+			}
+			got, err := Rebuilder{}.InferRepo(context.Background(), tc.targetPom, mockMux)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("InferRepo() = %q, want error", got)
 				}
-				got, err := Rebuilder{}.InferRepo(context.Background(), rebuild.Target{
-					Ecosystem: rebuild.Maven,
-					Package:   fmt.Sprintf("%s:%s", pom.GroupID, pom.ArtifactID),
-					Version:   pom.VersionID,
-				}, mockMux)
-				if err != nil && idx == len(tc.pom)-1 {
+			} else {
+				if err != nil {
 					t.Fatalf("InferRepo() error = %v", err)
 				}
-				if got != tc.url && idx == len(tc.pom)-1 {
-					t.Errorf("InferRepo() = %q, want %q", got, tc.url)
+				if got != tc.expectedURL {
+					t.Errorf("InferRepo() = %q, want %q", got, tc.expectedURL)
 				}
 			}
 
 		})
 	}
+}
+
+func addPomArtifact(mavenRegistry *mockMavenRegistry, pom *PomXML) {
+	key := struct{ PackageName, VersionID, FileType string }{
+		PackageName: fmt.Sprintf("%s:%s", pom.GroupID, pom.ArtifactID),
+		VersionID:   pom.VersionID,
+		FileType:    maven.TypePOM,
+	}
+	xml := "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\"><groupId>" + pom.GroupID + "</groupId><artifactId>" + pom.ArtifactID + "</artifactId><version>" + pom.VersionID + "</version>"
+	// Add parent if present
+	if pom.Parent.GroupID != "" && pom.Parent.ArtifactID != "" && pom.Parent.VersionID != "" {
+		xml += "<parent><groupId>" + pom.Parent.GroupID + "</groupId><artifactId>" + pom.Parent.ArtifactID + "</artifactId><version>" + pom.Parent.VersionID + "</version></parent>"
+	}
+	xml += "<url>" + pom.URL + "</url><scm><url>" + pom.SCMURL + "</url></scm></project>"
+	mavenRegistry.artifactCoordinates[key] = []byte(xml)
 }

--- a/pkg/rebuild/maven/pom.go
+++ b/pkg/rebuild/maven/pom.go
@@ -15,21 +15,25 @@ import (
 // PomXML is the root element of a Maven POM file.
 // The root element is called "project" and this is handled by the Decode method.
 type PomXML struct {
-	GroupID    string  `xml:"groupId"`
-	ArtifactID string  `xml:"artifactId"`
-	VersionID  string  `xml:"version"`
-	URL        string  `xml:"url"`
-	SCMURL     string  `xml:"scm>url"`
-	Parent     *PomXML `xml:"parent"`
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	VersionID  string `xml:"version"`
+	URL        string `xml:"url"`
+	SCMURL     string `xml:"scm>url"`
+	Parent     Parent `xml:"parent"`
+}
+
+// Parent represents the parent package ref within a Maven POM file.
+type Parent struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	VersionID  string `xml:"version"`
 }
 
 // Repo returns the repository URL for a Maven package.
 func (p *PomXML) Repo() string {
 	if p.SCMURL != "" {
 		return p.SCMURL
-	}
-	if p.Parent != nil {
-		return p.Parent.Repo()
 	}
 	return p.URL
 }

--- a/pkg/rebuild/maven/pom.go
+++ b/pkg/rebuild/maven/pom.go
@@ -15,25 +15,21 @@ import (
 // PomXML is the root element of a Maven POM file.
 // The root element is called "project" and this is handled by the Decode method.
 type PomXML struct {
-	GroupID    string `xml:"groupId"`
-	ArtifactID string `xml:"artifactId"`
-	VersionID  string `xml:"version"`
-	URL        string `xml:"url"`
-	SCMURL     string `xml:"scm>url"`
-	Parent     Parent `xml:"parent"`
-}
-
-// Parent represents the parent package ref within a Maven POM file.
-type Parent struct {
-	GroupID    string `xml:"groupId"`
-	ArtifactID string `xml:"artifactId"`
-	VersionID  string `xml:"version"`
+	GroupID    string  `xml:"groupId"`
+	ArtifactID string  `xml:"artifactId"`
+	VersionID  string  `xml:"version"`
+	URL        string  `xml:"url"`
+	SCMURL     string  `xml:"scm>url"`
+	Parent     *PomXML `xml:"parent"`
 }
 
 // Repo returns the repository URL for a Maven package.
 func (p *PomXML) Repo() string {
 	if p.SCMURL != "" {
 		return p.SCMURL
+	}
+	if p.Parent != nil {
+		return p.Parent.Repo()
 	}
 	return p.URL
 }

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -61,7 +61,7 @@ func TestNewPomXML(t *testing.T) {
 			input:    "<project><parent><groupId>PARENT_GROUP_ID</groupId></parent><groupId>GROUP_ID</groupId></project>",
 			expected: PomXML{
 				GroupID: "GROUP_ID",
-				Parent: &PomXML{
+				Parent: Parent{
 					GroupID: "PARENT_GROUP_ID",
 				},
 			},

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -61,7 +61,7 @@ func TestNewPomXML(t *testing.T) {
 			input:    "<project><parent><groupId>PARENT_GROUP_ID</groupId></parent><groupId>GROUP_ID</groupId></project>",
 			expected: PomXML{
 				GroupID: "GROUP_ID",
-				Parent: Parent{
+				Parent: &PomXML{
 					GroupID: "PARENT_GROUP_ID",
 				},
 			},


### PR DESCRIPTION
Fixes #700 

I prioritize looking for `scm.url` in the `pom` or `parent pom` as that URL points to the source repository. `url`, by convention, is the project home page. For OSS-Rebuild, `url` is https://oss-rebuild.dev/ and not `https://github.com/google/oss-rebuild`.

We also need to resolve the parent pom for to scan for `scm.url` from there.