### PR TITLE
Update patch version of fallback JDK

### DIFF
--- a/pkg/rebuild/maven/jdk_urls.go
+++ b/pkg/rebuild/maven/jdk_urls.go
@@ -45,7 +45,7 @@ var JDKDownloadURLs = map[string]string{
 	"12":       "https://download.java.net/java/GA/jdk12/33/GPL/openjdk-12_linux-x64_bin.tar.gz",
 	"11.0.2":   "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz",
 	"11.0.1":   "https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz",
-	"11":       "https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz",
+	"11":       "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.28_6.tar.gz",
 	"10.0.2":   "https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz",
 	"10.0.1":   "https://download.java.net/java/GA/jdk10/10.0.1/fb4372174a714e6b8c52526dc134031e/10/openjdk-10.0.1_linux-x64_bin.tar.gz",
 	"10":       "https://download.java.net/java/GA/jdk10/10/binaries/openjdk-10_linux-x64_bin.tar.gz",


### PR DESCRIPTION
Fixes #844 

On a related note, I am inclined to use latest patch versions of LTS JDK wherever possible.