### PR TITLE
Add golang support

### DIFF
--- a/pkg/build/baseimage.go
+++ b/pkg/build/baseimage.go
@@ -23,6 +23,7 @@ func DefaultBaseImageConfig() BaseImageConfig {
 		Ecosystems: map[rebuild.Ecosystem]string{
 			rebuild.Debian: "docker.io/library/debian:stable-20251103-slim",
 			rebuild.Maven:  "docker.io/library/debian:trixie-20250203-slim",
+			rebuild.Go:     "docker.io/library/golang:1.25.4-alpine3.22",
 		},
 	}
 }

--- a/pkg/rebuild/go/infer.go
+++ b/pkg/rebuild/go/infer.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package golang
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/google/oss-rebuild/internal/gitx"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+)
+
+// InferRepo infers the repository URL for a given Go module.
+func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	// For Go, the package name often contains the repository URL.
+	// TODO: maybe use the canonical repo func
+	if strings.HasPrefix(t.Package, "github.com/") || strings.HasPrefix(t.Package, "golang.org/") {
+		parts := strings.Split(t.Package, "/")
+		if len(parts) >= 3 {
+			repoPath := strings.Join(parts[0:3], "/")
+			return fmt.Sprintf("https://%s", repoPath), nil
+		}
+	}
+	return "", errors.New("could not infer repository for go module")
+}
+
+// CloneRepo clones the repository for a given Go module.
+func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, ropt *gitx.RepositoryOptions) (r rebuild.RepoConfig, err error) {
+	r.URI = repoURI
+	r.Repository, err = rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.DefaultSubmoduleRecursionDepth})
+	switch err {
+	case nil:
+		return r, nil
+	default:
+		return r, errors.Wrapf(err, "clone failed [repo=%s]", r.URI)
+	}
+}
+
+// InferStrategy infers the build strategy for a given Go module.
+func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, rcfg *rebuild.RepoConfig, hint rebuild.Strategy) (rebuild.Strategy, error) {
+	return &GoBuild{
+		Location: rebuild.Location{
+			Repo: rcfg.URI,
+			Ref:  t.Version,
+		},
+	}, nil
+}

--- a/pkg/rebuild/go/rebuild.go
+++ b/pkg/rebuild/go/rebuild.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package golang
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// Rebuilder implements the rebuild.Rebuilder interface for Go.
+type Rebuilder struct{}
+
+// UsesTimewarp indicates that this rebuilder uses timewarp.
+func (r Rebuilder) UsesTimewarp(input rebuild.Input) bool {
+	return false
+}
+
+// UpstreamURL returns the upstream URL for a given Go module.
+func (r Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	// Assumes the package name is the module path.
+	// See https://go.dev/ref/mod#proxy-protocol
+	return fmt.Sprintf("https://proxy.golang.org/%s/@v/%s.zip", t.Package, t.Version), nil
+}
+
+var _ rebuild.Rebuilder = Rebuilder{}

--- a/pkg/rebuild/go/strategy.go
+++ b/pkg/rebuild/go/strategy.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package golang
+
+import (
+	"encoding/base64"
+
+	"github.com/google/oss-rebuild/internal/textwrap"
+	"github.com/google/oss-rebuild/pkg/rebuild/flow"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// GoBuild represents a build strategy for a Go module.
+type GoBuild struct {
+	rebuild.Location
+}
+
+var _ rebuild.Strategy = &GoBuild{}
+
+func (b *GoBuild) ToWorkflow() *rebuild.WorkflowStrategy {
+	return &rebuild.WorkflowStrategy{
+		Location: b.Location,
+		Source: []flow.Step{{
+			Uses: "git-checkout",
+		}},
+		Deps: []flow.Step{{
+			Uses: "go/buildziptool",
+			With: map[string]string{
+				"mod":    mod,
+				"script": script,
+			},
+		}},
+		Build: []flow.Step{{
+			Runs: `mkdir /out && cd /tools/ && go run ./main.go {{.Target.Package}} {{.Target.Version}} /src{{.Location.Dir}}`,
+		}},
+		OutputPath: "../out/module.zip",
+	}
+}
+
+func (b *GoBuild) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
+	return b.ToWorkflow().GenerateFor(t, be)
+}
+
+func init() {
+	for _, t := range toolkit {
+		flow.Tools.MustRegister(t)
+	}
+}
+
+var (
+	mod = base64.StdEncoding.EncodeToString([]byte(`
+module gomodzip
+
+go 1.25.4
+
+require golang.org/x/mod v0.30.0
+`))
+	script = base64.StdEncoding.EncodeToString([]byte(`
+package main
+
+import (
+	"os"
+	"log"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/zip"
+)
+
+func main() {
+	f, err := os.Create("/out/module.zip")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	m := module.Version{Path: os.Args[1], Version: os.Args[2]}
+	if err := zip.CreateFromDir(f, m, os.Args[3]); err != nil {
+		log.Fatal(err)
+	}
+}
+`))
+)
+
+var toolkit = []*flow.Tool{
+	{
+		Name: "go/buildziptool",
+		Steps: []flow.Step{{
+			Runs: textwrap.Dedent(`
+			mkdir /tools/
+			echo {{.With.mod}} | base64 -d > /tools/go.mod
+			echo {{.With.script}} | base64 -d > /tools/main.go
+			cd /tools/
+			go mod tidy
+			go build ./main.go`)[1:],
+		}},
+	},
+}

--- a/pkg/rebuild/meta/meta.go
+++ b/pkg/rebuild/meta/meta.go
@@ -7,12 +7,14 @@ import (
 	"github.com/google/oss-rebuild/internal/httpx"
 	cratesrb "github.com/google/oss-rebuild/pkg/rebuild/cratesio"
 	debianrb "github.com/google/oss-rebuild/pkg/rebuild/debian"
+	golangrb "github.com/google/oss-rebuild/pkg/rebuild/go"
 	mavenrb "github.com/google/oss-rebuild/pkg/rebuild/maven"
 	npmrb "github.com/google/oss-rebuild/pkg/rebuild/npm"
 	pypirb "github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	cratesreg "github.com/google/oss-rebuild/pkg/registry/cratesio"
 	debianreg "github.com/google/oss-rebuild/pkg/registry/debian"
+	golangreg "github.com/google/oss-rebuild/pkg/registry/golang"
 	mavenreg "github.com/google/oss-rebuild/pkg/registry/maven"
 	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
 	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
@@ -25,6 +27,7 @@ func NewRegistryMux(c httpx.BasicClient) rebuild.RegistryMux {
 		NPM:      npmreg.HTTPRegistry{Client: c},
 		PyPI:     pypireg.HTTPRegistry{Client: c},
 		Maven:    mavenreg.HTTPRegistry{Client: c},
+		Go:       golangreg.HTTPRegistry{Client: c},
 	}
 }
 
@@ -34,4 +37,5 @@ var AllRebuilders = map[rebuild.Ecosystem]rebuild.Rebuilder{
 	rebuild.CratesIO: &cratesrb.Rebuilder{},
 	rebuild.Debian:   &debianrb.Rebuilder{},
 	rebuild.Maven:    &mavenrb.Rebuilder{},
+	rebuild.Go:       &golangrb.Rebuilder{},
 }

--- a/pkg/rebuild/rebuild/models.go
+++ b/pkg/rebuild/rebuild/models.go
@@ -20,6 +20,7 @@ const (
 	CratesIO Ecosystem = "cratesio"
 	Maven    Ecosystem = "maven"
 	Debian   Ecosystem = "debian"
+	Go       Ecosystem = "go"
 )
 
 // Target is a single target we might attempt to rebuild.
@@ -37,6 +38,8 @@ func (t Target) ArchiveType() archive.Format {
 		return archive.RawFormat
 	case CratesIO, NPM:
 		return archive.TarGzFormat
+	case Go:
+		return archive.ZipFormat
 	case PyPI:
 		switch {
 		case strings.HasSuffix(t.Artifact, ".whl"), strings.HasSuffix(t.Artifact, ".zip"):

--- a/pkg/rebuild/rebuild/registry.go
+++ b/pkg/rebuild/rebuild/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/oss-rebuild/internal/httpx"
 	"github.com/google/oss-rebuild/pkg/registry/cratesio"
 	"github.com/google/oss-rebuild/pkg/registry/debian"
+	"github.com/google/oss-rebuild/pkg/registry/golang"
 	"github.com/google/oss-rebuild/pkg/registry/maven"
 	"github.com/google/oss-rebuild/pkg/registry/npm"
 	"github.com/google/oss-rebuild/pkg/registry/pypi"
@@ -25,6 +26,7 @@ type RegistryMux struct {
 	CratesIO cratesio.Registry
 	Maven    maven.Registry
 	Debian   debian.Registry
+	Go       golang.Registry
 }
 
 // RegistryMuxWithCache returns a new RegistryMux with the provided cache wrapping each registry.
@@ -55,6 +57,11 @@ func RegistryMuxWithCache(registry RegistryMux, c cacheinternal.Cache) (Registry
 	} else {
 		return newmux, errors.New("unknown debian registry type")
 	}
+	if httpreg, ok := registry.Go.(golang.HTTPRegistry); ok {
+		newmux.Go = golang.HTTPRegistry{Client: httpx.NewCachedClient(httpreg.Client, c)}
+	} else {
+		return newmux, errors.New("unknown go registry type")
+	}
 	return newmux, nil
 }
 
@@ -83,6 +90,8 @@ func warmCacheforArtifact(ctx context.Context, registry RegistryMux, t Target) {
 		}
 		registry.Debian.DSC(ctx, component, name, t.Version)
 		registry.Debian.Artifact(ctx, component, name, t.Artifact)
+	case Go:
+		registry.Go.Module(ctx, t.Package, t.Version)
 	}
 }
 
@@ -96,7 +105,7 @@ func warmCacheForPackage(ctx context.Context, registry RegistryMux, t Target) {
 		registry.CratesIO.Crate(ctx, t.Package)
 	case Maven:
 		registry.Maven.PackageMetadata(ctx, t.Package)
-	case Debian:
-		// There is no Debian resource shared across versions.
+	case Debian, Go:
+		// There is no Go or Debian resource shared across versions.
 	}
 }

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/oss-rebuild/pkg/archive"
 	"github.com/google/oss-rebuild/pkg/rebuild/cratesio"
 	"github.com/google/oss-rebuild/pkg/rebuild/debian"
+	golang "github.com/google/oss-rebuild/pkg/rebuild/go"
 	"github.com/google/oss-rebuild/pkg/rebuild/maven"
 	"github.com/google/oss-rebuild/pkg/rebuild/npm"
 	"github.com/google/oss-rebuild/pkg/rebuild/pypi"
@@ -29,6 +30,7 @@ type StrategyOneOf struct {
 	NPMPackBuild         *npm.NPMPackBuild              `json:"npm_pack_build,omitempty" yaml:"npm_pack_build,omitempty"`
 	NPMCustomBuild       *npm.NPMCustomBuild            `json:"npm_custom_build,omitempty" yaml:"npm_custom_build,omitempty"`
 	CratesIOCargoPackage *cratesio.CratesIOCargoPackage `json:"cratesio_cargo_package,omitempty" yaml:"cratesio_cargo_package,omitempty"`
+	GoBuild              *golang.GoBuild                `json:"go_build,omitempty" yaml:"go_build,omitempty"`
 	MavenBuild           *maven.MavenBuild              `json:"maven_build,omitempty" yaml:"maven_build,omitempty"`
 	GradleBuild          *maven.GradleBuild             `json:"gradle_build,omitempty" yaml:"gradle_build,omitempty"`
 	DebianPackage        *debian.DebianPackage          `json:"debian_package,omitempty" yaml:"debian_package,omitempty"`
@@ -55,6 +57,8 @@ func NewStrategyOneOf(s rebuild.Strategy) StrategyOneOf {
 		oneof.NPMCustomBuild = t
 	case *cratesio.CratesIOCargoPackage:
 		oneof.CratesIOCargoPackage = t
+	case *golang.GoBuild:
+		oneof.GoBuild = t
 	case *debian.DebianPackage:
 		oneof.DebianPackage = t
 	case *debian.Debrebuild:
@@ -91,6 +95,10 @@ func (oneof *StrategyOneOf) Strategy() (rebuild.Strategy, error) {
 		if oneof.CratesIOCargoPackage != nil {
 			num++
 			s = oneof.CratesIOCargoPackage
+		}
+		if oneof.GoBuild != nil {
+			num++
+			s = oneof.GoBuild
 		}
 		if oneof.DebianPackage != nil {
 			num++

--- a/pkg/registry/golang/golang.go
+++ b/pkg/registry/golang/golang.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package golang
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/google/oss-rebuild/internal/httpx"
+	"github.com/google/oss-rebuild/internal/urlx"
+)
+
+var proxyURL = urlx.MustParse("https://proxy.golang.org")
+
+// Registry is a Go module registry.
+type Registry interface {
+	// Module fetches the .zip archive for a module.
+	Module(ctx context.Context, pkg, version string) (io.ReadCloser, error)
+}
+
+// HTTPRegistry is a Registry implementation that uses the proxy.golang.org HTTP API.
+type HTTPRegistry struct {
+	Client httpx.BasicClient
+}
+
+// Module fetches the .zip archive for a module from proxy.golang.org.
+func (r HTTPRegistry) Module(ctx context.Context, pkg, version string) (io.ReadCloser, error) {
+	pathURL, err := url.Parse(path.Join(pkg, "@v", version+".zip"))
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", proxyURL.ResolveReference(pathURL).String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := r.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return resp.Body, nil
+}


### PR DESCRIPTION
This still has a handful of polishing task required before it works:

- [ ] Decide on the right string literal for ecosystem, and the right package name (go vs golang vs goproxy)
- [ ] Clean up the output path logic. I was using docker build locally, and that's hardcoding the /src directory as a prefix on the output path
- [ ] Find a cleaner way of calling [mod/zip](https://pkg.go.dev/golang.org/x/mod/zip#CreateFromDir) package. There's no CLI version I've found so I'm writing a tiny main.go file and running it
- [ ] Actually use the binary that was built during deps
- [ ] Make sure packages that have git repo redirects (like the golang.org/x/ packages) are supported correctly
- [ ] Use canonicallization on the git repos
- [ ] Make sure packages in subdir work
- [ ] Clean up the version parsing in the tags
- [ ] Verify that comparison and GCB work (I only tested using docker locally)