### PR TITLE
Fix docker build executor chmod for alpine

### DIFF
--- a/pkg/build/local/build_planner.go
+++ b/pkg/build/local/build_planner.go
@@ -67,7 +67,7 @@ var dockerBuildDockerfileTpl = template.Must(
 			RUN cat <<'EOF' >/build
 			 set -eux
 			 {{.Instructions.Build | indent}}
-			 chmod +444 /src/{{.Instructions.OutputPath}}
+			 chmod 444 /src/{{.Instructions.OutputPath}}
 			 mkdir -p /out && cp /src/{{.Instructions.OutputPath}} /out/
 			EOF
 			WORKDIR "/src"


### PR DESCRIPTION
On alpine chmod does not support "+" in permission specs. Debian seems to support both, so I think this is preferred.