### PR TITLE
Add the force flag for local test container cleanup

### DIFF
--- a/tools/ctl/ide/commands/commands.go
+++ b/tools/ctl/ide/commands/commands.go
@@ -56,7 +56,7 @@ const (
 )
 
 func removeContainer(ctx context.Context, name string) error {
-	return exec.CommandContext(ctx, "docker", "container", "rm", name).Run()
+	return exec.CommandContext(ctx, "docker", "container", "rm", "-f", name).Run()
 }
 
 func runLocal(ctx context.Context, executor build.Executor, prebuildConfig rebuild.PrebuildConfig, dex rundex.Reader, inp rebuild.Input) error {


### PR DESCRIPTION
This allows the TUI to cleanup running containers without having to stop
them first