### PR TITLE
 Infer JDK version from Gradle files

### DIFF
--- a/pkg/rebuild/maven/gradleinfer.go
+++ b/pkg/rebuild/maven/gradleinfer.go
@@ -27,20 +27,20 @@ func GradleInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux,
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] tag heuristic error")
 	}
-	sourceJarGuess, err := findClosestCommitToSource(ctx, t, mux, repoConfig.Repository)
-	if err != nil {
-		log.Printf("source jar heuristic failed: %s", err)
-	}
 	var ref string
-	switch {
-	case tagGuess != "":
+	if tagGuess != "" {
 		ref = tagGuess
 		log.Printf("using tag heuristic ref: %s", tagGuess[:9])
-	case sourceJarGuess != nil:
-		ref = sourceJarGuess.Hash.String()
-		log.Printf("using source jar heuristic ref: %s", ref[:9])
-	default:
-		return nil, errors.Errorf("no git ref")
+	} else {
+		sourceJarGuess, err := findClosestCommitToSource(ctx, t, mux, repoConfig.Repository)
+		if err != nil {
+			log.Printf("source jar heuristic failed: %s", err)
+		} else if sourceJarGuess != nil {
+			ref = sourceJarGuess.Hash.String()
+			log.Printf("using source jar heuristic ref: %s", ref[:9])
+		} else {
+			return nil, errors.Errorf("no git ref")
+		}
 	}
 	commitObject, err := repoConfig.Repository.CommitObject(plumbing.NewHash(ref))
 	if err != nil {

--- a/pkg/rebuild/maven/gradleinfer_test.go
+++ b/pkg/rebuild/maven/gradleinfer_test.go
@@ -97,7 +97,7 @@ func TestFindBuildGradleDir(t *testing.T) {
 			repo := must(gitxtest.CreateRepoFromYAML(tc.repo, nil))
 			head, _ := repo.Head()
 			headCommit, _ := repo.CommitObject(head.Hash())
-			actualDir, err := findBuildGradleDir(headCommit, tc.pkg)
+			actualDir, _, err := findBuildGradleDir(headCommit, tc.pkg)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("findBuildGradleDir() should fail but did not")


### PR DESCRIPTION
Fixes #880 

Based on #880, I came up with two heuristics from where we could infer Java version. Their examples are [here](https://github.com/google/oss-rebuild/issues/880#issuecomment-3363909524) and [here](https://github.com/google/oss-rebuild/issues/880#issuecomment-3363909024).

TODO
 - [x] prioritize inference from manifest