### PR TITLE
Test for gradle inference

### DIFF
--- a/pkg/rebuild/maven/gradleinfer.go
+++ b/pkg/rebuild/maven/gradleinfer.go
@@ -36,7 +36,7 @@ func GradleInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux,
 		ref = sourceJarGuess.Hash.String()
 		log.Printf("using source jar heuristic ref: %s", ref[:9])
 	default:
-		return nil, errors.Errorf("no valid git ref")
+		return nil, errors.Errorf("no git ref")
 	}
 	commitObject, err := repoConfig.Repository.CommitObject(plumbing.NewHash(ref))
 	if err != nil {

--- a/pkg/rebuild/maven/gradleinfer_test.go
+++ b/pkg/rebuild/maven/gradleinfer_test.go
@@ -4,9 +4,13 @@
 package maven
 
 import (
+	"archive/zip"
 	"testing"
 
 	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
+	"github.com/google/oss-rebuild/pkg/archive"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/registry/maven"
 )
 
 func TestFindBuildGradleDir(t *testing.T) {
@@ -106,6 +110,162 @@ func TestFindBuildGradleDir(t *testing.T) {
 					t.Errorf("findBuildGradleDir() = %q, want %q", actualDir, tc.expectedDir)
 				}
 			}
+		})
+	}
+}
+
+func TestGradleInfer(t *testing.T) {
+	testCases := []struct {
+		name           string
+		target         rebuild.Target
+		repo           string
+		zipEntries     map[string][]*archive.ZipEntry
+		expectedCommit string
+		wantErr        bool
+	}{
+		{
+			name: "infer using tag heuristic",
+			target: rebuild.Target{
+				Package:   "com.example:myapp",
+				Version:   "1.0.0",
+				Ecosystem: rebuild.Maven,
+			},
+			repo: `
+            commits:
+            - id: initial-commit
+              files:
+                gradle.properties: |
+                  group=com.example
+                build.gradle: |
+                  repositories {
+                    mavenCentral()
+                  }
+            - id: second-commit
+              parents: [initial-commit]
+              tags: ['v1.0.0']
+              files:
+                README.md: |
+                    Sample Project`,
+			zipEntries: map[string][]*archive.ZipEntry{
+				maven.TypeJar: {
+					{
+						FileHeader: &zip.FileHeader{Name: "META-INF/maven/com/example/myapp/pom.xml"},
+						Body:       []byte("<project><groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version></project>"),
+					},
+					{
+						FileHeader: &zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+						Body:       []byte("Manifest-Version: 1.0\nBuild-Jdk: 11.0.1\n"),
+					},
+				},
+			},
+			// select second-commit because it has the tag matching version 1.0.0
+			expectedCommit: "second-commit",
+		},
+		{
+			name: "infer using source jar heuristic",
+			target: rebuild.Target{
+				Package:   "com.example:myapp",
+				Version:   "1.0.0",
+				Ecosystem: rebuild.Maven,
+			},
+			repo: `
+            commits:
+            - id: initial-commit
+              files:
+                build.gradle: |
+                  group=com.example
+                src/main/java/App.java: |
+                  class App {}
+            - id: second-commit
+              parents: [initial-commit]
+              files:
+                build.gradle: |
+                  group=com.example
+                src/main/java/App.java: |
+                  public class App {}`,
+			zipEntries: map[string][]*archive.ZipEntry{
+				maven.TypeJar: {
+					{
+						FileHeader: &zip.FileHeader{Name: "META-INF/maven/com/example/myapp/pom.xml"},
+						Body:       []byte("<project><groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version></project>"),
+					},
+					{
+						FileHeader: &zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+						Body:       []byte("Manifest-Version: 1.0\nBuild-Jdk: 11.0.1\n"),
+					},
+				},
+				maven.TypeSources: {
+					{
+						FileHeader: &zip.FileHeader{Name: "src/main/java/App.java"},
+						Body:       []byte("public class App {}"),
+					},
+				},
+			},
+			// select second-commit because it is the closest to the source jar creation time
+			expectedCommit: "second-commit",
+		},
+		{
+			name: "fail when no heuristics match",
+			target: rebuild.Target{
+				Package:   "com.example:unknown",
+				Version:   "0.1.0",
+				Ecosystem: rebuild.Maven,
+			},
+			repo: `
+            commits:
+            - id: initial-commit
+              tags: ['4.2.0']
+              files:
+                build.gradle: |
+                  group=com.example
+                src/main/java/Main.java: |
+                  public class Main {}`,
+			zipEntries: map[string][]*archive.ZipEntry{
+				maven.TypeJar: {
+					{
+						FileHeader: &zip.FileHeader{Name: "META-INF/maven/com/example/unknown/pom.xml"},
+						Body:       []byte("<project><groupId>com.example</groupId><artifactId>unknown</artifactId><version>0.1.0</version></project>"),
+					},
+					{
+						FileHeader: &zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+						Body:       []byte("Manifest-Version: 1.0\nBuild-Jdk: 11.0.1\n"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repoConfig := &rebuild.RepoConfig{}
+			repo, err := gitxtest.CreateRepoFromYAML(tc.repo, nil)
+			if err != nil {
+				t.Fatalf("CreateRepoFromYAML() error = %v", err)
+			}
+			repoConfig.Repository = repo.Repository
+			mockRegistry := &mockMavenRegistry{
+				artifactCoordinates: make(map[artifactCoordinates][]byte),
+			}
+			addArtifacts(mockRegistry, tc.zipEntries, tc.target)
+			mockMux := rebuild.RegistryMux{
+				Maven: mockRegistry,
+			}
+			got, err := GradleInfer(t.Context(), tc.target, mockMux, repoConfig)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("GradleInfer() = %v, want error", got)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("GradleInfer() error = %v", err)
+				}
+				actualCommit := got.(*GradleBuild).Location.Ref
+				expectedCommit := repo.Commits[tc.expectedCommit].String()
+				if actualCommit != expectedCommit {
+					t.Errorf("GradleInfer() commit = %q, want %q", actualCommit, tc.expectedCommit)
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
I also changed the log message for Gradle to `no git ref` as in Gradle we don't verify the build.gradle like we do for pom.xml in Maven. In Maven, the artifact ID is looked for in the commit tree. In Gradle, we don't do this. It is merely used for inferring build directory.

I can probably add validation to Gradle too.