### PR TITLE
Use agent execution name returned by server

### DIFF
--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -363,8 +363,8 @@ type AgentContext struct {
 
 // AgentCreateResponse returns the session ID and job name
 type AgentCreateResponse struct {
-	SessionID string `json:"session_id"`
-	JobName   string `json:"job_name"`
+	SessionID     string `json:"session_id"`
+	ExeuctionName string `json:"execution_name"`
 }
 
 // AgentCreateIterationRequest records iteration and triggers build
@@ -423,7 +423,7 @@ type AgentSession struct {
 	TimeoutSeconds   int            `firestore:"timeout_seconds,omitempty"`
 	Context          *AgentContext  `firestore:"context,omitempty"`
 	Status           string         `firestore:"status,omitempty"`
-	JobName          string         `firestore:"job_name,omitempty"`
+	ExecutionName    string         `firestore:"execution_name,omitempty"`
 	Created          time.Time      `firestore:"created,omitempty"`
 	Updated          time.Time      `firestore:"updated,omitempty"`
 	StopReason       string         `firestore:"stop_reason,omitempty"`

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -1370,10 +1370,10 @@ var localAgent = &cobra.Command{
 			// Because we're going to start running the session locally immediately, we can mark it as Running from the start.
 			// This avoids needing to update the session record immediately after creation.
 			Status: schema.AgentSessionStatusRunning,
-			// There is no job name, because we're going to run the agent in-process.
-			JobName: "",
-			Created: sessionTime,
-			Updated: sessionTime,
+			// There is no execution name, because we're going to run the agent in-process.
+			ExecutionName: "",
+			Created:       sessionTime,
+			Updated:       sessionTime,
 		}
 		// Create session in Firestore
 		err = fire.RunTransaction(ctx, func(ctx context.Context, t *firestore.Transaction) error {

--- a/tools/medic/main.go
+++ b/tools/medic/main.go
@@ -463,7 +463,7 @@ func main() {
 			TimeoutSeconds: 60 * 60, // 1 hr timeout
 			Context:        nil,
 			Status:         schema.AgentSessionStatusRunning, // We don't have any initializing to do, we're going to immediately start running iterations.
-			JobName:        "local-medic",                    // Doesn't really matter, there's no cloud run job to map this to.
+			ExecutionName:  "local-medic",                    // Doesn't really matter, there's no cloud run job to map this to.
 			Created:        sessionTime,
 			Updated:        sessionTime,
 		}


### PR DESCRIPTION
We were confusing "JobName" and the Execution.Name concepts.

The "Job" resource defines the template of the workload, while the
"Execution" is the actual instance, representing a collection of one or
more "Tasks" that actually do the work. When we're looking for an
"instance" of the agent, we want the Execution's name.

As far as I can tell, we can't provide an execution name ahead of time,
so we need to unpack the execution object from the response object.

I eneded up having to parse the Metadata as JSON to do this, but if we
ever wanted to avoid this we could switch libraries:

google.golang.org/api/run/v2 -> cloud.google.com/go/run/apiv2

The cloud.google.com library is recommended and "newer".