### PR TITLE
Add inference for `GAV` given a Gradle project

### DIFF
--- a/pkg/rebuild/maven/gradle.go
+++ b/pkg/rebuild/maven/gradle.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/pkg/errors"
+)
+
+const gradleScript = `import groovy.json.JsonOutput
+
+gradle.projectsLoaded {
+    def outputJsonPath = gradle.startParameter.projectProperties['outputJson']
+
+    gradle.rootProject.tasks.register("printCoordinates") {
+        doLast {
+            def jsonFile = new File(outputJsonPath ?: "output.json")
+
+            def rootProjectPath = gradle.rootProject.getProjectDir().toPath()
+
+            def toJsonMap
+            toJsonMap = { Project project ->
+                def map = [
+                        groupId   : project.getGroup().toString(),
+                        artifactId: project.getName(),
+                        version   : project.getVersion().toString(),
+                        buildManifest: rootProjectPath.relativize(project.getBuildFile().toPath()).toString(),
+                ]
+                if (!project.getChildProjects().isEmpty()) {
+                    map.submodules = project.getChildProjects().values().collect {
+                        toJsonMap(it)
+                    }
+                }
+                return map
+            }
+
+            def jsonModel = toJsonMap(gradle.getRootProject())
+            def jsonString = JsonOutput.prettyPrint(JsonOutput.toJson(jsonModel))
+            jsonFile.text = jsonString
+        }
+    }
+}`
+
+type GradleProject struct {
+	GroupId       string          `json:"groupId"`
+	ArtifactId    string          `json:"artifactId"`
+	Version       string          `json:"version"`
+	BuildFilePath string          `json:"buildFilePath"`
+	Submodules    []GradleProject `json:"submodules,omitempty"`
+}
+
+func RunPrintCoordinates(sourceRepo git.Repository) (GradleProject, error) {
+	cmd := exec.Command("./gradlew", "printCoordinates", "--init-script", "printCoordinates.gradle")
+	wt, err := sourceRepo.Worktree()
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "getting worktree of Gradle project")
+	}
+	rootDir := wt.Filesystem.Root()
+	cmd.Dir = rootDir
+	if err := os.WriteFile(path.Join(rootDir, "printCoordinates.gradle"), []byte(gradleScript), 0644); err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to write print_coordinates.gradle file")
+	}
+	err = cmd.Run()
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to run Gradle command")
+	}
+	pathToGeneratedJson := path.Join(wt.Filesystem.Root(), "output.json")
+	f, err := os.Open(pathToGeneratedJson)
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to open generated JSON file")
+	}
+	defer f.Close()
+	var gradleProject GradleProject
+	err = json.NewDecoder(f).Decode(&gradleProject)
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to decode generated JSON file")
+	}
+	return gradleProject, nil
+}

--- a/pkg/rebuild/maven/gradle_test.go
+++ b/pkg/rebuild/maven/gradle_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func TestRunPrintCoordinates(t *testing.T) {
+	testCases := []struct {
+		name         string
+		repoURL      string
+		sha          string
+		expectedGAVs []string
+	}{
+		{
+			name:         "GAV coordinates for a single module Gradle project",
+			repoURL:      "https://github.com/chains-project/maven-module-graph.git",
+			sha:          "32245d0a433e1a36d36c9fffa16b5936243e9c6b",
+			expectedGAVs: []string{"io.algomaster99.maven_module_graph:maven-module-graph:1.0.0-SNAPSHOT"},
+		},
+		{
+			name:    "GAV coordinates for a multi-module Gradle project",
+			repoURL: "https://github.com/perfmark/perfmark",
+			sha:     "9d9893c037949ec73ed9d018f6b9217b70d4bba6",
+			expectedGAVs: []string{
+				// "unspecified" version seems to be default value where no version is specified
+				":perfmark:unspecified",
+				"io.perfmark:perfmark-tracewriter:0.27.0",
+				"io.perfmark:perfmark-java7:0.27.0",
+				"io.perfmark:perfmark-api:0.27.0",
+				"io.perfmark:perfmark-java6:0.27.0",
+				"io.perfmark:perfmark-traceviewer:0.27.0",
+				"io.perfmark:perfmark-java15:0.27.0",
+				"io.perfmark:perfmark-java19:0.27.0",
+				"io.perfmark:perfmark-api-testing:0.27.0",
+				"io.perfmark:perfmark-impl:0.27.0",
+				"io.perfmark:perfmark-java9:0.27.0",
+				"io.perfmark:perfmark-agent:0.27.0",
+				"io.perfmark:perfmark-examples:0.27.0",
+				"io.perfmark:perfmark-testing:0.27.0"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "gradle-test-")
+			if err != nil {
+				t.Fatalf("Failed to create temp directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			r, err := git.PlainClone(tempDir, false, &git.CloneOptions{URL: tc.repoURL})
+			if err != nil {
+				t.Fatalf("Failed to clone repository: %v", err)
+			}
+			wt, err := r.Worktree()
+			if err != nil {
+				t.Fatalf("Failed to get worktree: %v", err)
+			}
+			err = wt.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(tc.sha)})
+			if err != nil {
+				t.Fatalf("Failed to clone repository: %v", err)
+			}
+			gp, err := RunPrintCoordinates(*r)
+			if err != nil {
+				t.Fatalf("Failed to run printCoordinates: %v", err)
+			}
+			actualGAVs := getAllGAVs(gp)
+			slices.Sort(actualGAVs)
+			slices.Sort(tc.expectedGAVs)
+			if !reflect.DeepEqual(actualGAVs, tc.expectedGAVs) {
+				t.Fatalf("Expected GAVs %v, got %v", tc.expectedGAVs, actualGAVs)
+			}
+		})
+	}
+}
+
+func getAllGAVs(gradleProject GradleProject) []string {
+	var gavs []string
+	gavs = append(gavs, fmt.Sprintf("%s:%s:%s", gradleProject.GroupId, gradleProject.ArtifactId, gradleProject.Version))
+	for _, submodule := range gradleProject.Submodules {
+		gavs = append(gavs, getAllGAVs(submodule)...)
+	}
+	return gavs
+}


### PR DESCRIPTION
I have written a small Gradle script `printCoordinates.gradle` which works if you just go to a Gradle project root and run:
```
./gradlew printCoordinates --init-script printCoordinates.gradle
```
It outputs a file that contains all the GAVs of all submodules and the path of build.gradle.

However, I am struggling to get it execute on `git.Repository`. It complains that `Failed to run printCoordinates: failed to run Gradle command: exit status 127` which is strange. I know that `gradlew` exists with correct permissions and on the correct path `wt.Filesystem.Root()` (I did a programmatic `ls`).