### PR TITLE
Upload inference logs

### DIFF
--- a/cmd/inference/main.go
+++ b/cmd/inference/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/oss-rebuild/internal/api/inferenceservice"
 	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/httpegress"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/pkg/errors"
 	"google.golang.org/api/idtoken"
 	gapihttp "google.golang.org/api/transport/http"
@@ -23,6 +24,7 @@ import (
 
 var (
 	gitCacheURL = flag.String("git-cache-url", "", "if provided, the git-cache service to use to fetch repos")
+	logsBucket  = flag.String("logs-bucket", "", "if provided, the GCS bucket to use for inference logs")
 )
 
 var httpcfg = httpegress.Config{}
@@ -54,6 +56,10 @@ func InferInit(ctx context.Context) (*inferenceservice.InferDeps, error) {
 			Worktree: memfs.New(),
 			Storer:   memory.NewStorage(),
 		}
+	}
+	d.LogStore, err = rebuild.NewGCSStore(ctx, "gs://"+*logsBucket)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating log asset store")
 	}
 	return &d, nil
 }

--- a/pkg/rebuild/rebuild/storage.go
+++ b/pkg/rebuild/rebuild/storage.go
@@ -49,6 +49,11 @@ const (
 	// TetragonLogAsset is the log of all tetragon events.
 	TetragonLogAsset AssetType = "tetragon.jsonl"
 
+	// InferenceLogAsset is the log of the inference process.
+	InferenceLogAsset AssetType = "inference.log"
+	// InferredStrategyInputs is the inferred build strategy.
+	InferredStrategyInputs AssetType = "strategy_inputs.json"
+
 	// AttestationBundleAsset is the signed attestation bundle generated for a rebuild.
 	AttestationBundleAsset AssetType = "rebuild.intoto.jsonl"
 


### PR DESCRIPTION
It is nice to have inference logs for our own debugging and also for expanding the logic for agent workflow to infer source repository using the inference logs. We had some positive results with inferring source URL based on logs of manual inference.

I haven't configured `LogStore` in agent API and also in our Terraform configuration. I will do so once the integration of these changes look good.