### PR TITLE
Prevent falling through if condition is false

### DIFF
--- a/pkg/rebuild/maven/maveninfer.go
+++ b/pkg/rebuild/maven/maveninfer.go
@@ -107,18 +107,20 @@ func MavenInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, 
 		fallthrough
 	case sourceJarGuess != nil:
 		commit = sourceJarGuess
-		pomXML, foundPkgPath, err := findPomXML(commit, t.Package)
-		if err != nil {
-			log.Printf("source jar heuristic failed: could not find a pom.xml for the package")
-		} else {
-			ref = sourceJarGuess.Hash.String()
-			dir = filepath.Dir(foundPkgPath)
-			if pomXML.Version() != version {
-				log.Printf("using source jar heuristic with mismatched version [expected=%s,actual=%s,path=%s,ref=%s]", version, pomXML.Version(), path.Join(dir, "pom.xml"), ref[:9])
+		if err == nil {
+			pomXML, foundPkgPath, err := findPomXML(commit, t.Package)
+			if err != nil {
+				log.Printf("source jar heuristic failed: could not find a pom.xml for the package")
 			} else {
-				log.Printf("using source jar heuristic (pkg and version match) ref: %s", ref[:9])
+				ref = sourceJarGuess.Hash.String()
+				dir = filepath.Dir(foundPkgPath)
+				if pomXML.Version() != version {
+					log.Printf("using source jar heuristic with mismatched version [expected=%s,actual=%s,path=%s,ref=%s]", version, pomXML.Version(), path.Join(dir, "pom.xml"), ref[:9])
+				} else {
+					log.Printf("using source jar heuristic (pkg and version match) ref: %s", ref[:9])
+				}
+				break
 			}
-			break
 		}
 		fallthrough
 	default:


### PR DESCRIPTION
This won't throw a nil dereferencing error if there is a `fallthrough` from git log heuristic to source jar heuristic and sourceJar guess is `nil`.
I also compute the heuristics lazily. `refMap` is only computed when tag heurisitic does not give a valid match or fails.