### PR TITLE
Correct media type in DSSE payload when signing 

### DIFF
--- a/analyzer/network/analyzerservice/analyze_test.go
+++ b/analyzer/network/analyzerservice/analyze_test.go
@@ -117,12 +117,12 @@ func createMockAttestationBundle(t rebuild.Target, strategy rebuild.Strategy) []
 	var bundle bytes.Buffer
 	encoder := json.NewEncoder(&bundle)
 	buildEnvelope := &dsse.Envelope{
-		PayloadType: in_toto.StatementInTotoV1,
+		PayloadType: attestation.InTotoPayloadType,
 		Payload:     base64.StdEncoding.EncodeToString(must(json.Marshal(must(buildAttestation.ToStatement())))),
 		Signatures:  []dsse.Signature{{Sig: base64.StdEncoding.EncodeToString([]byte("mock-sig"))}},
 	}
 	eqEnvelope := &dsse.Envelope{
-		PayloadType: in_toto.StatementInTotoV1,
+		PayloadType: attestation.InTotoPayloadType,
 		Payload:     base64.StdEncoding.EncodeToString(must(json.Marshal(must(eqAttestation.ToStatement())))),
 		Signatures:  []dsse.Signature{{Sig: base64.StdEncoding.EncodeToString([]byte("mock-sig"))}},
 	}

--- a/internal/verifier/intoto.go
+++ b/internal/verifier/intoto.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 
 	"github.com/google/oss-rebuild/internal/hashext"
+	"github.com/google/oss-rebuild/pkg/attestation"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
@@ -28,7 +29,9 @@ func (signer *InTotoEnvelopeSigner) SignStatement(ctx context.Context, s *in_tot
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling statement")
 	}
-	envelope, err := signer.SignPayload(ctx, s.StatementHeader.Type, b)
+	// Since this is signing only a slsa predicate wrapped in an in-toto statement,
+	// the payload type is fixed to the in-toto media type.
+	envelope, err := signer.SignPayload(ctx, attestation.InTotoPayloadType, b)
 	if err != nil {
 		return nil, errors.Wrap(err, "signing payload")
 	}

--- a/pkg/attestation/bundle.go
+++ b/pkg/attestation/bundle.go
@@ -16,6 +16,10 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
+// The envelope must have the in-toto media type
+// See https://github.com/in-toto/ITE/blob/a6bf0abbc99608ff5920446bf1141417b49a6d30/ITE/5/README.adoc#specification
+const InTotoPayloadType = "application/vnd.in-toto+json"
+
 type VerifiedEnvelope[T any] struct {
 	envelope *dsse.Envelope
 	payload  *T
@@ -29,7 +33,8 @@ func NewVerifiedEnvelope[T any](ctx context.Context, e *dsse.Envelope, verifier 
 	if _, err := verifier.Verify(ctx, e); err != nil {
 		return nil, errors.Wrap(err, "verifying envelope")
 	}
-	if e.PayloadType != in_toto.StatementInTotoV1 {
+	// Here in_toto.StatementInTotoV1 is kept for compatibility
+	if e.PayloadType != in_toto.StatementInTotoV1 && e.PayloadType != InTotoPayloadType {
 		return nil, errors.New("unexpected payload type")
 	}
 	if e.Payload == "" {

--- a/pkg/attestation/bundle_test.go
+++ b/pkg/attestation/bundle_test.go
@@ -40,7 +40,7 @@ func createTestEnvelope(t *testing.T, statement *in_toto.Statement) *dsse.Envelo
 	t.Helper()
 	payload := must(json.Marshal(statement))
 	return &dsse.Envelope{
-		PayloadType: in_toto.StatementInTotoV1,
+		PayloadType: InTotoPayloadType,
 		Payload:     base64.StdEncoding.EncodeToString(payload),
 		Signatures:  []dsse.Signature{{Sig: base64.StdEncoding.EncodeToString([]byte("test-signature"))}},
 	}
@@ -94,7 +94,7 @@ func TestVerifiedEnvelope_NewVerifiedEnvelope(t *testing.T) {
 		{
 			name: "empty payload",
 			envelope: &dsse.Envelope{
-				PayloadType: in_toto.StatementInTotoV1,
+				PayloadType: InTotoPayloadType,
 				Payload:     "",
 				Signatures:  validEnvelope.Signatures,
 			},
@@ -104,7 +104,7 @@ func TestVerifiedEnvelope_NewVerifiedEnvelope(t *testing.T) {
 		{
 			name: "invalid base64",
 			envelope: &dsse.Envelope{
-				PayloadType: in_toto.StatementInTotoV1,
+				PayloadType: InTotoPayloadType,
 				Payload:     "invalid-base64-!!!",
 				Signatures:  validEnvelope.Signatures,
 			},
@@ -114,7 +114,7 @@ func TestVerifiedEnvelope_NewVerifiedEnvelope(t *testing.T) {
 		{
 			name: "invalid json",
 			envelope: &dsse.Envelope{
-				PayloadType: in_toto.StatementInTotoV1,
+				PayloadType: InTotoPayloadType,
 				Payload:     base64.StdEncoding.EncodeToString([]byte("invalid json")),
 				Signatures:  validEnvelope.Signatures,
 			},


### PR DESCRIPTION
This PR modifies the `InTotoEnvelopeSigner` and tests to correct a bug where the in-toto predicate type URI is being used to populate the DSSE payload type (instead of the [media type as defined in the spec](https://github.com/in-toto/ITE/blob/a6bf0abbc99608ff5920446bf1141417b49a6d30/ITE/5/README.adoc#specification)).

I've also updated the tests to use media type in all the test envelopes.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>