### PR TITLE
Move timewarp config into Rebuilder interface

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -224,13 +224,13 @@ func buildAndAttest(ctx context.Context, deps *RebuildPackageDeps, mux rebuild.R
 		rebuild.DockerfileAsset:     deps.LocalMetadataStore,
 		rebuild.BuildInfoAsset:      deps.LocalMetadataStore,
 	})
-	h, err := deps.GCBExecutor.Start(ctx, rebuild.Input{
+	in := rebuild.Input{
 		Target:   t,
 		Strategy: strategy,
-	}, build.Options{
-		BuildID: obID,
-		// TODO: This needs to be configured by the ecosystem-specific code.
-		UseTimewarp:       true,
+	}
+	h, err := deps.GCBExecutor.Start(ctx, in, build.Options{
+		BuildID:           obID,
+		UseTimewarp:       rebuilders[t.Ecosystem].UsesTimewarp(in),
 		UseNetworkProxy:   useProxy,
 		UseSyscallMonitor: useSyscallMonitor,
 		Resources: build.Resources{

--- a/pkg/rebuild/cratesio/rebuild.go
+++ b/pkg/rebuild/cratesio/rebuild.go
@@ -177,6 +177,10 @@ func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, opts 
 	return rebuild.RebuildRemote(ctx, input, opts)
 }
 
+func (r Rebuilder) UsesTimewarp(input rebuild.Input) bool {
+	return false
+}
+
 func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
 	crate, err := mux.CratesIO.Version(ctx, t.Package, t.Version)
 	if err != nil {

--- a/pkg/rebuild/debian/rebuild.go
+++ b/pkg/rebuild/debian/rebuild.go
@@ -87,6 +87,10 @@ func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, opts 
 	return rebuild.RebuildRemote(ctx, input, opts)
 }
 
+func (r Rebuilder) UsesTimewarp(input rebuild.Input) bool {
+	return false
+}
+
 func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
 	_, name, err := ParseComponent(t.Package)
 	if err != nil {

--- a/pkg/rebuild/maven/rebuild.go
+++ b/pkg/rebuild/maven/rebuild.go
@@ -21,6 +21,10 @@ func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, opts 
 	return rebuild.RebuildRemote(ctx, input, opts)
 }
 
+func (r Rebuilder) UsesTimewarp(input rebuild.Input) bool {
+	return false
+}
+
 func (Rebuilder) Rebuild(ctx context.Context, t rebuild.Target, inst rebuild.Instructions, fs billy.Filesystem) error {
 	if _, err := rebuild.ExecuteScript(ctx, fs.Root(), inst.Source); err != nil {
 		return errors.Wrap(err, "fetching source")

--- a/pkg/rebuild/npm/rebuild.go
+++ b/pkg/rebuild/npm/rebuild.go
@@ -182,6 +182,10 @@ func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, opts 
 	return rebuild.RebuildRemote(ctx, input, opts)
 }
 
+func (r Rebuilder) UsesTimewarp(input rebuild.Input) bool {
+	return true
+}
+
 func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
 	vmeta, err := mux.NPM.Version(ctx, t.Package, t.Version)
 	if err != nil {

--- a/pkg/rebuild/pypi/rebuild.go
+++ b/pkg/rebuild/pypi/rebuild.go
@@ -114,6 +114,10 @@ func (r Rebuilder) RebuildRemote(ctx context.Context, input rebuild.Input, opts 
 	return rebuild.RebuildRemote(ctx, input, opts)
 }
 
+func (r Rebuilder) UsesTimewarp(input rebuild.Input) bool {
+	return true
+}
+
 func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
 	release, err := mux.PyPI.Release(ctx, t.Package, t.Version)
 	if err != nil {

--- a/pkg/rebuild/rebuild/rebuild.go
+++ b/pkg/rebuild/rebuild/rebuild.go
@@ -18,5 +18,6 @@ type Rebuilder interface {
 	Rebuild(context.Context, Target, Instructions, billy.Filesystem) error
 	Compare(context.Context, Target, Asset, Asset, AssetStore, Instructions) (error, error)
 	RebuildRemote(context.Context, Input, RemoteOptions) error
+	UsesTimewarp(Input) bool
 	UpstreamURL(context.Context, Target, RegistryMux) (string, error)
 }


### PR DESCRIPTION
This PR attempts to be be as minimal as possible while still unblocking deprecation of the RebuildRemote interface.