### PR TITLE
Change sig keyID to gcpkms:// scheme

### DIFF
--- a/cmd/oss-rebuild/verify.go
+++ b/cmd/oss-rebuild/verify.go
@@ -20,8 +20,9 @@ import (
 )
 
 const kmsV1API = "https://cloudkms.googleapis.com/v1/"
+const gcpKMSScheme = "gcpkms://"
 const ossRebuildKeyResource = "projects/oss-rebuild/locations/global/keyRings/ring/cryptoKeys/signing-key/cryptoKeyVersions/1"
-const ossRebuildKeyURI = "https://cloudkms.googleapis.com/v1/" + ossRebuildKeyResource
+const ossRebuildKeyURI = gcpKMSScheme + ossRebuildKeyResource
 
 type key struct {
 	crypto.PublicKey
@@ -62,8 +63,11 @@ func parsePKIX(pubkey string) (crypto.PublicKey, error) {
 }
 
 func makeKMSVerifier(ctx context.Context, cryptoKeyVersion string) (dsse.Verifier, error) {
+	// Handle both old HTTPS format and new gcpkms:// format
 	if strings.HasPrefix(cryptoKeyVersion, kmsV1API) {
 		cryptoKeyVersion = strings.TrimPrefix(cryptoKeyVersion, kmsV1API)
+	} else if strings.HasPrefix(cryptoKeyVersion, gcpKMSScheme) {
+		cryptoKeyVersion = strings.TrimPrefix(cryptoKeyVersion, gcpKMSScheme)
 	}
 	kc, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {

--- a/pkg/kmsdsse/kmsdsse.go
+++ b/pkg/kmsdsse/kmsdsse.go
@@ -100,7 +100,7 @@ func (s *CloudKMSSignerVerifier) Verify(ctx context.Context, data, sig []byte) e
 }
 
 func (s CloudKMSSignerVerifier) KeyID() (string, error) {
-	return "https://cloudkms.googleapis.com/v1/" + s.keyName, nil
+	return "gcpkms://" + s.keyName, nil
 }
 
 var _ dsse.SignerVerifier = (*CloudKMSSignerVerifier)(nil)


### PR DESCRIPTION
This updates the signature KeyID format to use the `gcpkms://` scheme, replacing the previous `https://cloudkms.googleapis.com/v1/` prefix. This change aligns our identifier format with conventions defined by `go-cloud` and subsequently used by Tekton. It offers a more terse URI structure without loss of precision. Adopting this scheme also corrects our alignment with [`aip.dev` guidance](https://google.aip.dev/122#resource-uris) which specifies the form we're using ("Resource URI") is not the precise description we'd hoped for ("Full Resource Name"). While we could use this latter form, the `go-cloud` format has the dual benefits of brevity and a more cloud-agnostic approach.