### PR TITLE
Fix output path for artifact in a submodule

### DIFF
--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -4,6 +4,8 @@
 package maven
 
 import (
+	"path"
+
 	"github.com/google/oss-rebuild/internal/textwrap"
 	"github.com/pkg/errors"
 
@@ -48,7 +50,7 @@ func (b *MavenBuild) ToWorkflow() (*rebuild.WorkflowStrategy, error) {
 				Needs: []string{"maven"},
 			},
 		},
-		OutputDir: "target/",
+		OutputDir: path.Join(b.Dir, "target"),
 	}, nil
 }
 

--- a/pkg/rebuild/maven/strategy_test.go
+++ b/pkg/rebuild/maven/strategy_test.go
@@ -42,7 +42,7 @@ wget -q -O - "https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linu
 					export JAVA_HOME=/opt/jdk
 					export PATH=$JAVA_HOME/bin:$PATH
 					mvn clean package -DskipTests`[1:]),
-				OutputPath: "target/ldapchai-0.8.6.jar",
+				OutputPath: "dir/target/ldapchai-0.8.6.jar",
 			},
 			false,
 		},

--- a/pkg/rebuild/rebuild/strategy.go
+++ b/pkg/rebuild/rebuild/strategy.go
@@ -10,7 +10,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Location is where a set of rebuild instruction should be executed.
+// Location defines the source code to be used for a rebuild, specifying the Git
+// repository, a reference (like a commit hash or tag), and an optional
+// subdirectory for executing the build and/or for expected output.
 type Location struct {
 	Repo string `json:"repo" yaml:"repo"`
 	Ref  string `json:"ref" yaml:"ref"`


### PR DESCRIPTION
Initially, we would configure the output path as the directory `target/`, but if the artifact is in a submodule, the artifact would be inside the `target` directory which in turn is inside the submodule. For example, the artifact path of `maven!ch.qos.logback:logback-classic!1.5.18!logback-classic-1.5.18.jar ` is `logback-classic/target/logback-classic-1.5.18.jar` and not `target/logback-classic-1.5.18.jar`. We use `Dir` attribute in the MavenBuild struct. This `Dir` is the directory of the pom.xml that we infer and by default the target directory is at the same level as pom.xml. 