### PR TITLE
Add meta.AllRebuilders

### DIFF
--- a/analyzer/network/analyzerservice/analyze.go
+++ b/analyzer/network/analyzerservice/analyze.go
@@ -20,10 +20,7 @@ import (
 	"github.com/google/oss-rebuild/internal/verifier"
 	"github.com/google/oss-rebuild/pkg/archive"
 	"github.com/google/oss-rebuild/pkg/attestation"
-	cratesrb "github.com/google/oss-rebuild/pkg/rebuild/cratesio"
-	debianrb "github.com/google/oss-rebuild/pkg/rebuild/debian"
-	npmrb "github.com/google/oss-rebuild/pkg/rebuild/npm"
-	pypirb "github.com/google/oss-rebuild/pkg/rebuild/pypi"
+	"github.com/google/oss-rebuild/pkg/rebuild/meta"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/google/oss-rebuild/pkg/rebuild/stability"
@@ -165,7 +162,7 @@ func getBuildDefinition(rebuildAttestation *attestation.RebuildAttestation) (*sc
 }
 
 func compareArtifacts(ctx context.Context, mux rebuild.RegistryMux, t rebuild.Target, remoteStore rebuild.LocatableAssetStore, rebuildAttestation *attestation.RebuildAttestation) (*verifier.ArtifactSummary, *verifier.ArtifactSummary, error) {
-	rebuilder, ok := rebuilders[t.Ecosystem]
+	rebuilder, ok := meta.AllRebuilders[t.Ecosystem]
 	if !ok {
 		return nil, nil, errors.New("unsupported ecosystem")
 	}
@@ -203,15 +200,8 @@ func compareArtifacts(ctx context.Context, mux rebuild.RegistryMux, t rebuild.Ta
 	return &rb, &up, nil
 }
 
-var rebuilders = map[rebuild.Ecosystem]rebuild.Rebuilder{
-	rebuild.NPM:      &npmrb.Rebuilder{},
-	rebuild.PyPI:     &pypirb.Rebuilder{},
-	rebuild.CratesIO: &cratesrb.Rebuilder{},
-	rebuild.Debian:   &debianrb.Rebuilder{},
-}
-
 func executeNetworkRebuild(ctx context.Context, deps *AnalyzerDeps, t rebuild.Target, strategy rebuild.Strategy, rebuildAttestation *attestation.RebuildAttestation) (string, error) {
-	rebuilder, ok := rebuilders[t.Ecosystem]
+	rebuilder, ok := meta.AllRebuilders[t.Ecosystem]
 	if !ok {
 		return "", errors.New("unsupported ecosystem")
 	}

--- a/pkg/rebuild/meta/meta.go
+++ b/pkg/rebuild/meta/meta.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package meta
+
+import (
+	cratesrb "github.com/google/oss-rebuild/pkg/rebuild/cratesio"
+	debianrb "github.com/google/oss-rebuild/pkg/rebuild/debian"
+	mavenrb "github.com/google/oss-rebuild/pkg/rebuild/maven"
+	npmrb "github.com/google/oss-rebuild/pkg/rebuild/npm"
+	pypirb "github.com/google/oss-rebuild/pkg/rebuild/pypi"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+var AllRebuilders = map[rebuild.Ecosystem]rebuild.Rebuilder{
+	rebuild.NPM:      &npmrb.Rebuilder{},
+	rebuild.PyPI:     &pypirb.Rebuilder{},
+	rebuild.CratesIO: &cratesrb.Rebuilder{},
+	rebuild.Debian:   &debianrb.Rebuilder{},
+	rebuild.Maven:    &mavenrb.Rebuilder{},
+}

--- a/tools/benchmark/run/local.go
+++ b/tools/benchmark/run/local.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/oss-rebuild/pkg/build/local"
 	"github.com/google/oss-rebuild/pkg/rebuild/cratesio"
 	"github.com/google/oss-rebuild/pkg/rebuild/debian"
+	"github.com/google/oss-rebuild/pkg/rebuild/meta"
 	"github.com/google/oss-rebuild/pkg/rebuild/npm"
 	"github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -102,19 +103,8 @@ func (s *localExecutionService) RebuildPackage(ctx context.Context, req schema.R
 func (s *localExecutionService) infer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (rebuild.Strategy, error) {
 	mem := memory.NewStorage()
 	fs := memfs.New()
-	var rebuilder rebuild.Rebuilder
-	switch t.Ecosystem {
-	case rebuild.NPM:
-		rebuilder = npm.Rebuilder{}
-	case rebuild.PyPI:
-		rebuilder = pypi.Rebuilder{}
-	case rebuild.CratesIO:
-		rebuilder = cratesio.Rebuilder{}
-	case rebuild.Debian:
-		rebuilder = debian.Rebuilder{}
-	case rebuild.Maven:
-		return nil, errors.New("maven not implemented")
-	default:
+	rebuilder, ok := meta.AllRebuilders[t.Ecosystem]
+	if !ok {
 		return nil, errors.New("unsupported ecosystem")
 	}
 	repo, err := rebuilder.InferRepo(ctx, t, mux)


### PR DESCRIPTION
It's common that we want to switch using target and get access to the
ecosystem-specific behavior. This package makes that relatively
straightforward, and makes adding new ecosystems easier.