### PR TITLE
Add `Git-Branch`as property to be removed

### DIFF
--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -59,6 +59,7 @@ var StableJARBuildMetadata = ZipEntryStabilizer{
 			"Created-By",
 			"DSTAMP",
 			"Eclipse-SourceReferences",
+			"Git-Branch",
 			"Git-Commit-Id-Describe",
 			"Git-Remote-Origin-Url",
 			"Git-SHA",


### PR DESCRIPTION
Encountered a change in this property in `maven/net.kyori:adventure-api/4.17.0/adventure-api-4.17.0.jar`. 

```
├── META-INF/MANIFEST.MF
│ @@ -1,7 +1,8 @@
│  Manifest-Version: 1.0

│  Automatic-Module-Name: net.kyori.adventure

│  Specification-Title: net.kyori.adventure

│  Specification-Version: 4.17.0

│  Specification-Vendor: KyoriPowered

│  Git-Commit: bbdca1338be5d7d1660abdea7393c6c67c8cf610

│ +Git-Branch: main/4
```