### PR TITLE
Skip javadoc generation

### DIFF
--- a/pkg/rebuild/maven/gradleinfer.go
+++ b/pkg/rebuild/maven/gradleinfer.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"context"
+	"log"
+
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+)
+
+type GradleBuildInferer struct{}
+
+var _ rebuild.StrategyInferer = &GradleBuildInferer{}
+
+func (m *GradleBuildInferer) Infer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, repoConfig *rebuild.RepoConfig, commitObject *object.Commit) (rebuild.Strategy, error) {
+	name, version := t.Package, t.Version
+	tagGuess, err := rebuild.FindTagMatch(name, version, repoConfig.Repository)
+	if err != nil {
+		return nil, errors.Wrapf(err, "[INTERNAL] tag heuristic error")
+	}
+
+	var ref string
+	if tagGuess != "" {
+		ref = tagGuess
+		log.Printf("using tag heuristic ref: %s", tagGuess[:9])
+	} else {
+		return nil, errors.Errorf("no valid git ref")
+	}
+
+	// Infer JDK for Gradle
+	jdk, err := inferOrFallbackToDefaultJDK(ctx, name, version, mux)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching JDK")
+	}
+
+	return &GradleBuild{
+		Location: rebuild.Location{
+			Repo: repoConfig.URI,
+			Dir:  "",
+			Ref:  ref,
+		},
+		Target:     t,
+		JDKVersion: jdk,
+	}, nil
+}

--- a/pkg/rebuild/maven/gradlestrategy.go
+++ b/pkg/rebuild/maven/gradlestrategy.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/flow"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+type GradleBuild struct {
+	rebuild.Location
+	rebuild.Target
+
+	// JDKVersion is the version of the JDK to use for the build.
+	JDKVersion string `json:"jdk_version" yaml:"jdk_version"`
+}
+
+var _ rebuild.Strategy = &GradleBuild{}
+
+func (b *GradleBuild) ToWorkflow() (*rebuild.WorkflowStrategy, error) {
+	jdkVersionURL, exists := JDKDownloadURLs[b.JDKVersion]
+	if !exists {
+		return nil, errors.Errorf("no download URL for JDK version %s", b.JDKVersion)
+	}
+
+	return &rebuild.WorkflowStrategy{
+		Location: b.Location,
+		Source: []flow.Step{{
+			Uses: "git-checkout",
+		}},
+		Deps: []flow.Step{{
+			Uses: "maven/setup-java",
+			With: map[string]string{
+				"versionURL": jdkVersionURL,
+			},
+		}},
+		Build: []flow.Step{
+			{
+				Uses: "maven/export-java",
+			},
+			{
+				Uses: "maven/gradle-build",
+			},
+			{
+				Uses: "maven/move-gradle-build-output",
+				With: map[string]string{
+					"targetName": b.Artifact,
+				},
+			},
+		},
+		OutputDir: "",
+	}, nil
+}
+
+func (b *GradleBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
+	workflow, err := b.ToWorkflow()
+	if err != nil {
+		return rebuild.Instructions{}, err
+	}
+	return workflow.GenerateFor(t, be)
+}

--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -7,17 +7,14 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"encoding/xml"
 	"fmt"
 	"io"
 	"log"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage"
@@ -57,96 +54,35 @@ func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string
 }
 
 func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, repoConfig *rebuild.RepoConfig, hint rebuild.Strategy) (rebuild.Strategy, error) {
-	// Do pom.xml search.
 	head, _ := repoConfig.Repository.Head()
 	commitObject, _ := repoConfig.Repository.CommitObject(head.Hash())
-	_, pkgPath, err := findPomXML(commitObject, t.Package)
+
+	buildSystem, err := inferBuildSystem(commitObject)
 	if err != nil {
-		log.Printf("pom.xml path heuristic failed [pkg=%s,repo=%s]: %s\n", t.Package, repoConfig.URI, err.Error())
+		return nil, errors.Wrapf(err, "inferring build system")
 	}
 
-	// Do version heuristic search.
-	refMap, err := pomXMLSearch(t.Package, pkgPath, repoConfig.Repository)
-	if err != nil {
-		log.Printf("pom.xml version heuristic failed [pkg=%s,repo=%s]: %s\n", t.Package, repoConfig.URI, err.Error())
-	}
-
-	name, version := t.Package, t.Version
-	cfg := &MavenBuild{}
-	dir := path.Dir(pkgPath)
-	pomXMLGuess := refMap[version]
-	tagGuess, err := rebuild.FindTagMatch(name, version, repoConfig.Repository)
-	if err != nil {
-		return cfg, errors.Wrapf(err, "[INTERNAL] tag heuristic error")
-	}
-
-	var ref string
-	var commit *object.Commit
-	switch {
-	case tagGuess != "":
-		commit, err = repoConfig.Repository.CommitObject(plumbing.NewHash(tagGuess))
-		if err == nil {
-			if newPath, err := findAndValidatePomXML(commit, name, version, dir); err != nil {
-				log.Printf("registry heuristic tag invalid: %v", err)
-			} else {
-				log.Printf("using tag heuristic ref: %s", tagGuess[:9])
-				ref = tagGuess
-				dir = filepath.Dir(newPath)
-				break
-			}
-		} else if err == plumbing.ErrObjectNotFound {
-			log.Printf("tag heuristic ref not found in repo")
-		} else {
-			return cfg, errors.Wrapf(err, "[INTERNAL] Failed ref resolve from tag [repo=%s,ref=%s]", repoConfig.URI, tagGuess)
-		}
-		fallthrough
-	case pomXMLGuess != "":
-		commit, err = repoConfig.Repository.CommitObject(plumbing.NewHash(pomXMLGuess))
-		if err == nil {
-			if newPath, err := findAndValidatePomXML(commit, name, version, dir); err != nil {
-				log.Printf("registry heuristic git log invalid: %v", err)
-			} else {
-				log.Printf("using git log heuristic ref: %s", pomXMLGuess[:9])
-				ref = pomXMLGuess
-				dir = filepath.Dir(newPath)
-				break
-			}
-		} else if err == plumbing.ErrObjectNotFound {
-			log.Printf("git log heuristic ref not found in repo")
-		} else {
-			return cfg, errors.Wrapf(err, "[INTERNAL] Failed ref resolve from git log [repo=%s,ref=%s]", repoConfig.URI, pomXMLGuess)
-		}
-		fallthrough
-	default:
-		if tagGuess == "" && pomXMLGuess == "" {
-			return cfg, errors.Errorf("no git ref")
-		}
-		return cfg, errors.Errorf("no valid git ref")
-	}
-	jdk, err := inferOrFallbackToDefaultJDK(ctx, name, version, mux)
-	if err != nil {
-		return cfg, errors.Wrap(err, "fetching JDK")
-	}
-	return &MavenBuild{
-		Location: rebuild.Location{
-			Repo: repoConfig.URI,
-			Dir:  dir,
-			Ref:  ref,
-		},
-		JDKVersion: jdk,
-	}, nil
+	return buildSystem.Infer(ctx, t, mux, repoConfig, commitObject)
 }
 
-func getPomXML(tree *object.Tree, path string) (pomXML PomXML, err error) {
-	f, err := tree.File(path)
-	if err != nil {
-		return pomXML, err
+func inferBuildSystem(commit *object.Commit) (rebuild.StrategyInferer, error) {
+	var inferer rebuild.StrategyInferer
+	fileIter, _ := commit.Files()
+	fileIter.ForEach(func(f *object.File) error {
+		if path.Base(f.Name) == "pom.xml" && !strings.HasPrefix(f.Name, "src/") && !strings.Contains(f.Name, "/src/") {
+			inferer = &MavenBuildInferer{}
+			return nil
+		}
+		if path.Base(f.Name) == "gradlew" {
+			inferer = &GradleBuildInferer{}
+			return nil
+		}
+		return nil
+	})
+	if inferer == nil {
+		return nil, errors.Errorf("only Maven and Gradle are supported")
 	}
-	p, err := f.Contents()
-	if err != nil {
-		return pomXML, err
-	}
-	return pomXML, xml.Unmarshal([]byte(p), &pomXML)
+	return inferer, nil
 }
 
 // inferOrFallbackToDefaultJDK tries to infer the JDK version from the artifact's metadata, falling back to a default if necessary.
@@ -252,134 +188,4 @@ func getClassFileMajorVersion(classBytes []byte) (int, error) {
 	bytecodeToVersionOffset := uint16(44)
 	majorVersion := (uint16(classBytes[6]) << 8) | uint16(classBytes[7]) - bytecodeToVersionOffset
 	return int(majorVersion), nil
-}
-
-// findAndValidatePomXML ensures the package config has the expected name and version,
-// or finds a new version if necessary.
-func findAndValidatePomXML(commit *object.Commit, name, version, dir string) (string, error) {
-	commitTree, _ := commit.Tree()
-	path := path.Join(dir, "pom.xml")
-	orig, err := getPomXML(commitTree, path)
-	pomXML := &orig
-	if err == object.ErrFileNotFound {
-		pomXML, path, err = findPomXML(commit, name)
-	}
-	if err == object.ErrFileNotFound {
-		return path, errors.Errorf("pom.xml file not found [path=%s]", path)
-	} else if _, ok := err.(*xml.SyntaxError); ok {
-		return path, errors.Wrapf(err, "failed to parse pom.xml")
-	} else if err != nil {
-		return path, errors.Wrapf(err, "unknown pom.xml error")
-	} else if pomXML.Name() != name {
-		return path, errors.Errorf("mismatched name [expected=%s,actual=%s,path=%s]", name, pomXML.Name(), path)
-	} else if pomXML.Version() != version {
-		return path, errors.Errorf("mismatched version [expected=%s,actual=%s,path=%s]", version, pomXML.Version(), path)
-	}
-	return path, nil
-}
-
-func findPomXML(commit *object.Commit, pkg string) (*PomXML, string, error) {
-	commitTree, _ := commit.Tree()
-	var names []string
-	var pomXMLs []PomXML
-	commitTree.Files().ForEach(func(f *object.File) error {
-		// Per Maven conventions, skip non-"pom.xml" files and those inside a `src` directory (unlikely to contain metadata).
-		// Reference: https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html
-		// Note: This will miss pom files, with name other than "pom.xml", whose paths are explicitly passed during build via "-f".
-		if path.Base(f.Name) != "pom.xml" || strings.HasPrefix(f.Name, "src/") || strings.Contains(f.Name, "/src/") {
-			return nil
-		}
-		pomXML, err := getPomXML(commitTree, f.Name)
-		if err != nil {
-			// XXX: ignore parse errors
-			return nil
-		}
-		if pkg == pomXML.Name() {
-			names = append(names, f.Name)
-			pomXMLs = append(pomXMLs, pomXML)
-		}
-		return nil
-	})
-	if len(names) > 0 {
-		if len(names) > 1 {
-			log.Printf("Multiple pom.xml file candidates [pkg=%s,ref=%s,matches=%v]\n", pkg, commit.Hash.String(), names)
-		}
-		return &pomXMLs[0], names[0], nil
-	}
-	return nil, "", errors.Errorf("pom.xml heuristic found no matches")
-}
-
-func pomXMLSearch(name, pomXMLPath string, repo *git.Repository) (tm map[string]string, err error) {
-	tm = make(map[string]string)
-	commitIter, err := repo.Log(&git.LogOptions{
-		Order:      git.LogOrderCommitterTime,
-		PathFilter: func(s string) bool { return s == pomXMLPath },
-		All:        true,
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "searching for commits touching pom.xml")
-	}
-	duplicates := make(map[string]string)
-	err = commitIter.ForEach(func(c *object.Commit) error {
-		t, err := c.Tree()
-		if err != nil {
-			return errors.Wrapf(err, "fetching tree")
-		}
-		pomXML, err := getPomXML(t, pomXMLPath)
-		if _, ok := err.(*xml.SyntaxError); ok {
-			return nil // unable to parse
-		} else if errors.Is(err, object.ErrFileNotFound) {
-			return nil // file deleted at this commit
-		} else if err != nil {
-			return errors.Wrapf(err, "fetching pom.xml")
-		}
-		if pomXML.Name() != name {
-			// TODO: Handle the case where the package name has changed.
-			log.Printf("Package name mismatch [expected=%s,actual=%s,path=%s,ref=%s]\n", name, pomXML.Name(), pomXMLPath, c.Hash.String())
-			return nil
-		}
-		ver := pomXML.Version()
-		if ver == "" {
-			return nil
-		}
-		// If any are the same, return nil. (merges would create duplicates.)
-		var foundMatch bool
-		err = c.Parents().ForEach(func(c *object.Commit) error {
-			t, err := c.Tree()
-			if err != nil {
-				return errors.Wrapf(err, "fetching tree")
-			}
-			pomXML, err := getPomXML(t, pomXMLPath)
-			if err != nil {
-				// TODO: Detect and record file moves.
-				return nil
-			}
-			if pomXML.Name() == name && pomXML.Version() == ver {
-				foundMatch = true
-			}
-			return nil
-		})
-		if err != nil {
-			return errors.Wrapf(err, "comparing against parent pom.xml")
-		}
-		if !foundMatch {
-			if tm[ver] != "" {
-				// NOTE: This ignores commits processed later sequentially. Empirically, this seems to pick the better commit.
-				if duplicates[ver] != "" {
-					duplicates[ver] = fmt.Sprintf("%s,%s", duplicates[ver], c.Hash.String())
-				} else {
-					duplicates[ver] = fmt.Sprintf("%s,%s", tm[ver], c.Hash.String())
-				}
-			} else {
-				tm[ver] = c.Hash.String()
-			}
-		}
-		return nil
-	})
-	if len(duplicates) > 0 {
-		for ver, dupes := range duplicates {
-			log.Printf("Multiple matches found [pkg=%s,ver=%s,refs=%v]\n", name, ver, dupes)
-		}
-	}
-	return tm, err
 }

--- a/pkg/rebuild/maven/maveninfer.go
+++ b/pkg/rebuild/maven/maveninfer.go
@@ -1,0 +1,243 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+)
+
+type MavenBuildInferer struct{}
+
+var _ rebuild.StrategyInferer = &MavenBuildInferer{}
+
+func (m *MavenBuildInferer) Infer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, repoConfig *rebuild.RepoConfig, commitObject *object.Commit) (rebuild.Strategy, error) {
+	_, pkgPath, err := findPomXML(commitObject, t.Package)
+	if err != nil {
+		return nil, errors.Wrapf(err, "build manifest heuristic failed")
+	}
+
+	refMap, err := pomXMLSearch(t.Package, pkgPath, repoConfig.Repository)
+	if err != nil {
+		log.Printf("pom.xml version heuristic failed [pkg=%s,repo=%s]: %s\n", t.Package, repoConfig.URI, err.Error())
+	}
+	name, version := t.Package, t.Version
+	var dir string
+	pomXMLGuess := refMap[version]
+	tagGuess, err := rebuild.FindTagMatch(name, version, repoConfig.Repository)
+	if err != nil {
+		return nil, errors.Wrapf(err, "[INTERNAL] tag heuristic error")
+	}
+
+	var ref string
+	var commit *object.Commit
+	switch {
+	case tagGuess != "":
+		commit, err = repoConfig.Repository.CommitObject(plumbing.NewHash(tagGuess))
+		if err == nil {
+			if newPath, err := findAndValidatePomXML(commit, name, version, pkgPath); err != nil {
+				log.Printf("registry heuristic tag invalid: %v", err)
+			} else {
+				log.Printf("using tag heuristic ref: %s", tagGuess[:9])
+				ref = tagGuess
+				dir = filepath.Dir(newPath)
+				break
+			}
+		} else if err == plumbing.ErrObjectNotFound {
+			log.Printf("tag heuristic ref not found in repo")
+		} else {
+			return nil, errors.Wrapf(err, "[INTERNAL] Failed ref resolve from tag [repo=%s,ref=%s]", repoConfig.URI, tagGuess)
+		}
+		fallthrough
+	case pomXMLGuess != "":
+		commit, err = repoConfig.Repository.CommitObject(plumbing.NewHash(pomXMLGuess))
+		if err == nil {
+			if newPath, err := findAndValidatePomXML(commit, name, version, pkgPath); err != nil {
+				log.Printf("registry heuristic git log invalid: %v", err)
+			} else {
+				log.Printf("using git log heuristic ref: %s", pomXMLGuess[:9])
+				ref = pomXMLGuess
+				dir = filepath.Dir(newPath)
+				break
+			}
+		} else if err == plumbing.ErrObjectNotFound {
+			log.Printf("git log heuristic ref not found in repo")
+		} else {
+			return nil, errors.Wrapf(err, "[INTERNAL] Failed ref resolve from git log [repo=%s,ref=%s]", repoConfig.URI, pomXMLGuess)
+		}
+		fallthrough
+	default:
+		if tagGuess == "" && pomXMLGuess == "" {
+			return nil, errors.Errorf("no git ref")
+		}
+		return nil, errors.Errorf("no valid git ref")
+	}
+	jdk, err := inferOrFallbackToDefaultJDK(ctx, name, version, mux)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching JDK")
+	}
+	return &MavenBuild{
+		Location: rebuild.Location{
+			Repo: repoConfig.URI,
+			Dir:  dir,
+			Ref:  ref,
+		},
+		JDKVersion: jdk,
+	}, nil
+}
+
+func findPomXML(commit *object.Commit, pkg string) (*PomXML, string, error) {
+	commitTree, _ := commit.Tree()
+	var names []string
+	var pomXMLs []PomXML
+	commitTree.Files().ForEach(func(f *object.File) error {
+		// Per Maven conventions, skip non-"pom.xml" files and those inside a `src` directory (unlikely to contain metadata).
+		// Reference: https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html
+		// Note: This will miss pom files, with name other than "pom.xml", whose paths are explicitly passed during build via "-f".
+		if path.Base(f.Name) != "pom.xml" || strings.HasPrefix(f.Name, "src/") || strings.Contains(f.Name, "/src/") {
+			return nil
+		}
+		pomXML, err := getPomXML(commitTree, f.Name)
+		if err != nil {
+			// XXX: ignore parse errors
+			return nil
+		}
+		if pkg == pomXML.Name() {
+			names = append(names, f.Name)
+			pomXMLs = append(pomXMLs, pomXML)
+		}
+		return nil
+	})
+	if len(names) > 0 {
+		if len(names) > 1 {
+			log.Printf("Multiple pom.xml file candidates [pkg=%s,ref=%s,matches=%v]\n", pkg, commit.Hash.String(), names)
+		}
+		return &pomXMLs[0], names[0], nil
+	}
+	return nil, "", errors.Errorf("pom.xml heuristic found no matches")
+}
+
+func pomXMLSearch(name, pomXMLPath string, repo *git.Repository) (tm map[string]string, err error) {
+	tm = make(map[string]string)
+	commitIter, err := repo.Log(&git.LogOptions{
+		Order:      git.LogOrderCommitterTime,
+		PathFilter: func(s string) bool { return s == pomXMLPath },
+		All:        true,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "searching for commits touching pom.xml")
+	}
+	duplicates := make(map[string]string)
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		t, err := c.Tree()
+		if err != nil {
+			return errors.Wrapf(err, "fetching tree")
+		}
+		pomXML, err := getPomXML(t, pomXMLPath)
+		if _, ok := err.(*xml.SyntaxError); ok {
+			return nil // unable to parse
+		} else if errors.Is(err, object.ErrFileNotFound) {
+			return nil // file deleted at this commit
+		} else if err != nil {
+			return errors.Wrapf(err, "fetching pom.xml")
+		}
+		if pomXML.Name() != name {
+			// TODO: Handle the case where the package name has changed.
+			log.Printf("Package name mismatch [expected=%s,actual=%s,path=%s,ref=%s]\n", name, pomXML.Name(), pomXMLPath, c.Hash.String())
+			return nil
+		}
+		ver := pomXML.Version()
+		if ver == "" {
+			return nil
+		}
+		// If any are the same, return nil. (merges would create duplicates.)
+		var foundMatch bool
+		err = c.Parents().ForEach(func(c *object.Commit) error {
+			t, err := c.Tree()
+			if err != nil {
+				return errors.Wrapf(err, "fetching tree")
+			}
+			pomXML, err := getPomXML(t, pomXMLPath)
+			if err != nil {
+				// TODO: Detect and record file moves.
+				return nil
+			}
+			if pomXML.Name() == name && pomXML.Version() == ver {
+				foundMatch = true
+			}
+			return nil
+		})
+		if err != nil {
+			return errors.Wrapf(err, "comparing against parent pom.xml")
+		}
+		if !foundMatch {
+			if tm[ver] != "" {
+				// NOTE: This ignores commits processed later sequentially. Empirically, this seems to pick the better commit.
+				if duplicates[ver] != "" {
+					duplicates[ver] = fmt.Sprintf("%s,%s", duplicates[ver], c.Hash.String())
+				} else {
+					duplicates[ver] = fmt.Sprintf("%s,%s", tm[ver], c.Hash.String())
+				}
+			} else {
+				tm[ver] = c.Hash.String()
+			}
+		}
+		return nil
+	})
+	if len(duplicates) > 0 {
+		for ver, dupes := range duplicates {
+			log.Printf("Multiple matches found [pkg=%s,ver=%s,refs=%v]\n", name, ver, dupes)
+		}
+	}
+	return tm, err
+}
+
+// findAndValidatePomXML ensures the package config has the expected name and version,
+// or finds a new version if necessary.
+func findAndValidatePomXML(commit *object.Commit, name, version, pomPath string) (string, error) {
+	if base := path.Base(pomPath); base == "build.gradle" || base == "build.gradle.kts" {
+		return pomPath, nil
+	}
+	commitTree, _ := commit.Tree()
+	orig, err := getPomXML(commitTree, pomPath)
+	pomXML := &orig
+	if err == object.ErrFileNotFound {
+		pomXML, pomPath, err = findPomXML(commit, name)
+	}
+	if err == object.ErrFileNotFound {
+		return pomPath, errors.Errorf("pom.xml file not found [path=%s]", pomPath)
+	} else if _, ok := err.(*xml.SyntaxError); ok {
+		return pomPath, errors.Wrapf(err, "failed to parse pom.xml")
+	} else if err != nil {
+		return pomPath, errors.Wrapf(err, "unknown pom.xml error")
+	} else if pomXML.Name() != name {
+		return pomPath, errors.Errorf("mismatched name [expected=%s,actual=%s,path=%s]", name, pomXML.Name(), pomPath)
+	} else if pomXML.Version() != version {
+		return pomPath, errors.Errorf("mismatched version [expected=%s,actual=%s,path=%s]", version, pomXML.Version(), pomPath)
+	}
+	return pomPath, nil
+}
+
+func getPomXML(tree *object.Tree, path string) (pomXML PomXML, err error) {
+	f, err := tree.File(path)
+	if err != nil {
+		return pomXML, err
+	}
+	p, err := f.Contents()
+	if err != nil {
+		return pomXML, err
+	}
+	return pomXML, xml.Unmarshal([]byte(p), &pomXML)
+}

--- a/pkg/rebuild/maven/mavenstrategy.go
+++ b/pkg/rebuild/maven/mavenstrategy.go
@@ -6,7 +6,6 @@ package maven
 import (
 	"path"
 
-	"github.com/google/oss-rebuild/internal/textwrap"
 	"github.com/pkg/errors"
 
 	"github.com/google/oss-rebuild/pkg/rebuild/flow"
@@ -27,6 +26,7 @@ func (b *MavenBuild) ToWorkflow() (*rebuild.WorkflowStrategy, error) {
 	if !exists {
 		return nil, errors.Errorf("no download URL for JDK version %s", b.JDKVersion)
 	}
+
 	return &rebuild.WorkflowStrategy{
 		Location: b.Location,
 		Source: []flow.Step{{
@@ -43,11 +43,7 @@ func (b *MavenBuild) ToWorkflow() (*rebuild.WorkflowStrategy, error) {
 				Uses: "maven/export-java",
 			},
 			{
-				// TODO: Java 9 needs additional certificate installed in /etc/ssl/certs/java/cacerts
-				// It can be passed to maven command via -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
-				Runs: "mvn clean package -DskipTests",
-				// Note `maven` from apt also pull in jdk-21 and hence we must export JAVA_HOME and PATH in the step before
-				Needs: []string{"maven"},
+				Uses: "maven/maven-build",
 			},
 		},
 		OutputDir: path.Join(b.Dir, "target"),
@@ -60,32 +56,4 @@ func (b *MavenBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild
 		return rebuild.Instructions{}, err
 	}
 	return workflow.GenerateFor(t, be)
-}
-
-func init() {
-	for _, t := range toolkit {
-		flow.Tools.MustRegister(t)
-	}
-}
-
-var toolkit = []*flow.Tool{
-	{
-		Name: "maven/setup-java",
-		Steps: []flow.Step{
-			{
-				Runs: textwrap.Dedent(`
-				mkdir -p /opt/jdk
-				wget -q -O - "{{.With.versionURL}}" | tar -xzf - --strip-components=1 -C /opt/jdk`[1:]),
-				Needs: []string{"wget"},
-			},
-		},
-	},
-	{
-		Name: "maven/export-java",
-		Steps: []flow.Step{{
-			Runs: textwrap.Dedent(`
-				export JAVA_HOME=/opt/jdk
-				export PATH=$JAVA_HOME/bin:$PATH`[1:]),
-		}},
-	},
 }

--- a/pkg/rebuild/maven/tools.go
+++ b/pkg/rebuild/maven/tools.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package maven
+
+import (
+	"github.com/google/oss-rebuild/internal/textwrap"
+	"github.com/google/oss-rebuild/pkg/rebuild/flow"
+)
+
+func init() {
+	for _, t := range toolkit {
+		flow.Tools.MustRegister(t)
+	}
+}
+
+var toolkit = []*flow.Tool{
+	{
+		Name: "maven/setup-java",
+		Steps: []flow.Step{
+			{
+				Runs: textwrap.Dedent(`
+				mkdir -p /opt/jdk
+				wget -q -O - "{{.With.versionURL}}" | tar -xzf - --strip-components=1 -C /opt/jdk`[1:]),
+				Needs: []string{"wget"},
+			},
+		},
+	},
+	{
+		Name: "maven/export-java",
+		Steps: []flow.Step{{
+			Runs: textwrap.Dedent(`
+				export JAVA_HOME=/opt/jdk
+				export PATH=$JAVA_HOME/bin:$PATH`[1:]),
+		}},
+	},
+	{
+		Name: "maven/maven-build",
+		Steps: []flow.Step{{
+			// TODO: Java 9 needs additional certificate installed in /etc/ssl/certs/java/cacerts
+			// It can be passed to maven command via -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
+			Runs: "mvn clean package -DskipTests",
+			// Note `maven` from apt also pull in jdk-21 and hence we must export JAVA_HOME and PATH in the step before
+			Needs: []string{"maven"},
+		}},
+	},
+	{
+		Name: "maven/gradle-build",
+		Steps: []flow.Step{{
+			Runs: "./gradlew build -x test --no-daemon",
+		}},
+	},
+	{
+		Name: "maven/move-gradle-build-output",
+		Steps: []flow.Step{{
+			Runs: "find . -name {{.With.targetName}} -type f -exec mv {} /src/ \\;",
+		}},
+	},
+}

--- a/pkg/rebuild/maven/tools.go
+++ b/pkg/rebuild/maven/tools.go
@@ -39,7 +39,7 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			// TODO: Java 9 needs additional certificate installed in /etc/ssl/certs/java/cacerts
 			// It can be passed to maven command via -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
-			Runs: "mvn clean package -DskipTests",
+			Runs: "mvn clean package -DskipTests -Dmaven.javadoc.skip",
 			// Note `maven` from apt also pull in jdk-21 and hence we must export JAVA_HOME and PATH in the step before
 			Needs: []string{"maven"},
 		}},
@@ -47,7 +47,7 @@ var toolkit = []*flow.Tool{
 	{
 		Name: "maven/gradle-build",
 		Steps: []flow.Step{{
-			Runs: "./gradlew build -x test --no-daemon",
+			Runs: "./gradlew build -x test -x javadoc --no-daemon",
 		}},
 	},
 	{

--- a/pkg/rebuild/rebuild/strategy.go
+++ b/pkg/rebuild/rebuild/strategy.go
@@ -4,9 +4,11 @@
 package rebuild
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/pkg/errors"
 )
 
@@ -58,6 +60,10 @@ func (b *BuildEnv) TimewarpURLFromString(ecosystem string, rfc3339Time string) (
 // Strategy generates instructions to execute a rebuild.
 type Strategy interface {
 	GenerateFor(Target, BuildEnv) (Instructions, error)
+}
+
+type StrategyInferer interface {
+	Infer(context.Context, Target, RegistryMux, *RepoConfig, *object.Commit) (Strategy, error)
 }
 
 // LocationHint is a partial strategy used to provide a hint (git repo, git ref) to the inference machinery, but it is not sufficient for execution.

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -30,6 +30,7 @@ type StrategyOneOf struct {
 	NPMCustomBuild       *npm.NPMCustomBuild            `json:"npm_custom_build,omitempty" yaml:"npm_custom_build,omitempty"`
 	CratesIOCargoPackage *cratesio.CratesIOCargoPackage `json:"cratesio_cargo_package,omitempty" yaml:"cratesio_cargo_package,omitempty"`
 	MavenBuild           *maven.MavenBuild              `json:"maven_build,omitempty" yaml:"maven_build,omitempty"`
+	GradleBuild          *maven.GradleBuild             `json:"gradle_build,omitempty" yaml:"gradle_build,omitempty"`
 	DebianPackage        *debian.DebianPackage          `json:"debian_package,omitempty" yaml:"debian_package,omitempty"`
 	Debrebuild           *debian.Debrebuild             `json:"debrebuild,omitempty" yaml:"debrebuild,omitempty"`
 	ManualStrategy       *rebuild.ManualStrategy        `json:"manual,omitempty" yaml:"manual,omitempty"`
@@ -46,6 +47,8 @@ func NewStrategyOneOf(s rebuild.Strategy) StrategyOneOf {
 		oneof.PureWheelBuild = t
 	case *maven.MavenBuild:
 		oneof.MavenBuild = t
+	case *maven.GradleBuild:
+		oneof.GradleBuild = t
 	case *npm.NPMPackBuild:
 		oneof.NPMPackBuild = t
 	case *npm.NPMCustomBuild:
@@ -108,6 +111,10 @@ func (oneof *StrategyOneOf) Strategy() (rebuild.Strategy, error) {
 		if oneof.MavenBuild != nil {
 			num++
 			s = oneof.MavenBuild
+		}
+		if oneof.GradleBuild != nil {
+			num++
+			s = oneof.GradleBuild
 		}
 	}
 	if num != 1 {


### PR DESCRIPTION
There were some failures related to generating javadoc. I add them here to skip the goal/task that generates it.

It would interfere with #694 as release artifacts usually contain javadoc, but it works for now.