### PR TITLE
Add attestation update API

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -229,6 +229,9 @@ resource "google_storage_bucket" "attestations" {
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
   depends_on                  = [google_project_service.storage]
+  versioning {
+    enabled = true
+  }
 }
 resource "google_storage_bucket" "metadata" {
   name                        = "${var.host}-rebuild-metadata"

--- a/internal/verifier/attestation.go
+++ b/internal/verifier/attestation.go
@@ -20,7 +20,7 @@ import (
 )
 
 // CreateAttestations creates the SLSA attestations associated with a rebuild.
-func CreateAttestations(ctx context.Context, t rebuild.Target, defn *schema.BuildDefinition, strategy rebuild.Strategy, id string, rb, up ArtifactSummary, metadata rebuild.AssetStore, serviceLoc, prebuildLoc, buildDefLoc rebuild.Location, prebuildConfig rebuild.PrebuildConfig) (equivalence, build *in_toto.ProvenanceStatementSLSA1, err error) {
+func CreateAttestations(ctx context.Context, t rebuild.Target, defn *schema.BuildDefinition, strategy rebuild.Strategy, id string, rb, up ArtifactSummary, metadata rebuild.AssetStore, serviceLoc, prebuildLoc, buildDefLoc rebuild.Location, prebuildConfig rebuild.PrebuildConfig, mode schema.OverwriteMode) (equivalence, build *in_toto.ProvenanceStatementSLSA1, err error) {
 	var dockerfile []byte
 	{
 		r, err := metadata.Reader(ctx, rebuild.DockerfileAsset.For(t))
@@ -122,10 +122,11 @@ func CreateAttestations(ctx context.Context, t rebuild.Target, defn *schema.Buil
 		return nil, nil, errors.Wrap(err, "marshalling Strategy")
 	}
 	externalParams := attestation.RebuildParams{
-		Ecosystem: string(t.Ecosystem),
-		Package:   t.Package,
-		Version:   t.Version,
-		Artifact:  t.Artifact,
+		Ecosystem:     string(t.Ecosystem),
+		Package:       t.Package,
+		Version:       t.Version,
+		Artifact:      t.Artifact,
+		OverwriteMode: mode,
 	}
 	// Only add manual strategy field if it was used.
 	if defn != nil {

--- a/internal/verifier/attestation_test.go
+++ b/internal/verifier/attestation_test.go
@@ -70,7 +70,7 @@ func TestCreateAttestations(t *testing.T) {
 		serviceLoc := rebuild.Location{Repo: "https://github.com/google/oss-rebuild", Ref: "v0.0.0-202501010000-feeddeadbeef00"}
 		prebuildLoc := rebuild.Location{Repo: "https://github.com/google/oss-rebuild", Ref: "v0.0.0-202401010000-feeddeadbeef99"}
 		buildDefLoc := rebuild.Location{Repo: "https://github.com/google/oss-rebuild", Ref: "b33eec7134eff8a16cb902b80e434de58bf37e2c", Dir: "definitions/cratesio/bytes/1.0.0/bytes-1.0.0.crate/build.yaml"}
-		eqStmt, buildStmt, err := CreateAttestations(ctx, target, &defn, strategy, "test-id", rbSummary, upSummary, metadata, serviceLoc, prebuildLoc, buildDefLoc, rebuild.PrebuildConfig{Bucket: "test-bucket", Dir: "test-dir", Auth: true})
+		eqStmt, buildStmt, err := CreateAttestations(ctx, target, &defn, strategy, "test-id", rbSummary, upSummary, metadata, serviceLoc, prebuildLoc, buildDefLoc, rebuild.PrebuildConfig{Bucket: "test-bucket", Dir: "test-dir", Auth: true}, schema.OverwriteMode(""))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/pkg/attestation/types.go
+++ b/pkg/attestation/types.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
 )
@@ -71,6 +72,8 @@ type RebuildParams struct {
 	Package string `json:"package"`
 	// Version is the specific version of the package to rebuild
 	Version string `json:"version"`
+	// OverwriteMode specifies the justification for overwriting an existing attestation
+	OverwriteMode schema.OverwriteMode `json:"overwrite_mode,omitempty"`
 }
 
 // RebuildDeps represents the resolved dependencies for a rebuild operation.

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package changelog
+
+import (
+	_ "embed"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed changelog.yaml
+var changelogYAML []byte
+
+// Builtin is the list of service updates impacting attesttaions as parsed from the embedded YAML.
+var Builtin []ChangelogEntry
+
+func init() {
+	if err := yaml.Unmarshal(changelogYAML, &Builtin); err != nil {
+		panic(err)
+	}
+}
+
+// ChangelogEntry represents a single impactful change in the service history.
+type ChangelogEntry struct {
+	Version string `yaml:"version"`
+	Reason  string `yaml:"reason"`
+}
+
+// EntryOnInterval returns true if there is a documented change strictly after oldVersion and up to/including newVersion.
+// It relies on lexicographical comparison of Golang pseudo-versions.
+func EntryOnInterval(oldVersion, newVersion string) bool {
+	for _, entry := range Builtin {
+		// Check if oldVersion < entry.Version <= newVersion
+		if entry.Version > oldVersion && entry.Version <= newVersion {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/changelog/changelog.yaml
+++ b/pkg/changelog/changelog.yaml
@@ -1,0 +1,13 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+- version: "v0.0.0-20250205222847-abb51bc97097"
+  reason: "Record service version in provenance (#306) - Added serviceSource to internal parameters"
+- version: "v0.0.0-20250612124827-f51ca15d7b4f"
+  reason: "Add new PrebuildConfig field to attestation (#551) - Added prebuildConfig to internal parameters"
+- version: "v0.0.0-20250919194454-0452e2656e86"
+  reason: "Correct media type in DSSE payload when signing (#807) - Changed payload media type from application/json to application/vnd.in-toto+json"
+- version: "v0.0.0-20251126223253-f0ce92a1d91d"
+  reason: "Change sig keyID to gcpkms:// scheme (#978) - Changed signature KeyID prefix from https://cloudkms.googleapis.com/v1/ to gcpkms://"
+- version: "v0.0.0-20251126223818-cb1d6e0911a5"
+  reason: "Bump base image version to alpine:3.21 (#980) - Updated default base image from alpine:3.19 to alpine:3.21"


### PR DESCRIPTION
This adds versioning to the attestation GCS bucket, an initial list of
changes to consider meaningful for updating existing attestations, and
adding an explicit option to trigger overwriting on the rebuild API.