### PR TITLE
Add `get-gradle-gav` command to infer the GAVs in Gradle project

### DIFF
--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -33,6 +33,8 @@ import (
 	gcs "cloud.google.com/go/storage"
 	"github.com/cheggaaa/pb"
 	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/oss-rebuild/internal/api"
 	"github.com/google/oss-rebuild/internal/api/inferenceservice"
 	"github.com/google/oss-rebuild/internal/oauth"
@@ -48,6 +50,7 @@ import (
 	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/google/oss-rebuild/tools/benchmark"
 	"github.com/google/oss-rebuild/tools/benchmark/run"
+	"github.com/google/oss-rebuild/tools/ctl/gradle"
 	"github.com/google/oss-rebuild/tools/ctl/ide"
 	"github.com/google/oss-rebuild/tools/ctl/layout"
 	"github.com/google/oss-rebuild/tools/ctl/localfiles"
@@ -1017,6 +1020,43 @@ var infer = &cobra.Command{
 	},
 }
 
+var getGradleGAV = &cobra.Command{
+	Use:   "get-gradle-gav --repository <URI> --ref <ref>",
+	Short: "Extracts GAV coordinates from a Gradle project at a given commit",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repoURL := *repository
+		sha := *ref
+
+		tempDir, err := os.MkdirTemp("", "gradle-gav-")
+		if err != nil {
+			return errors.Wrap(err, "failed to create temp directory")
+		}
+		defer os.RemoveAll(tempDir)
+
+		repo, err := git.PlainClone(tempDir, false, &git.CloneOptions{URL: repoURL})
+		if err != nil {
+			return errors.Wrap(err, "failed to clone repository")
+		}
+		wt, err := repo.Worktree()
+		if err != nil {
+			return errors.Wrap(err, "failed to get worktree")
+		}
+		if err := wt.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(sha)}); err != nil {
+			return errors.Wrap(err, "failed to checkout commit")
+		}
+
+		gradleProject, err := gradle.RunPrintCoordinates(*repo)
+		if err != nil {
+			return errors.Wrap(err, "running printCoordinates")
+		}
+
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(gradleProject)
+	},
+}
+
 func logFailure(f func() error) {
 	if err := f(); err != nil {
 		log.Println(err)
@@ -1193,6 +1233,9 @@ var (
 	sample  = flag.Int("sample", -1, "if provided, only N results will be displayed")
 	project = flag.String("project", "", "the project from which to fetch the Firestore data")
 	clean   = flag.Bool("clean", false, "whether to apply normalization heuristics to group similar verdicts")
+	// get-gradle-gav
+	repository = flag.String("repository", "", "the repository URI")
+	ref        = flag.String("ref", "", "the git reference (branch, tag, commit)")
 	// TUI
 	benchmarkDir     = flag.String("benchmark-dir", "", "a directory with benchmarks to work with")
 	defDir           = flag.String("def-dir", "", "tui will make edits to strategies in this manual build definition repo")
@@ -1272,6 +1315,9 @@ func init() {
 	infer.Flags().AddGoFlag(flag.Lookup("version"))
 	infer.Flags().AddGoFlag(flag.Lookup("artifact"))
 
+	getGradleGAV.Flags().AddGoFlag(flag.Lookup("repository"))
+	getGradleGAV.Flags().AddGoFlag(flag.Lookup("ref"))
+
 	migrate.Flags().AddGoFlag(flag.Lookup("project"))
 	migrate.Flags().AddGoFlag(flag.Lookup("dryrun"))
 
@@ -1295,6 +1341,7 @@ func init() {
 	rootCmd.AddCommand(setTrackedPackagesCmd)
 	rootCmd.AddCommand(getTrackedPackagesCmd)
 	rootCmd.AddCommand(runAgent)
+	rootCmd.AddCommand(getGradleGAV)
 }
 
 func main() {

--- a/tools/ctl/gradle/gradle.go
+++ b/tools/ctl/gradle/gradle.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gradle
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/pkg/errors"
+)
+
+const gradleScript = `import groovy.json.JsonOutput
+
+gradle.projectsLoaded {
+    def outputJsonPath = gradle.startParameter.projectProperties['outputJson']
+
+    gradle.rootProject.tasks.register("printCoordinates") {
+        doLast {
+            def jsonFile = new File(outputJsonPath ?: "output.json")
+
+            def rootProjectPath = gradle.rootProject.getProjectDir().toPath()
+
+            def toJsonMap
+            toJsonMap = { Project project ->
+                def map = [
+                        groupId   : project.getGroup().toString(),
+                        artifactId: project.getName(),
+                        version   : project.getVersion().toString(),
+                        buildManifest: rootProjectPath.relativize(project.getBuildFile().toPath()).toString(),
+                ]
+                if (!project.getChildProjects().isEmpty()) {
+                    map.submodules = project.getChildProjects().values().collect {
+                        toJsonMap(it)
+                    }
+                }
+                return map
+            }
+
+            def jsonModel = toJsonMap(gradle.getRootProject())
+            def jsonString = JsonOutput.prettyPrint(JsonOutput.toJson(jsonModel))
+            jsonFile.text = jsonString
+        }
+    }
+}`
+
+type GradleProject struct {
+	GroupId       string          `json:"groupId"`
+	ArtifactId    string          `json:"artifactId"`
+	Version       string          `json:"version"`
+	BuildManifest string          `json:"buildManifest"`
+	Submodules    []GradleProject `json:"submodules,omitempty"`
+}
+
+func RunPrintCoordinates(sourceRepo git.Repository) (GradleProject, error) {
+	cmd := exec.Command("./gradlew", "printCoordinates", "--init-script", "printCoordinates.gradle")
+	wt, err := sourceRepo.Worktree()
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "getting worktree of Gradle project")
+	}
+	rootDir := wt.Filesystem.Root()
+	cmd.Dir = rootDir
+	if err := os.WriteFile(path.Join(rootDir, "printCoordinates.gradle"), []byte(gradleScript), 0644); err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to write print_coordinates.gradle file")
+	}
+	err = cmd.Run()
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to run Gradle command")
+	}
+	pathToGeneratedJson := path.Join(wt.Filesystem.Root(), "output.json")
+	f, err := os.Open(pathToGeneratedJson)
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to open generated JSON file")
+	}
+	defer f.Close()
+	var gradleProject GradleProject
+	err = json.NewDecoder(f).Decode(&gradleProject)
+	if err != nil {
+		return GradleProject{}, errors.Wrap(err, "failed to decode generated JSON file")
+	}
+	return gradleProject, nil
+}

--- a/tools/ctl/gradle/gradle_test.go
+++ b/tools/ctl/gradle/gradle_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gradle
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func TestRunPrintCoordinates(t *testing.T) {
+	testCases := []struct {
+		name         string
+		repoURL      string
+		sha          string
+		expectedGAVs []string
+	}{
+		{
+			name:         "GAV coordinates for a single module Gradle project",
+			repoURL:      "https://github.com/chains-project/maven-module-graph.git",
+			sha:          "32245d0a433e1a36d36c9fffa16b5936243e9c6b",
+			expectedGAVs: []string{"io.algomaster99.maven_module_graph:maven-module-graph:1.0.0-SNAPSHOT"},
+		},
+		{
+			name:    "GAV coordinates for a multi-module Gradle project",
+			repoURL: "https://github.com/perfmark/perfmark",
+			sha:     "9d9893c037949ec73ed9d018f6b9217b70d4bba6",
+			expectedGAVs: []string{
+				// "unspecified" version seems to be default value where no version is specified
+				":perfmark:unspecified",
+				"io.perfmark:perfmark-tracewriter:0.27.0",
+				"io.perfmark:perfmark-java7:0.27.0",
+				"io.perfmark:perfmark-api:0.27.0",
+				"io.perfmark:perfmark-java6:0.27.0",
+				"io.perfmark:perfmark-traceviewer:0.27.0",
+				"io.perfmark:perfmark-java15:0.27.0",
+				"io.perfmark:perfmark-java19:0.27.0",
+				"io.perfmark:perfmark-api-testing:0.27.0",
+				"io.perfmark:perfmark-impl:0.27.0",
+				"io.perfmark:perfmark-java9:0.27.0",
+				"io.perfmark:perfmark-agent:0.27.0",
+				"io.perfmark:perfmark-examples:0.27.0",
+				"io.perfmark:perfmark-testing:0.27.0"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "gradle-test-")
+			if err != nil {
+				t.Fatalf("Failed to create temp directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			r, err := git.PlainClone(tempDir, false, &git.CloneOptions{URL: tc.repoURL})
+			if err != nil {
+				t.Fatalf("Failed to clone repository: %v", err)
+			}
+			wt, err := r.Worktree()
+			if err != nil {
+				t.Fatalf("Failed to get worktree: %v", err)
+			}
+			err = wt.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(tc.sha)})
+			if err != nil {
+				t.Fatalf("Failed to clone repository: %v", err)
+			}
+			gp, err := RunPrintCoordinates(*r)
+			if err != nil {
+				t.Fatalf("Failed to run printCoordinates: %v", err)
+			}
+			actualGAVs := getAllGAVs(gp)
+			slices.Sort(actualGAVs)
+			slices.Sort(tc.expectedGAVs)
+			if !reflect.DeepEqual(actualGAVs, tc.expectedGAVs) {
+				t.Fatalf("Expected GAVs %v, got %v", tc.expectedGAVs, actualGAVs)
+			}
+		})
+	}
+}
+
+func getAllGAVs(gradleProject GradleProject) []string {
+	var gavs []string
+	gavs = append(gavs, fmt.Sprintf("%s:%s:%s", gradleProject.GroupId, gradleProject.ArtifactId, gradleProject.Version))
+	for _, submodule := range gradleProject.Submodules {
+		gavs = append(gavs, getAllGAVs(submodule)...)
+	}
+	return gavs
+}


### PR DESCRIPTION
Continuation of https://github.com/google/oss-rebuild/pull/736

Run: `go run tools/ctl/ctl.go get-gradle-gav --repository https://github.com/chains-project/maven-module-graph --ref 32245d0a433e1a36d36c9fffa16b5936243e9c6b`

```
{
  "groupId": "io.algomaster99.maven_module_graph",
  "artifactId": "maven-module-graph",
  "version": "1.0.0-SNAPSHOT",
  "buildManifest": "build.gradle"
}
```