### PR TITLE
Run build commands in batch mode

### DIFF
--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -44,7 +44,7 @@ func (b *MavenBuild) ToWorkflow() (*rebuild.WorkflowStrategy, error) {
 			{
 				// TODO: Java 9 needs additional certificate installed in /etc/ssl/certs/java/cacerts
 				// It can be passed to maven command via -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
-				Runs: "mvn clean package -DskipTests",
+				Runs: "mvn clean package -DskipTests --batch-mode",
 				// Note `maven` from apt also pull in jdk-21 and hence we must export JAVA_HOME and PATH in the step before
 				Needs: []string{"maven"},
 			},
@@ -87,7 +87,7 @@ func (b *GradleBuild) ToWorkflow() (*rebuild.WorkflowStrategy, error) {
 				// We assume the project uses the Gradle Wrapper (gradlew).
 				// We run assemble as it is an atomic lifecycle task that outputs the artifact.
 				// The property `-Pversion` is used to set the project version which ensures that the right version is appended to the artifact name.
-				Runs: "./gradlew assemble --no-daemon -Pversion={{.Target.Version}}",
+				Runs: "./gradlew assemble --no-daemon --console=plain -Pversion={{.Target.Version}}",
 			},
 		},
 		OutputDir: path.Join(b.Dir, "build", "libs"),

--- a/pkg/rebuild/maven/strategy_test.go
+++ b/pkg/rebuild/maven/strategy_test.go
@@ -42,7 +42,7 @@ func TestStrategies(t *testing.T) {
 				Build: textwrap.Dedent(`
 					export JAVA_HOME=/opt/jdk
 					export PATH=$JAVA_HOME/bin:$PATH
-					mvn clean package -DskipTests`[1:]),
+					mvn clean package -DskipTests --batch-mode`[1:]),
 				OutputPath: "dir/target/ldapchai-0.8.6.jar",
 			},
 			false,
@@ -71,7 +71,7 @@ func TestStrategies(t *testing.T) {
 				Build: textwrap.Dedent(`
 					export JAVA_HOME=/opt/jdk
 					export PATH=$JAVA_HOME/bin:$PATH
-					./gradlew assemble --no-daemon -Pversion=0.8.6`[1:]),
+					./gradlew assemble --no-daemon --console=plain -Pversion=0.8.6`[1:]),
 				OutputPath: "dir/build/libs/ldapchai-0.8.6.jar",
 			},
 			false,


### PR DESCRIPTION
This helps put no ANSI text in build output which makes it easier to write search patterns.