### PR TITLE
Strip minor and patch version from JDK

### DIFF
--- a/pkg/rebuild/maven/infer_test.go
+++ b/pkg/rebuild/maven/infer_test.go
@@ -72,6 +72,16 @@ func TestJDKVersionInference(t *testing.T) {
 			wantVersion: "17.0.2",
 		},
 		{
+			name: "strip patch version",
+			input: []*archive.ZipEntry{
+				{
+					FileHeader: &zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					Body:       []byte("Manifest-Version: 1.0\r\nBuild-Jdk-Spec: 17.0.6\r\n\r\n"),
+				},
+			},
+			wantVersion: "17",
+		},
+		{
 			name: "fallback to classfile",
 			input: []*archive.ZipEntry{
 				{


### PR DESCRIPTION
This is to ensure that we don't fallback to JDK 11 even when we have inferred JDKs like `17.0.6`.