### PR TITLE
Add KeepAlive flag to docker run executor

### DIFF
--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -55,6 +55,7 @@ func NewTuiApp(dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.Fetc
 			// starting the next run. This effectively keeps the "most recent"
 			// container available for interactive exploration
 			RetainContainer: true,
+			KeepAlive:       true,
 		})
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This keeps "run local" containers available for attaching and
exerimenting even after the build completes.