### PR TITLE
Add logic to annotate sysgraph with netlog

### DIFF
--- a/pkg/sysgraph/sgtransform/annotate.go
+++ b/pkg/sysgraph/sgtransform/annotate.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Network annotation enriches a sysgraph with HTTP metadata from a netlog.
+//
+// A sysgraph captures kernel-level observations (processes, files, network
+// connections via tetragon) while a netlog captures application-level HTTP
+// requests from the proxy. These are independent artifacts and not all builds
+// produce both. When both are available, AnnotateNetwork performs a post-hoc
+// join to associate HTTP metadata with the kernel-observed connections.
+//
+// The join key is the source port: each tcp_connect kprobe records a network
+// address resource ("saddr:sport->daddr:dport"), and each netlog entry
+// records the peer's source port. AnnotateNetwork matches these to produce a
+// non-mutating SysGraph decorator whose Action method merges HTTP metadata
+// on read, leaving the underlying graph untouched.
+//
+// Because a single action (process) may make many network connections, each
+// annotation is keyed by the network resource's digest hash to avoid
+// collisions:
+//
+//	<digest_hash>.http.method = "GET"
+//	<digest_hash>.http.scheme = "https"
+//	<digest_hash>.http.host   = "registry.npmjs.org"
+//	<digest_hash>.http.path   = "/npm"
+
+package sgtransform
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/google/oss-rebuild/pkg/proxy/netlog"
+	"github.com/google/oss-rebuild/pkg/sysgraph/pbdigest"
+	sgpb "github.com/google/oss-rebuild/pkg/sysgraph/proto/sysgraph"
+	"google.golang.org/protobuf/proto"
+)
+
+// NetworkAnnotatedSysGraph is a sysgraph view that enriches network actions
+// with HTTP metadata from netlog entries.
+type NetworkAnnotatedSysGraph struct {
+	SysGraph
+	// actionMetadata maps action ID → extra metadata key/value pairs to merge.
+	actionMetadata map[int64]map[string]string
+}
+
+var _ SysGraph = (*NetworkAnnotatedSysGraph)(nil)
+
+// AnnotateNetwork creates a view over sg that enriches actions with HTTP
+// metadata from netlog entries, joined via source port matching.
+func AnnotateNetwork(ctx context.Context, sg SysGraph, entries []netlog.HTTPRequestLog) (*NetworkAnnotatedSysGraph, error) {
+	// Build map: PeerPort → *HTTPRequestLog.
+	portMap := make(map[string]*netlog.HTTPRequestLog, len(entries))
+	for i := range entries {
+		if entries[i].PeerPort != "" {
+			portMap[entries[i].PeerPort] = &entries[i]
+		}
+		// TODO: Detect port reuse and use time-based heuristic
+	}
+	// Scan all actions to build the metadata overlay.
+	actionMetadata := make(map[int64]map[string]string)
+	aids, err := sg.ActionIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, aid := range aids {
+		action, err := sg.Action(ctx, aid)
+		if err != nil {
+			return nil, err
+		}
+		for digestStr := range action.GetOutputs() {
+			dg, err := pbdigest.NewFromString(digestStr)
+			if err != nil {
+				continue
+			}
+			r, err := sg.Resource(ctx, dg)
+			if err != nil {
+				continue
+			}
+			if r.GetType() != sgpb.ResourceType_RESOURCE_TYPE_NETWORK_ADDRESS {
+				continue
+			}
+			addr := r.GetNetworkAddrInfo().GetAddress()
+			sport, err := extractSourcePort(addr)
+			if err != nil {
+				continue
+			}
+			entry, ok := portMap[sport]
+			if !ok {
+				continue
+			}
+			if actionMetadata[aid] == nil {
+				actionMetadata[aid] = make(map[string]string)
+			}
+			prefix := dg.Hash + "."
+			actionMetadata[aid][prefix+"http.method"] = entry.Method
+			actionMetadata[aid][prefix+"http.scheme"] = entry.Scheme
+			actionMetadata[aid][prefix+"http.host"] = entry.Host
+			actionMetadata[aid][prefix+"http.path"] = entry.Path
+		}
+	}
+	return &NetworkAnnotatedSysGraph{
+		SysGraph:       sg,
+		actionMetadata: actionMetadata,
+	}, nil
+}
+
+// Action returns the action with the given id, enriched with HTTP metadata
+// if a netlog match was found.
+func (n *NetworkAnnotatedSysGraph) Action(ctx context.Context, id int64) (*sgpb.Action, error) {
+	a, err := n.SysGraph.Action(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	extra, ok := n.actionMetadata[id]
+	if !ok {
+		return a, nil
+	}
+	a = proto.Clone(a).(*sgpb.Action)
+	md := a.GetMetadata()
+	if md == nil {
+		md = make(map[string]string)
+	}
+	maps.Copy(md, extra)
+	a.SetMetadata(md)
+	return a, nil
+}
+
+// extractSourcePort parses the source port from a tcp_connect address string
+// of the format "saddr:sport->daddr:dport".
+func extractSourcePort(address string) (string, error) {
+	// Split on "->" to get "saddr:sport" and "daddr:dport".
+	parts := strings.SplitN(address, "->", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid address format: %s", address)
+	}
+	src := parts[0]
+	// Extract port from "saddr:sport".
+	idx := strings.LastIndex(src, ":")
+	if idx < 0 {
+		return "", fmt.Errorf("no port in source address: %s", src)
+	}
+	return src[idx+1:], nil
+}

--- a/pkg/sysgraph/sgtransform/annotate_test.go
+++ b/pkg/sysgraph/sgtransform/annotate_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package sgtransform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/proxy/netlog"
+	"github.com/google/oss-rebuild/pkg/sysgraph/inmemory"
+	"github.com/google/oss-rebuild/pkg/sysgraph/pbdigest"
+	sgpb "github.com/google/oss-rebuild/pkg/sysgraph/proto/sysgraph"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestAnnotateNetwork(t *testing.T) {
+	// Create a network address resource.
+	netResource := sgpb.Resource_builder{
+		Type: sgpb.ResourceType_RESOURCE_TYPE_NETWORK_ADDRESS.Enum(),
+		NetworkAddrInfo: sgpb.NetworkAddrInfo_builder{
+			Protocol: proto.String("tcp"),
+			Address:  proto.String("10.0.0.1:12345->93.184.216.34:443"),
+		}.Build(),
+	}.Build()
+	netDg, err := pbdigest.NewFromMessage(netResource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create a file resource (should be ignored).
+	fileResource := sgpb.Resource_builder{
+		Type: sgpb.ResourceType_RESOURCE_TYPE_FILE.Enum(),
+		FileInfo: sgpb.FileInfo_builder{
+			Path: proto.String("/tmp/test"),
+		}.Build(),
+	}.Build()
+	fileDg, err := pbdigest.NewFromMessage(fileResource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sg := &inmemory.SysGraph{
+		GraphPb: sgpb.SysGraph_builder{
+			EntryPointActionIds: []int64{1},
+		}.Build(),
+		Actions: map[int64]*sgpb.Action{
+			1: sgpb.Action_builder{
+				Id: proto.Int64(1),
+				Outputs: map[string]*sgpb.ResourceInteractions{
+					netDg.String():  sgpb.ResourceInteractions_builder{}.Build(),
+					fileDg.String(): sgpb.ResourceInteractions_builder{}.Build(),
+				},
+			}.Build(),
+			2: sgpb.Action_builder{
+				Id: proto.Int64(2),
+				Outputs: map[string]*sgpb.ResourceInteractions{
+					fileDg.String(): sgpb.ResourceInteractions_builder{}.Build(),
+				},
+			}.Build(),
+		},
+		ResourceMap: map[pbdigest.Digest]*sgpb.Resource{
+			netDg:  netResource,
+			fileDg: fileResource,
+		},
+	}
+	entries := []netlog.HTTPRequestLog{
+		{
+			Method:   "GET",
+			Scheme:   "https",
+			Host:     "example.com",
+			Path:     "/api/v1/data",
+			PeerPort: "12345",
+			Time:     time.Now(),
+		},
+		{
+			Method:   "POST",
+			Scheme:   "https",
+			Host:     "other.com",
+			Path:     "/upload",
+			PeerPort: "99999",
+			Time:     time.Now(),
+		},
+	}
+	ctx := t.Context()
+	annotated, err := AnnotateNetwork(ctx, sg, entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify action 1 got annotated via the view.
+	a1, err := annotated.Action(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := netDg.Hash + "."
+	want := map[string]string{
+		prefix + "http.method": "GET",
+		prefix + "http.scheme": "https",
+		prefix + "http.host":   "example.com",
+		prefix + "http.path":   "/api/v1/data",
+	}
+	if diff := cmp.Diff(want, a1.GetMetadata()); diff != "" {
+		t.Errorf("action 1 metadata mismatch (-want +got):\n%s", diff)
+	}
+	// Verify action 2 was not annotated.
+	a2, err := annotated.Action(ctx, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md2 := a2.GetMetadata(); md2 != nil && len(md2) > 0 {
+		t.Errorf("expected no metadata on action 2, got %v", md2)
+	}
+	// Verify the original sysgraph is unmodified.
+	origA1, err := sg.Action(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md := origA1.GetMetadata(); md != nil && len(md) > 0 {
+		t.Errorf("expected original action 1 to have no metadata, got %v", md)
+	}
+}
+
+func TestAnnotateNetwork_NoMatch(t *testing.T) {
+	netResource := sgpb.Resource_builder{
+		Type: sgpb.ResourceType_RESOURCE_TYPE_NETWORK_ADDRESS.Enum(),
+		NetworkAddrInfo: sgpb.NetworkAddrInfo_builder{
+			Protocol: proto.String("tcp"),
+			Address:  proto.String("10.0.0.1:55555->93.184.216.34:443"),
+		}.Build(),
+	}.Build()
+	netDg, err := pbdigest.NewFromMessage(netResource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sg := &inmemory.SysGraph{
+		GraphPb: sgpb.SysGraph_builder{}.Build(),
+		Actions: map[int64]*sgpb.Action{
+			1: sgpb.Action_builder{
+				Id: proto.Int64(1),
+				Outputs: map[string]*sgpb.ResourceInteractions{
+					netDg.String(): sgpb.ResourceInteractions_builder{}.Build(),
+				},
+			}.Build(),
+		},
+		ResourceMap: map[pbdigest.Digest]*sgpb.Resource{
+			netDg: netResource,
+		},
+	}
+	entries := []netlog.HTTPRequestLog{
+		{
+			Method:   "GET",
+			Scheme:   "https",
+			Host:     "example.com",
+			Path:     "/",
+			PeerPort: "11111",
+			Time:     time.Now(),
+		},
+	}
+	ctx := t.Context()
+	annotated, err := AnnotateNetwork(ctx, sg, entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No match -> metadata should remain nil.
+	a, err := annotated.Action(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md := a.GetMetadata(); md != nil && len(md) > 0 {
+		t.Errorf("expected no metadata, got %v", md)
+	}
+}
+
+func TestExtractSourcePort(t *testing.T) {
+	tests := []struct {
+		address string
+		want    string
+		wantErr bool
+	}{
+		{"10.0.0.1:12345->93.184.216.34:443", "12345", false},
+		{"::1:8080->::1:443", "8080", false},
+		{"invalid", "", true},
+		{"no-arrow:123", "", true},
+	}
+	for _, tt := range tests {
+		got, err := extractSourcePort(tt.address)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("extractSourcePort(%q) error = %v, wantErr %v", tt.address, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("extractSourcePort(%q) = %q, want %q", tt.address, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
We annotate each Action with its netlog data scoped by the digest of the
associated Resource (i.e. the container for the NetworkAddrInfo).

> Children: [#1120](https://redirect.github.com/google/oss-rebuild/pull/1120)