### PR TITLE
Grant read permissions to the generated artifact

### DIFF
--- a/pkg/build/local/build_planner.go
+++ b/pkg/build/local/build_planner.go
@@ -67,6 +67,7 @@ var dockerBuildDockerfileTpl = template.Must(
 			RUN cat <<'EOF' >/build
 			 set -eux
 			 {{.Instructions.Build | indent}}
+			 chmod +444 /src/{{.Instructions.OutputPath}}
 			 mkdir -p /out && cp /src/{{.Instructions.OutputPath}} /out/
 			EOF
 			WORKDIR "/src"


### PR DESCRIPTION
This ensures that the generated artifact can at least be [read by `UploadFile`](https://github.com/google/oss-rebuild/blob/bffa736119fcc8aa93e2951432deed90b6b77bee/pkg/build/local/build_executor.go#L277) so that it can be uploaded from the mounted volume of docker container to the asset store.