### PR TITLE
Set tui debug storage to local asset store by default

### DIFF
--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -201,7 +201,11 @@ var tui = &cobra.Command{
 		} else {
 			assetStoreFn = localfiles.AssetStore
 		}
-		butler := localfiles.NewButler(*metadataBucket, *logsBucket, *debugStorage, mux, assetStoreFn)
+		debug := *debugStorage
+		if debug == "" {
+			debug = "file://" + localfiles.AssetsPath()
+		}
+		butler := localfiles.NewButler(*metadataBucket, *logsBucket, debug, mux, assetStoreFn)
 		var aiClient *genai.Client
 		{
 			aiProject := *project


### PR DESCRIPTION
This resolves a bug that was blocking asset diffs in local execution
modes.