### PR TITLE
Use strategy hint if initial reference fails

### DIFF
--- a/internal/agent/logic.go
+++ b/internal/agent/logic.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -336,6 +337,57 @@ func (a *defaultAgent) getTools() []*llm.FunctionDefinition {
 	}
 }
 
+func (a *defaultAgent) proposeInferenceWithAIAssist(ctx context.Context, initialErr error, wt billy.Filesystem, str *memory.Storage) (*schema.StrategyOneOf, error) {
+	prompt := []string{
+		fmt.Sprintf("Based on the following inference failure error \"%v\" for package '%s', find the correct source code repository URL.", initialErr, a.t.Package),
+		"Just return the URL WITHOUT any additional text or formatting.",
+		"For example, for the package 'org.apache.camel:camel-support', return 'https://github.com/apache/camel' not 'https://github.com/apache/camel/tree/main/core/camel-support'.",
+		"Use the tools you have at your disposal to find the URL.",
+		"Finally, if you don't find the URL, just return an empty string.",
+	}
+	repoURL, err := llm.GenerateTextContent(ctx, a.deps.GenaiClient, llm.GeminiPro, &genai.GenerateContentConfig{
+		Temperature: genai.Ptr(float32(0.0)),
+		Tools: []*genai.Tool{
+			{GoogleSearch: &genai.GoogleSearch{}},
+		},
+	}, genai.NewPartFromText(strings.Join(prompt, "\n")))
+	if err != nil {
+		return nil, errors.Wrap(err, "getting AI repo hint")
+	}
+	if repoURL == "" {
+		return nil, errors.Wrap(initialErr, "AI could not find a repository hint")
+	}
+	log.Printf("AI suggested repo hint: %s", repoURL)
+	req := schema.InferenceRequest{
+		Ecosystem: a.t.Ecosystem,
+		Package:   a.t.Package,
+		Version:   a.t.Version,
+		Artifact:  a.t.Artifact,
+		StrategyHint: &schema.StrategyOneOf{
+			LocationHint: &rebuild.LocationHint{
+				Location: rebuild.Location{
+					Repo: repoURL,
+				},
+			},
+		},
+	}
+	s, err := inferenceservice.Infer(
+		ctx,
+		req,
+		&inferenceservice.InferDeps{
+			HTTPClient: http.DefaultClient,
+			GitCache:   nil,
+			RepoOptF: func() *gitx.RepositoryOptions {
+				return &gitx.RepositoryOptions{
+					Worktree: wt,
+					Storer:   str,
+				}
+			},
+		},
+	)
+	return s, errors.Wrap(err, "AI-assisted inference failed")
+}
+
 func (a *defaultAgent) proposeNormalInference(ctx context.Context) (*schema.StrategyOneOf, error) {
 	wt := memfs.New()
 	str := memory.NewStorage()
@@ -359,7 +411,13 @@ func (a *defaultAgent) proposeNormalInference(ctx context.Context) (*schema.Stra
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "inferring initial strategy")
+		wt = memfs.New()
+		str = memory.NewStorage()
+		s, err = a.proposeInferenceWithAIAssist(ctx, err, wt, str)
+		if err != nil {
+			return nil, errors.Wrap(err, "AI-assisted inference failed")
+		}
+		log.Println("AI-assisted inference succeeded.")
 	}
 	a.repo, err = git.Open(str, wt)
 	if err != nil {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -26,6 +26,7 @@ type AgentDeps struct {
 	LogsBucket     string
 	GCSClient      *gcs.Client
 	MaxTurns       int
+	GenaiClient    *genai.Client
 }
 
 type ProposeOpts struct {
@@ -104,6 +105,7 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) *sch
 		LogsBucket:     deps.LogsBucket,
 		GCSClient:      deps.GCSClient,
 		MaxTurns:       10,
+		GenaiClient:    deps.Client,
 	})
 	var err error
 	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, llm.GeminiPro, config, &llm.ChatOpts{Tools: a.getTools()})


### PR DESCRIPTION
I haven't tested this yet. But the logic is to try inference again with Google Search to get the correct source repository.