### PR TITLE
Remove local rundex path stutter

### DIFF
--- a/tools/ctl/layout/layout.go
+++ b/tools/ctl/layout/layout.go
@@ -4,9 +4,11 @@
 package layout
 
 const (
-	AssetsDir          = "assets"                     // General AssetStore for logs, artifacts, diffs, etc.
-	BuildDefsDir       = "build-defs"                 // Storage of build definitions.
-	RundexDir          = "rundex"                     // The metadata about runs and rebuild attempts.
-	RundexRunsPath     = RundexDir + "/runs_metadata" // Metadata about runs.
-	RundexRebuildsPath = RundexDir + "/runs"          // Rebuild records.
+	AssetsDir          = "assets"     // General AssetStore for logs, artifacts, diffs, etc.
+	BuildDefsDir       = "build-defs" // Storage of build definitions.
+	RundexDir          = "rundex"     // The metadata about runs and rebuild attempts.
+	RundexRunsDir      = "runs_metadata"
+	RundexRunsPath     = RundexDir + "/" + RundexRunsDir // Metadata about runs.
+	RundexRebuildsDir  = "runs"
+	RundexRebuildsPath = RundexDir + "/" + RundexRebuildsDir // Rebuild records.
 )

--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -519,7 +519,7 @@ const (
 // FetchRuns fetches Runs out of firestore.
 func (f *LocalClient) FetchRuns(ctx context.Context, opts FetchRunsOpts) ([]Run, error) {
 	runs := make([]Run, 0)
-	err := util.Walk(f.fs, layout.RundexRunsPath, func(path string, info fs.FileInfo, err error) error {
+	err := util.Walk(f.fs, layout.RundexRunsDir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -561,10 +561,10 @@ func (f *LocalClient) FetchRebuilds(ctx context.Context, req *FetchRebuildReques
 		var toWalk []string
 		if len(req.Runs) != 0 {
 			for _, r := range req.Runs {
-				toWalk = append(toWalk, filepath.Join(layout.RundexRebuildsPath, r))
+				toWalk = append(toWalk, filepath.Join(layout.RundexRebuildsDir, r))
 			}
 		} else {
-			toWalk = []string{layout.RundexRebuildsPath}
+			toWalk = []string{layout.RundexRebuildsDir}
 		}
 		defer close(all)
 		for _, p := range toWalk {
@@ -617,7 +617,7 @@ func (f *LocalClient) WatchRebuilds() <-chan *Rebuild {
 }
 
 func (f *LocalClient) WriteRebuild(ctx context.Context, r Rebuild) error {
-	path := filepath.Join(layout.RundexRebuildsPath, r.Ecosystem, r.Package, r.Artifact, rebuildFileName)
+	path := filepath.Join(layout.RundexRebuildsDir, r.Ecosystem, r.Package, r.Artifact, rebuildFileName)
 	file, err := f.fs.Create(path)
 	if err != nil {
 		return errors.Wrap(err, "creating file")
@@ -635,7 +635,7 @@ func (f *LocalClient) WriteRebuild(ctx context.Context, r Rebuild) error {
 }
 
 func (f *LocalClient) WriteRun(ctx context.Context, r Run) error {
-	path := filepath.Join(layout.RundexRunsPath, fmt.Sprintf("%s.json", r.ID))
+	path := filepath.Join(layout.RundexRunsDir, fmt.Sprintf("%s.json", r.ID))
 	file, err := f.fs.Create(path)
 	if err != nil {
 		return errors.Wrap(err, "creating file")


### PR DESCRIPTION
The layout package is consumed primarily in two ways:

1) For GCS clients, which need full paths because they're working from the GCS bucket alone
2) For local billyfs Filesystems that are already chrooted into a subdir

Given that, I decided to expose both the name of the rundex subdirs for local fs-based clients, and the full path of the subdirs for GCS based clients.