### PR TITLE
Skip javadoc generation in Gradle

### DIFF
--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -175,7 +175,7 @@ var toolkit = []*flow.Tool{
 		Name: "maven/gradlew-build",
 		Steps: []flow.Step{
 			{
-				Runs: "./gradlew assemble --no-daemon --console=plain -Pversion={{.Target.Version}}",
+				Runs: "./gradlew assemble --no-daemon --console=plain -Pversion={{.Target.Version}} -x javadoc",
 			},
 		},
 	},
@@ -183,7 +183,7 @@ var toolkit = []*flow.Tool{
 		Name: "maven/gradle-build",
 		Steps: []flow.Step{
 			{
-				Runs: "gradle assemble --no-daemon --console=plain -Pversion={{.Target.Version}}",
+				Runs: "gradle assemble --no-daemon --console=plain -Pversion={{.Target.Version}} -x javadoc",
 			},
 		},
 	},

--- a/pkg/rebuild/maven/strategy_test.go
+++ b/pkg/rebuild/maven/strategy_test.go
@@ -71,7 +71,7 @@ func TestStrategies(t *testing.T) {
 				Build: textwrap.Dedent(`
 					export JAVA_HOME=/opt/jdk
 					export PATH=$JAVA_HOME/bin:$PATH
-					./gradlew assemble --no-daemon --console=plain -Pversion=0.8.6`[1:]),
+					./gradlew assemble --no-daemon --console=plain -Pversion=0.8.6 -x javadoc`[1:]),
 				OutputPath: "dir/build/libs/ldapchai-0.8.6.jar",
 			},
 			false,
@@ -106,7 +106,7 @@ func TestStrategies(t *testing.T) {
 					export PATH=$JAVA_HOME/bin:$PATH
 					export GRADLE_HOME=/opt/gradle
 					export PATH=$GRADLE_HOME/bin:$PATH
-					gradle assemble --no-daemon --console=plain -Pversion=0.8.6`[1:]),
+					gradle assemble --no-daemon --console=plain -Pversion=0.8.6 -x javadoc`[1:]),
 				OutputPath: "dir/build/libs/ldapchai-0.8.6.jar",
 			},
 		},


### PR DESCRIPTION
4 cases where build failed because of javadoc generation.
```
org.springframework.security:spring-security-web,6.4.4,spring-security-web-6.4.4.jar
org.springframework.integration:spring-integration-core,6.2.1,spring-integration-core-6.2.1.jar
com.google.re2j:re2j,1.8,re2j-1.8.jar
org.mozilla:rhino,1.7.15,rhino-1.7.15.jar
```
Except for `re2j` and `spring-security-web` all the builds pass now.
```
* What went wrong:
A problem occurred configuring root project 're2j'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve org.apache.maven:maven-settings-builder:3.0.4.
     Required by:
         project : > com.github.hierynomus.license:com.github.hierynomus.license.gradle.plugin:0.15.0 > gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0 > com.mycila:license-maven-plugin:3.0
      > Could not resolve org.apache.maven:maven-settings-builder:3.0.4.
         > Could not get resource 'https://plugins.gradle.org/m2/org/apache/maven/maven-settings-builder/3.0.4/maven-settings-builder-3.0.4.pom'.
            > Could not GET 'https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0.4/maven-settings-builder-3.0.4.pom'.
               > Received fatal alert: handshake_failure
```
```
> Task :spring-security-docs:api FAILED

[Incubating] Problems report is available at: file:///src/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.12.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
107 actionable tasks: 107 executed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':spring-security-docs:api'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '/src/docs/build/tmp/api/javadoc.options'
```
> this also seems like javadoc but executed using a different task "api". Looking into why this wasn't skipped.