### PR TITLE
Fix timewarp configuration

### DIFF
--- a/pkg/build/local/build_planner.go
+++ b/pkg/build/local/build_planner.go
@@ -121,7 +121,7 @@ func (p *DockerBuildPlanner) generateDockerfile(input rebuild.Input, instruction
 		BaseImage:      baseImage,
 		OS:             os,
 		PackageManager: pkgMgr,
-		UseTimewarp:    timewarpURL != "",
+		UseTimewarp:    opts.UseTimewarp,
 		TimewarpURL:    timewarpURL,
 		TimewarpAuth:   timewarpAuth,
 	}


### PR DESCRIPTION
The `timewarp` setting should be set by the `UseTimewarp` and not by URL. Also, there is a default URL set above in the same file. Don't we have parameters to set it? Why is there a default hardcoded here?