### PR TITLE
Add meta.NewRegistryMux

### DIFF
--- a/analyzer/network/analyzerservice/analyze.go
+++ b/analyzer/network/analyzerservice/analyze.go
@@ -24,10 +24,6 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/google/oss-rebuild/pkg/rebuild/stability"
-	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
-	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
-	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
-	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/google/uuid"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
@@ -97,13 +93,7 @@ func analyzeRebuild(ctx context.Context, t rebuild.Target, deps *AnalyzerDeps) (
 		return nil, errors.Wrap(err, "extracting strategy from attestation")
 	}
 	ctx = context.WithValue(ctx, rebuild.HTTPBasicClientID, deps.HTTPClient)
-	regclient := httpx.NewCachedClient(deps.HTTPClient, &cache.CoalescingMemoryCache{})
-	mux := rebuild.RegistryMux{
-		Debian:   debianreg.HTTPRegistry{Client: regclient},
-		CratesIO: cratesreg.HTTPRegistry{Client: regclient},
-		NPM:      npmreg.HTTPRegistry{Client: regclient},
-		PyPI:     pypireg.HTTPRegistry{Client: regclient},
-	}
+	mux := meta.NewRegistryMux(httpx.NewCachedClient(deps.HTTPClient, &cache.CoalescingMemoryCache{}))
 	id, err := executeNetworkRebuild(ctx, deps, t, strategy, rebuildAttestation)
 	if err != nil {
 		return nil, errors.Wrap(err, "network rebuild failed")

--- a/internal/api/agentapiservice/iteration.go
+++ b/internal/api/agentapiservice/iteration.go
@@ -20,11 +20,6 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/google/oss-rebuild/pkg/rebuild/stability"
-	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
-	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
-	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
-	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
-	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"google.golang.org/api/iterator"
@@ -158,13 +153,7 @@ func AgentCreateIteration(ctx context.Context, req schema.AgentCreateIterationRe
 		if err != nil {
 			return nil, api.AsStatus(codes.Internal, errors.New("making gateway client"))
 		}
-		mux := rebuild.RegistryMux{
-			Debian:   debianreg.HTTPRegistry{Client: regclient},
-			CratesIO: cratesreg.HTTPRegistry{Client: regclient},
-			NPM:      npmreg.HTTPRegistry{Client: regclient},
-			PyPI:     pypireg.HTTPRegistry{Client: regclient},
-			Maven:    mavenreg.HTTPRegistry{Client: regclient},
-		}
+		mux := meta.NewRegistryMux(regclient)
 		upstreamURI, err := rebuilder.UpstreamURL(ctx, session.Target, mux)
 		if err != nil {
 			return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "getting upstream url"))

--- a/internal/api/inferenceservice/infer.go
+++ b/internal/api/inferenceservice/infer.go
@@ -13,11 +13,6 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/meta"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
-	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
-	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
-	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
-	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
-	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 )
@@ -65,13 +60,7 @@ func Infer(ctx context.Context, req schema.InferenceRequest, deps *InferDeps) (*
 		ctx = context.WithValue(ctx, rebuild.RepoCacheClientID, *deps.GitCache)
 	}
 	ctx = context.WithValue(ctx, rebuild.HTTPBasicClientID, deps.HTTPClient)
-	mux := rebuild.RegistryMux{
-		CratesIO: cratesreg.HTTPRegistry{Client: deps.HTTPClient},
-		NPM:      npmreg.HTTPRegistry{Client: deps.HTTPClient},
-		PyPI:     pypireg.HTTPRegistry{Client: deps.HTTPClient},
-		Maven:    mavenreg.HTTPRegistry{Client: deps.HTTPClient},
-		Debian:   debianreg.HTTPRegistry{Client: deps.HTTPClient},
-	}
+	mux := meta.NewRegistryMux(deps.HTTPClient)
 	var s rebuild.Strategy
 	t := rebuild.Target{
 		Ecosystem: req.Ecosystem,

--- a/internal/api/rebuilderservice/smoketest.go
+++ b/internal/api/rebuilderservice/smoketest.go
@@ -14,15 +14,11 @@ import (
 	cratesrb "github.com/google/oss-rebuild/pkg/rebuild/cratesio"
 	debianrb "github.com/google/oss-rebuild/pkg/rebuild/debian"
 	mavenrb "github.com/google/oss-rebuild/pkg/rebuild/maven"
+	"github.com/google/oss-rebuild/pkg/rebuild/meta"
 	npmrb "github.com/google/oss-rebuild/pkg/rebuild/npm"
 	pypirb "github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
-	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
-	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
-	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
-	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
-	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 )
@@ -135,13 +131,7 @@ func RebuildSmoketest(ctx context.Context, sreq schema.SmoketestRequest, deps *R
 		ctx = context.WithValue(ctx, rebuild.RepoCacheClientID, *deps.GitCache)
 	}
 	ctx = context.WithValue(ctx, rebuild.HTTPBasicClientID, deps.HTTPClient)
-	mux := rebuild.RegistryMux{
-		Debian:   debianreg.HTTPRegistry{Client: deps.HTTPClient},
-		CratesIO: cratesreg.HTTPRegistry{Client: deps.HTTPClient},
-		NPM:      npmreg.HTTPRegistry{Client: deps.HTTPClient},
-		PyPI:     pypireg.HTTPRegistry{Client: deps.HTTPClient},
-		Maven:    mavenreg.HTTPRegistry{Client: deps.HTTPClient},
-	}
+	mux := meta.NewRegistryMux(deps.HTTPClient)
 	if deps.TimewarpURL != nil {
 		ctx = context.WithValue(ctx, rebuild.TimewarpID, *deps.TimewarpURL)
 	}

--- a/pkg/rebuild/meta/meta.go
+++ b/pkg/rebuild/meta/meta.go
@@ -4,13 +4,29 @@
 package meta
 
 import (
+	"github.com/google/oss-rebuild/internal/httpx"
 	cratesrb "github.com/google/oss-rebuild/pkg/rebuild/cratesio"
 	debianrb "github.com/google/oss-rebuild/pkg/rebuild/debian"
 	mavenrb "github.com/google/oss-rebuild/pkg/rebuild/maven"
 	npmrb "github.com/google/oss-rebuild/pkg/rebuild/npm"
 	pypirb "github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
+	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
+	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
+	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
+	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 )
+
+func NewRegistryMux(c httpx.BasicClient) rebuild.RegistryMux {
+	return rebuild.RegistryMux{
+		Debian:   debianreg.HTTPRegistry{Client: c},
+		CratesIO: cratesreg.HTTPRegistry{Client: c},
+		NPM:      npmreg.HTTPRegistry{Client: c},
+		PyPI:     pypireg.HTTPRegistry{Client: c},
+		Maven:    mavenreg.HTTPRegistry{Client: c},
+	}
+}
 
 var AllRebuilders = map[rebuild.Ecosystem]rebuild.Rebuilder{
 	rebuild.NPM:      &npmrb.Rebuilder{},

--- a/tools/benchmark/run/local.go
+++ b/tools/benchmark/run/local.go
@@ -27,10 +27,6 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/google/oss-rebuild/pkg/rebuild/stability"
-	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
-	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
-	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
-	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/pkg/errors"
 )
 
@@ -54,13 +50,7 @@ func (s *localExecutionService) RebuildPackage(ctx context.Context, req schema.R
 	if req.UseSyscallMonitor {
 		return nil, errors.New("syscall monitor not supported")
 	}
-	regClient := httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{})
-	mux := rebuild.RegistryMux{
-		Debian:   debianreg.HTTPRegistry{Client: regClient},
-		CratesIO: cratesreg.HTTPRegistry{Client: regClient},
-		NPM:      npmreg.HTTPRegistry{Client: regClient},
-		PyPI:     pypireg.HTTPRegistry{Client: regClient},
-	}
+	mux := meta.NewRegistryMux(httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{}))
 	t := rebuild.Target{Ecosystem: req.Ecosystem, Package: req.Package, Version: req.Version, Artifact: req.Artifact}
 	if req.Artifact == "" {
 		switch t.Ecosystem {

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -51,11 +51,6 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/meta"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
-	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
-	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
-	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
-	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
-	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/google/oss-rebuild/tools/benchmark"
 	"github.com/google/oss-rebuild/tools/benchmark/run"
 	"github.com/google/oss-rebuild/tools/ctl/gradle"
@@ -175,14 +170,7 @@ var tui = &cobra.Command{
 				log.Fatal(errors.Wrap(err, "failed to create local build def asset store"))
 			}
 		}
-		regclient := http.DefaultClient
-		mux := rebuild.RegistryMux{
-			Debian:   debianreg.HTTPRegistry{Client: regclient},
-			CratesIO: cratesreg.HTTPRegistry{Client: regclient},
-			NPM:      npmreg.HTTPRegistry{Client: regclient},
-			PyPI:     pypireg.HTTPRegistry{Client: regclient},
-			Maven:    mavenreg.HTTPRegistry{Client: regclient},
-		}
+		mux := meta.NewRegistryMux(http.DefaultClient)
 		var assetStoreFn func(runID string) (rebuild.LocatableAssetStore, error)
 		if *sharedAssetStore != "" {
 			u, err := url.Parse(*sharedAssetStore)
@@ -403,13 +391,7 @@ var export = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		regclient := http.DefaultClient
-		mux := rebuild.RegistryMux{
-			Debian:   debianreg.HTTPRegistry{Client: regclient},
-			CratesIO: cratesreg.HTTPRegistry{Client: regclient},
-			NPM:      npmreg.HTTPRegistry{Client: regclient},
-			PyPI:     pypireg.HTTPRegistry{Client: regclient},
-		}
+		mux := meta.NewRegistryMux(http.DefaultClient)
 		butler := localfiles.NewButler(*metadataBucket, *logsBucket, *debugStorage, mux, func(_ string) (rebuild.LocatableAssetStore, error) { return destStore, nil })
 		// Write the metadata about the run.
 		if *exportRundex {


### PR DESCRIPTION
During this migration I found a few places where we had RegistryMux
object that were missing an ecosystem. Centralizing it makes it easier
to add new ecosystems in the future.