### PR TITLE
Add Run documents to group Agent executions

### DIFF
--- a/internal/api/apiservice/agent.go
+++ b/internal/api/apiservice/agent.go
@@ -75,6 +75,7 @@ func AgentCreate(ctx context.Context, req schema.AgentCreateRequest, deps *Agent
 	}
 	session := schema.AgentSession{
 		ID:             sessionID,
+		RunID:          req.RunID,
 		Target:         req.Target,
 		MaxIterations:  maxIterations,
 		TimeoutSeconds: deps.AgentTimeoutSeconds,

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -320,6 +320,7 @@ type ExecutionMode string
 const (
 	SmoketestMode ExecutionMode = "smoketest" // No attestations, faster.
 	AttestMode    ExecutionMode = "attest"    // Creates attestations, slower.
+	AgentMode     ExecutionMode = "agent"     // Agent service for debugging.
 )
 
 // Agent-related constants and types for AI agent feature
@@ -343,6 +344,7 @@ const (
 // AgentCreateRequest creates a new agent session
 type AgentCreateRequest struct {
 	Target        rebuild.Target `form:",required"`
+	RunID         string         `form:""`
 	MaxIterations int            `form:""`
 	Context       *AgentContext  `form:""`
 }
@@ -418,6 +420,7 @@ type AgentCompleteResponse struct {
 // AgentSession stores agent session metadata in Firestore
 type AgentSession struct {
 	ID               string         `firestore:"id,omitempty"`
+	RunID            string         `firestore:"run_id,omitempty"`
 	Target           rebuild.Target `firestore:"target,omitempty"`
 	MaxIterations    int            `firestore:"max_iterations,omitempty"`
 	TimeoutSeconds   int            `firestore:"timeout_seconds,omitempty"`


### PR DESCRIPTION
This allows a large set of Agent executions to be queried as a group