### PR TITLE
Force image name to be lowercase

### DIFF
--- a/pkg/build/local/build_executor.go
+++ b/pkg/build/local/build_executor.go
@@ -98,7 +98,8 @@ type DockerBuildExecutorConfig struct {
 
 // Start implements build.Executor.
 func (e *DockerBuildExecutor) Start(ctx context.Context, input rebuild.Input, opts build.Options) (build.Handle, error) {
-	buildID := opts.BuildID
+	// buildID is used as image name and must be lowercase
+	buildID := strings.ToLower(opts.BuildID)
 	if buildID == "" {
 		buildID = fmt.Sprintf("docker-build-%d", time.Now().UnixNano())
 	}


### PR DESCRIPTION
Indeed it wasn't the best idea to generate `buildID` based on `pkg` and `version`, @wbxyz . Apparently, some of the versions are `1.0.2.RELEASE`. When this is passed to be the image name, the docker build fails as [lowercase image name is not allowed](https://stackoverflow.com/questions/36858837/lowercase-images-names-in-docker).