### PR TITLE
Set timewarp based on ecosystem

### DIFF
--- a/internal/api/agentapiservice/iteration.go
+++ b/internal/api/agentapiservice/iteration.go
@@ -111,12 +111,13 @@ func AgentCreateIteration(ctx context.Context, req schema.AgentCreateIterationRe
 	if deps.PrebuildConfig.Auth {
 		authRequired = append(authRequired, "gs://"+deps.PrebuildConfig.Bucket)
 	}
-	h, err := deps.GCBExecutor.Start(ctx, rebuild.Input{
+	input := rebuild.Input{
 		Target:   session.Target,
 		Strategy: strategy,
-	}, build.Options{
+	}
+	h, err := deps.GCBExecutor.Start(ctx, input, build.Options{
 		BuildID:     obliviousID,
-		UseTimewarp: true,
+		UseTimewarp: meta.AllRebuilders[input.Target.Ecosystem].UsesTimewarp(input),
 		Resources: build.Resources{
 			AssetStore:       store,
 			ToolURLs:         toolURLs,


### PR DESCRIPTION
During my testing, this forced timewarp for Maven builds.