### PR TITLE
Filter on pom.xml using base name and non test directory

### DIFF
--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -283,7 +283,10 @@ func findPomXML(commit *object.Commit, pkg string) (*PomXML, string, error) {
 	var names []string
 	var pomXMLs []PomXML
 	commitTree.Files().ForEach(func(f *object.File) error {
-		if !strings.HasSuffix(f.Name, "pom.xml") {
+		// Per Maven conventions, skip non-"pom.xml" files and those inside a `src` directory (unlikely to contain metadata).
+		// Reference: https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html
+		// Note: This will miss pom files, with name other than "pom.xml", whose paths are explicitly passed during build via "-f".
+		if path.Base(f.Name) != "pom.xml" || strings.HasPrefix(f.Name, "src/") || strings.Contains(f.Name, "/src/") {
 			return nil
 		}
 		pomXML, err := getPomXML(commitTree, f.Name)


### PR DESCRIPTION
During inference, we first infer the the path to the pom.xml in the `HEAD` revision. We should ensure that this pom file's basename should exactly be `pom.xml` (and not suffix) and should not be a test resource. This hinder incorrect inference later when we do version heuristic search.

Note, that this only affects 5 artifacts in the current benchmark.