### PR TITLE
Replace ReleaseFile with new Artifact API

### DIFF
--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/google/oss-rebuild/internal/uri"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
-	"github.com/google/oss-rebuild/pkg/registry/maven"
 	"github.com/pkg/errors"
 )
 
@@ -123,7 +122,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 		}
 		return cfg, errors.Errorf("no valid git ref")
 	}
-	jdk, err := inferOrFallbackToDefaultJDK(ctx, name, version, mux)
+	jdk, err := inferOrFallbackToDefaultJDK(ctx, t, mux)
 	if err != nil {
 		return cfg, errors.Wrap(err, "fetching JDK")
 	}
@@ -150,8 +149,8 @@ func getPomXML(tree *object.Tree, path string) (pomXML PomXML, err error) {
 }
 
 // inferOrFallbackToDefaultJDK tries to infer the JDK version from the artifact's metadata, falling back to a default if necessary.
-func inferOrFallbackToDefaultJDK(ctx context.Context, name, version string, mux rebuild.RegistryMux) (string, error) {
-	jdk, err := inferJDKVersion(ctx, name, version, mux)
+func inferOrFallbackToDefaultJDK(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	jdk, err := inferJDKVersion(ctx, t, mux)
 	if err != nil {
 		return "", errors.Wrap(err, "fetching JDK")
 	}
@@ -166,8 +165,8 @@ func inferOrFallbackToDefaultJDK(ctx context.Context, name, version string, mux 
 }
 
 // inferJDKVersion gets the JDK version from the MANIFEST or Java bytecode.
-func inferJDKVersion(ctx context.Context, name, version string, mux rebuild.RegistryMux) (string, error) {
-	releaseFile, err := mux.Maven.ReleaseFile(ctx, name, version, maven.TypeJar)
+func inferJDKVersion(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	releaseFile, err := mux.Maven.Artifact(ctx, t.Package, t.Version, t.Artifact)
 	if err != nil {
 		return "", errors.Wrap(err, "fetching jar file")
 	}

--- a/pkg/rebuild/maven/pom.go
+++ b/pkg/rebuild/maven/pom.go
@@ -64,7 +64,7 @@ func (p *PomXML) Version() string {
 // TODO: This will ensure that we can simply resolve parent POM by only changing the target, thus eliminating the need for `ResolveParentPom`.
 func NewPomXML(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (PomXML, error) {
 	var p PomXML
-	r, err := mux.Maven.ReleaseFile(ctx, t.Package, t.Version, maven.TypePOM)
+	r, err := mux.Maven.Artifact(ctx, t.Package, t.Version, t.Artifact)
 	if err != nil {
 		return p, err
 	}
@@ -88,7 +88,12 @@ func ResolveParentPom(ctx context.Context, pom PomXML, mux rebuild.RegistryMux) 
 		group = pom.GroupID
 	}
 	var parent PomXML
-	r, err := mux.Maven.ReleaseFile(ctx, fmt.Sprintf("%s:%s", group, pom.Parent.ArtifactID), ver, maven.TypePOM)
+	pkgName := fmt.Sprintf("%s:%s", group, pom.Parent.ArtifactID)
+	artifact, err := maven.TypePOM(pkgName, ver)
+	if err != nil {
+		return parent, err
+	}
+	r, err := mux.Maven.Artifact(ctx, pkgName, ver, artifact)
 	if err != nil {
 		return parent, err
 	}

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -35,6 +35,10 @@ func (r TestRegistry) ReleaseURL(_ context.Context, _, _, _ string) (string, err
 	return "", nil
 }
 
+func (r TestRegistry) Artifact(_ context.Context, _, _, _ string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
 func TestNewPomXML(t *testing.T) {
 	tests := []struct {
 		testName string

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -26,17 +26,13 @@ func (TestRegistry) PackageVersion(_ context.Context, _, _ string) (*mavenreg.Ma
 	return nil, nil
 }
 
-func (r TestRegistry) ReleaseFile(_ context.Context, _, _, _ string) (io.ReadCloser, error) {
+func (r TestRegistry) Artifact(_ context.Context, _, _, _ string) (io.ReadCloser, error) {
 	reader := strings.NewReader(r.releaseFile)
 	return io.NopCloser(reader), nil
 }
 
 func (r TestRegistry) ReleaseURL(_ context.Context, _, _, _ string) (string, error) {
 	return "", nil
-}
-
-func (r TestRegistry) Artifact(_ context.Context, _, _, _ string) (io.ReadCloser, error) {
-	return nil, nil
 }
 
 func TestNewPomXML(t *testing.T) {

--- a/pkg/rebuild/maven/rebuild.go
+++ b/pkg/rebuild/maven/rebuild.go
@@ -76,7 +76,7 @@ func (Rebuilder) Compare(ctx context.Context, t rebuild.Target, rb rebuild.Asset
 
 func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
 	// Assuming the primary artifact is a .jar file.
-	return mux.Maven.ReleaseURL(ctx, t.Package, t.Version, ".jar")
+	return mux.Maven.ReleaseURL(ctx, t.Package, t.Version, t.Artifact)
 }
 
 func RebuildMany(ctx context.Context, inputs []rebuild.Input, mux rebuild.RegistryMux) ([]rebuild.Verdict, error) {

--- a/pkg/rebuild/rebuild/compare.go
+++ b/pkg/rebuild/rebuild/compare.go
@@ -29,6 +29,8 @@ func UpstreamArtifactReader(ctx context.Context, t Target, mux RegistryMux) (io.
 			return nil, errors.Errorf("failed to parse debian component: %s", t.Package)
 		}
 		return mux.Debian.Artifact(ctx, component, name, t.Artifact)
+	case Maven:
+		return mux.Maven.Artifact(ctx, t.Package, t.Version, t.Artifact)
 	default:
 		return nil, errors.New("unsupported ecosystem")
 	}

--- a/pkg/registry/maven/maven.go
+++ b/pkg/registry/maven/maven.go
@@ -82,6 +82,7 @@ type Registry interface {
 	PackageVersion(context.Context, string, string) (*MavenVersion, error)
 	ReleaseFile(context.Context, string, string, string) (io.ReadCloser, error)
 	ReleaseURL(context.Context, string, string, string) (string, error)
+	Artifact(context.Context, string, string, string) (io.ReadCloser, error)
 }
 
 // HTTPRegistry is a Registry implementation that uses the search.maven.org HTTP API.
@@ -172,4 +173,23 @@ func (r HTTPRegistry) ReleaseURL(ctx context.Context, pkg, version, typ string) 
 	artifactPath := path.Join(strings.ReplaceAll(g, ".", "/"), a, version, fmt.Sprintf("%s-%s%s", a, version, typ))
 	artifactURL := releaseURL.JoinPath(artifactPath)
 	return artifactURL.String(), nil
+}
+
+// Artifact returns file that is part of the Maven release.
+func (r HTTPRegistry) Artifact(ctx context.Context, pkg, version, artifact string) (io.ReadCloser, error) {
+	g, a, found := strings.Cut(pkg, ":")
+	if !found {
+		return nil, errors.New("package identifier not of form 'group:artifact'")
+	}
+	artifactPath := path.Join(strings.ReplaceAll(g, ".", "/"), a, version, artifact)
+	artifactURL := releaseURL.JoinPath(artifactPath)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL.String(), nil)
+	resp, err := r.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, errors.Wrap(errors.New(resp.Status), "fetching artifact")
+	}
+	return resp.Body, nil
 }

--- a/pkg/registry/maven/maven.go
+++ b/pkg/registry/maven/maven.go
@@ -62,25 +62,70 @@ type MavenVersion struct {
 	Files          []string `json:"ec"`
 }
 
-const (
-	// TypePOM is a POM file.
-	TypePOM string = ".pom"
-	// TypeSources is a sources file.
-	TypeSources string = "-sources.jar"
-	// TypeJar is a jar file.
-	TypeJar string = ".jar"
-	// TypeJavadoc is a javadoc file.
-	TypeJavadoc string = "-javadoc.jar"
-	// TypeModule is a module file.
-	TypeModule   string = ".module"
-	TypeMetadata string = "-metadata.xml"
-)
+// TypePOM is a POM file.
+func TypePOM(pkg, version string) (string, error) {
+	_, a, err := getGroupIDArtifactID(pkg)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s.pom", a, version), nil
+}
+
+// TypeSources is a sources file.
+func TypeSources(pkg, version string) (string, error) {
+	_, a, err := getGroupIDArtifactID(pkg)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s-sources.jar", a, version), nil
+}
+
+// TypeJar is a jar file.
+func TypeJar(pkg, version string) (string, error) {
+	_, a, err := getGroupIDArtifactID(pkg)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s.jar", a, version), nil
+}
+
+// TypeJavadoc is a javadoc file.
+func TypeJavadoc(pkg, version string) (string, error) {
+	_, a, err := getGroupIDArtifactID(pkg)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s-javadoc.jar", a, version), nil
+}
+
+// TypeModule is a module file.
+func TypeModule(pkg, version string) (string, error) {
+	_, a, err := getGroupIDArtifactID(pkg)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s.module", a, version), nil
+}
+
+// TypeMetadata is a metadata file used for discovery by Maven Central.
+// https://maven.apache.org/repositories/metadata.html
+func TypeMetadata() string {
+	return "maven-metadata.xml"
+}
+
+// getGroupIDArtifactID extracts the group and artifact IDs from a package string.
+func getGroupIDArtifactID(pkg string) (string, string, error) {
+	g, a, found := strings.Cut(pkg, ":")
+	if !found {
+		return "", "", errors.New("package identifier not of form 'group:artifact'")
+	}
+	return g, a, nil
+}
 
 // Registry is a Maven Central package registry.
 type Registry interface {
 	PackageMetadata(context.Context, string) (*MavenPackage, error)
 	PackageVersion(context.Context, string, string) (*MavenVersion, error)
-	ReleaseFile(context.Context, string, string, string) (io.ReadCloser, error)
 	ReleaseURL(context.Context, string, string, string) (string, error)
 	Artifact(context.Context, string, string, string) (io.ReadCloser, error)
 }
@@ -133,7 +178,7 @@ func (r HTTPRegistry) PackageVersion(ctx context.Context, pkg, version string) (
 
 // PackageMetadata returns the metadata for a Maven package.
 func (r HTTPRegistry) PackageMetadata(ctx context.Context, pkg string) (result *MavenPackage, err error) {
-	content, err := r.ReleaseFile(ctx, pkg, "maven", TypeMetadata)
+	content, err := r.Artifact(ctx, pkg, "maven", TypeMetadata())
 	if err != nil {
 		return nil, err
 	}
@@ -146,44 +191,24 @@ func (r HTTPRegistry) PackageMetadata(ctx context.Context, pkg string) (result *
 	return result, nil
 }
 
-// ReleaseFile returns a release file for a Maven package version.
-func (r HTTPRegistry) ReleaseFile(ctx context.Context, pkg, version string, typ string) (io.ReadCloser, error) {
-	releaseURL, err := r.ReleaseURL(ctx, pkg, version, typ)
-	if err != nil {
-		return nil, err
-	}
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, releaseURL, nil)
-	resp, err := r.Client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != 200 {
-		return nil, errors.Wrap(errors.New(resp.Status), "fetching release artifact")
-	}
-
-	return resp.Body, nil
-}
-
 // ReleaseURL returns the URL for the release file for a Maven package version.
-func (r HTTPRegistry) ReleaseURL(ctx context.Context, pkg, version, typ string) (string, error) {
+func (r HTTPRegistry) ReleaseURL(ctx context.Context, pkg, version, artifact string) (string, error) {
 	g, a, found := strings.Cut(pkg, ":")
 	if !found {
 		return "", errors.New("package identifier not of form 'group:artifact'")
 	}
-	artifactPath := path.Join(strings.ReplaceAll(g, ".", "/"), a, version, fmt.Sprintf("%s-%s%s", a, version, typ))
+	artifactPath := path.Join(strings.ReplaceAll(g, ".", "/"), a, version, artifact)
 	artifactURL := releaseURL.JoinPath(artifactPath)
 	return artifactURL.String(), nil
 }
 
 // Artifact returns file that is part of the Maven release.
 func (r HTTPRegistry) Artifact(ctx context.Context, pkg, version, artifact string) (io.ReadCloser, error) {
-	g, a, found := strings.Cut(pkg, ":")
-	if !found {
-		return nil, errors.New("package identifier not of form 'group:artifact'")
+	artifactURL, err := r.ReleaseURL(ctx, pkg, version, artifact)
+	if err != nil {
+		return nil, err
 	}
-	artifactPath := path.Join(strings.ReplaceAll(g, ".", "/"), a, version, artifact)
-	artifactURL := releaseURL.JoinPath(artifactPath)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL.String(), nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL, nil)
 	resp, err := r.Client.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/registry/maven/maven_test.go
+++ b/pkg/registry/maven/maven_test.go
@@ -11,23 +11,23 @@ import (
 func TestReleaseURL(t *testing.T) {
 	testCases := []struct {
 		test     string
-		artifact string
+		pkg      string
 		version  string
-		filetype string
+		artifact string
 		want     string
 	}{
 		{
 			test:     "guava_pom",
-			artifact: "com.google.guava:guava",
+			pkg:      "com.google.guava:guava",
 			version:  "33.4.8-jre",
-			filetype: TypePOM,
+			artifact: "guava-33.4.8-jre.pom",
 			want:     "https://repo1.maven.org/maven2/com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.pom",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.test, func(t *testing.T) {
 			r := HTTPRegistry{}
-			url, err := r.ReleaseURL(context.Background(), tc.artifact, tc.version, tc.filetype)
+			url, err := r.ReleaseURL(context.Background(), tc.pkg, tc.version, tc.artifact)
 			if err != nil {
 				t.Fatalf("ReleaseURL() error = %v", err)
 			}

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -44,6 +44,7 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
 	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
+	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
 	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
 	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/google/oss-rebuild/tools/benchmark"
@@ -207,6 +208,7 @@ var tui = &cobra.Command{
 			CratesIO: cratesreg.HTTPRegistry{Client: regclient},
 			NPM:      npmreg.HTTPRegistry{Client: regclient},
 			PyPI:     pypireg.HTTPRegistry{Client: regclient},
+			Maven:    mavenreg.HTTPRegistry{Client: regclient},
 		}
 		var assetStoreFn func(runID string) (rebuild.LocatableAssetStore, error)
 		if *sharedAssetStore != "" {

--- a/tools/indexscan/main.go
+++ b/tools/indexscan/main.go
@@ -354,7 +354,11 @@ func main() {
 		if err != nil {
 			log.Fatal(errors.Wrap(err, "fetching version metadata"))
 		}
-		f, err = mavenreg.HTTPRegistry{}.ReleaseFile(ctx, *pkg, *version, mavenreg.TypeSources)
+		artifact, err := mavenreg.TypeSources(*pkg, *version)
+		if err != nil {
+			log.Fatal(errors.Wrap(err, "creating artifact name for source jar"))
+		}
+		f, err = mavenreg.HTTPRegistry{}.Artifact(ctx, *pkg, *version, artifact)
 		if err != nil {
 			log.Fatal(errors.Wrap(err, "fetching source jar"))
 		}


### PR DESCRIPTION
We use `Artifact` API everywhere instead of `ReleaseFile`. `ReleaseFile` takes in the extension and in most cases we have the artifact name. It is better to directly use the `Artifact` API in those cases. In cases, where we know the extension of the artifact, the name of the artifact can be inferred using package name and version. Thus, this can also be replaced with `Artifact` API.

Related https://github.com/google/oss-rebuild/pull/732#discussion_r2308208507

To be merged after #732 