### PR TITLE
Set project location flag for api job

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -85,6 +85,9 @@ func main() {
 		Project:  *project,
 		Location: *location,
 	})
+	if err != nil {
+		log.Fatal("Failed to create genai client: ", err)
+	}
 	deps := agent.RunSessionDeps{
 		Client:         aiClient,
 		IterationStub:  iterationStub,

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -824,6 +824,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
       image = data.google_artifact_registry_docker_image.api.self_link
       args = concat([
         "--project=${var.project}",
+        "--location=us-central1",
         "--build-local-url=${google_cloud_run_v2_service.build-local.uri}",
         "--build-remote-identity=${google_service_account.builder-remote.name}",
         "--inference-url=${google_cloud_run_v2_service.inference.uri}",


### PR DESCRIPTION
This was resulting in an uninitialized genai client in the agent.
Related, we weren't checking for errors when creating the client, which
I fixed.