### PR TITLE
Remove logs bucket from agent api deps

### DIFF
--- a/cmd/agent-api/main.go
+++ b/cmd/agent-api/main.go
@@ -82,7 +82,6 @@ func AgentCreateIterationInit(ctx context.Context) (*agentapiservice.AgentCreate
 	d.GCBExecutor = executor
 	d.BuildProject = *project
 	d.BuildServiceAccount = *buildRemoteIdentity
-	d.LogsBucket = *logsBucket
 	d.MetadataBucket = *metadataBucket
 	if *prebuildVersion != "" {
 		prebuildRepo, err := serviceid.ParseLocation(BuildRepo, *prebuildVersion)

--- a/internal/api/agentapiservice/iteration.go
+++ b/internal/api/agentapiservice/iteration.go
@@ -26,7 +26,6 @@ type AgentCreateIterationDeps struct {
 	GCBExecutor         *gcb.Executor
 	BuildProject        string
 	BuildServiceAccount string
-	LogsBucket          string
 	MetadataBucket      string
 	PrebuildConfig      rebuild.PrebuildConfig
 }


### PR DESCRIPTION
The agent api deps already include a build executor which has the logs
configured, so the bucket doesn't need to be passed explicity.