### PR TITLE
Add verified maven strategy

### DIFF
--- a/definitions/maven/org.apache.pdfbox:pdfbox/3.0.3/pdfbox-3.0.3.jar/build.yaml
+++ b/definitions/maven/org.apache.pdfbox:pdfbox/3.0.3/pdfbox-3.0.3.jar/build.yaml
@@ -1,0 +1,6 @@
+maven_build:
+  location:
+    repo: https://github.com/apache/pdfbox
+    ref: 39888640082f44929825fc828cfacb18edb2badb
+    dir: pdfbox
+    jdk_version: "11"


### PR DESCRIPTION
We had successful AI inference (especially the repo URLs) with the following 23 tuples `pkg,version,artifact`. This PR will add one of them, `org.apache.pdfbox:pdfbox,3.0.3,pdfbox-3.0.3.jar`, to try and test out building from repo.

```
commons-cli:commons-cli,1.9.0,commons-cli-1.9.0.jar
io.ebean:ebean-migration,14.2.0,ebean-migration-14.2.0.jar
org.jboss.modules:jboss-modules,2.1.5.final,jboss-modules-2.1.5.Final.jar
com.github.nbbrd.java-design-util:java-design-processor,1.5.1,java-design-processor-1.5.1.jar
com.opencsv:opencsv,5.9,opencsv-5.9.jar
com.aliyun:tea-util,0.2.23,tea-util-0.2.23.jar
com.microsoft.azure.functions:azure-functions-java-library,3.1.0,azure-functions-java-library-3.1.0.jar
commons-beanutils:commons-beanutils,1.10.1,commons-beanutils-1.10.1.jar
org.wildfly.transaction:wildfly-transaction-client,3.0.5.final,wildfly-transaction-client-3.0.5.Final.jar
org.jboss.msc:jboss-msc,1.5.5.final,jboss-msc-1.5.5.Final.jar
org.apache.pdfbox:pdfbox,3.0.3,pdfbox-3.0.3.jar
commons-io:commons-io,2.16.1,commons-io-2.16.1.jar
org.opendaylight.yangtools:yang-common,14.0.5,yang-common-14.0.5.jar
org.apache.ignite:ignite-core,2.16.0,ignite-core-2.16.0.jar
org.apache.velocity:velocity-engine-core,2.4.1,velocity-engine-core-2.4.1.jar
org.apache.commons:commons-lang3,3.17.0,commons-lang3-3.17.0.jar
org.apache.wicket:wicket-core,10.1.0,wicket-core-10.1.0.jar
org.datanucleus:datanucleus-core,6.0.11,datanucleus-core-6.0.11.jar
com.aliyun.oss:aliyun-sdk-oss,3.18.1,aliyun-sdk-oss-3.18.1.jar
io.gravitee.reporter:gravitee-reporter-api,1.30.0,gravitee-reporter-api-1.30.0.jar
org.apache.hop:hop-core,2.12.0,hop-core-2.12.0.jar
org.jboss.xnio:xnio-api,3.8.16.final,xnio-api-3.8.16.Final.jar
org.apereo.inspektr:inspektr-audit,1.8.21.ga,inspektr-audit-1.8.21.GA.jar
```