### PR TITLE
Enable running benchmark locally

### DIFF
--- a/pkg/build/local/run_planner.go
+++ b/pkg/build/local/run_planner.go
@@ -104,7 +104,7 @@ func (p *DockerRunPlanner) generateScript(instructions rebuild.Instructions, inp
 	if err := dockerRunScriptTpl.Execute(&buf, dockerRunScriptArgs{
 		Inst:           instructions,
 		PackageManager: pkgMgr,
-		UseTimewarp:    timewarpURL != "",
+		UseTimewarp:    opts.UseTimewarp,
 		TimewarpURL:    timewarpURL,
 		TimewarpAuth:   timewarpAuth,
 	}); err != nil {

--- a/tools/benchmark/run/local.go
+++ b/tools/benchmark/run/local.go
@@ -132,7 +132,9 @@ func executeBuild(ctx context.Context, t rebuild.Target, strategy rebuild.Strate
 			ToolURLs: map[build.ToolType]string{
 				build.TimewarpTool: opts.PrebuildURL + "/timewarp",
 			},
+			BaseImageConfig: build.DefaultBaseImageConfig(),
 		},
+		UseTimewarp: meta.AllRebuilders[t.Ecosystem].UsesTimewarp(input),
 	}
 	handle, err := executor.Start(ctx, input, buildOpts)
 	if err != nil {

--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -617,7 +617,7 @@ func (f *LocalClient) WatchRebuilds() <-chan *Rebuild {
 }
 
 func (f *LocalClient) WriteRebuild(ctx context.Context, r Rebuild) error {
-	path := filepath.Join(layout.RundexRebuildsDir, r.Ecosystem, r.Package, r.Artifact, rebuildFileName)
+	path := filepath.Join(layout.RundexRebuildsDir, r.RunID, r.Ecosystem, r.Package, r.Artifact, rebuildFileName)
 	file, err := f.fs.Create(path)
 	if err != nil {
 		return errors.Wrap(err, "creating file")


### PR DESCRIPTION
The PR would enable running benchmark locally. This helps to not rely on Google Cloud infrastructure to run rebuilds. This also helps leveraging tui to view the local runs.

Todos:
- [x] support for putting inference logs in assets
- [x] it seems the local runs are hardcoded to `smoketest`; we would want it to be flexible.
~- [ ] nit: the docker run output is also redirected to stdout. This causes the progress bar to render multiple times thus creating disruption in the log.~ not that important for this issue.
  Example:
  ```
   0 / 1 [------------------------------------------------------------------------------------]   0.00%Get:1 http://deb.debian.org/debian trixie InRelease [140 kB]
	Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
	Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
	Get:4 http://deb.debian.org/debian trixie/main amd64 Packages [9669 kB]
	 0 / 1 [------------------------------------------------------------------------------------]   0.00%Get:5 http://deb.debian.org/debian trixie-updates/main amd64 Packages [5412 B]
	Get:6 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [52.2 kB]
	 0 / 1 [------------------------------------------------------------------------------------]   0.00%Fetched 9957 kB in 1s (9788 kB/s)
	 0 / 1 [------------------------------------------------------------------------------------]   0.00%
	 0 / 1 [------------------------------------------------------------------------------------]   0.00%
	Reading state information...
	 0 / 1 [------------------------------------------------------------------------------------]   0.00%
  ```
~- [ ] make output directory configurable~ reading and writing of logs both are tied to this so we should not do this in this PR.
- [x] retrieve results using `get-results`