### PR TITLE
Implement custom file patching in the docker proxy

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -37,6 +37,7 @@ var (
 	dockerJavaTruststoreEnvVar = flag.Bool("docker_java_truststore", false, "whether to patch containers with Java proxy cert truststore file and env var")
 	dockerBazelTruststore      = flag.Bool("docker_bazel_truststore", false, "whether to patch containers with global .bazelrc file pointing to the Java proxy cert truststore")
 	dockerProxySocket          = flag.Bool("docker_recursive_proxy", false, "whether to patch containers with a unix domain socket which proxies docker requests from created containers")
+	dockerCustomFiles          = flag.String("docker_custom_files", "", "JSON string mapping path to CustomFile. Content must be Base64 encoded because it is unmarshaled into a Go []byte.")
 	policyMode                 = flag.String("policy_mode", "disabled", "mode to run the proxy in. Options: disabled, enforce")
 	policyFile                 = flag.String("policy_file", "", "path to a json file specifying the policy to apply to the proxy")
 )
@@ -85,11 +86,18 @@ func main() {
 		if *dockerTruststoreEnvVars != "" {
 			truststoreEnvVars = strings.Split(*dockerTruststoreEnvVars, ",")
 		}
+		var customFiles map[string]docker.CustomFile
+		if *dockerCustomFiles != "" {
+			if err := json.Unmarshal([]byte(*dockerCustomFiles), &customFiles); err != nil {
+				log.Fatalf("Error parsing docker_custom_files: %v", err)
+			}
+		}
 		ctp, err := docker.NewContainerTruststorePatcher(*ca.Leaf, docker.ContainerTruststorePatcherOpts{
 			EnvVars:              envVars,
 			TruststoreEnvVars:    truststoreEnvVars,
 			JavaTruststoreEnvVar: *dockerJavaTruststoreEnvVar,
 			BazelTruststore:      *dockerBazelTruststore,
+			CustomFiles:          customFiles,
 			RecursiveProxy:       *dockerProxySocket,
 			NetworkOverride:      *dockerNetwork,
 		})

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -551,12 +551,7 @@ func TestDockerInDocker(t *testing.T) {
 	inspectContainer := "inspect-saved-" + name
 
 	// Dump proxy logs on failure for debugging.
-	t.Cleanup(func() {
-		if t.Failed() {
-			logs, _, _ := runDockerCommand(t, "exec", env.ProxyContainer, "sh", "-c", "tail -100 /proxy.log")
-			t.Logf("Proxy logs:\n%s", logs)
-		}
-	})
+	registerLogDump(t, env)
 
 	// Clean up stale volumes and register future resource cleanups.
 	cleanupProxyVolumes(t)
@@ -713,4 +708,73 @@ func TestNetworkPolicyDynamic(t *testing.T) {
 
 	// Same request to example.com should now fail.
 	env.runInBuildExpectFail(t, "wget -qO- http://example.com")
+}
+
+func TestDockerCustomFiles(t *testing.T) {
+	checkDockerAvailable(t)
+	bin := buildProxyBinary(t)
+
+	tests := []struct {
+		name            string
+		customFilesJSON string
+		fileName        string
+		imageName       string
+		expectedContent string
+	}{
+		{
+			name:            "OverwriteExisting",
+			customFilesJSON: `{"/etc/overwrite.conf":{"Content":"bmV3","Mode":0}}`,
+			fileName:        "/etc/overwrite.conf",
+			imageName:       "base-overwrite",
+			expectedContent: "new",
+		},
+		{
+			name:            "AppendToExisting",
+			customFilesJSON: `{"/etc/append.conf":{"Content":"bmV3","Mode":1}}`,
+			fileName:        "/etc/append.conf",
+			imageName:       "base-append",
+			expectedContent: "originalnew",
+		},
+		{
+			name:            "ErrorOnExisting",
+			customFilesJSON: `{"/etc/error.conf":{"Content":"bmV3","Mode":2}}`,
+			fileName:        "/etc/error.conf",
+			imageName:       "base-error",
+			expectedContent: "original",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupProxyTestEnv(t, bin, proxyTestEnvOpts{
+				WithDockerProxy: true,
+				ExtraProxyFlags: []string{
+					"--docker_custom_files='" + tc.customFilesJSON + "'",
+				},
+			})
+			registerLogDump(t, env)
+			env.runInBuild(t, "apk add --no-cache docker-cli")
+			dh := fmt.Sprintf("DOCKER_HOST=tcp://%s:3130", env.ProxyIP)
+
+			// Build base image with file.
+			env.runInBuild(t, "mkdir -p /tmp/build && "+
+				fmt.Sprintf(`printf 'FROM alpine:3.21\nRUN echo -n "original" > %s\n' > /tmp/build/Dockerfile`, tc.fileName))
+			env.runInBuild(t, dh+" docker build -t "+tc.imageName+" /tmp/build")
+
+			// Run container and verify.
+			stdout, _ := env.runInBuild(t, dh+" docker run --rm "+tc.imageName+" cat "+tc.fileName)
+			if stdout != tc.expectedContent {
+				t.Fatalf("Expected %q, got: %q", tc.expectedContent, stdout)
+			}
+		})
+	}
+}
+
+func registerLogDump(t *testing.T, env *proxyTestEnv) {
+	t.Cleanup(func() {
+		if t.Failed() {
+			logs, _, _ := runDockerCommand(t, "exec", env.ProxyContainer, "sh", "-c", "tail -100 /proxy.log")
+			t.Logf("Proxy logs:\n%s", logs)
+		}
+	})
 }

--- a/pkg/proxy/docker/docker.go
+++ b/pkg/proxy/docker/docker.go
@@ -407,6 +407,19 @@ type patchSet struct {
 	Patches []patch
 }
 
+type FileWriteMode int
+
+const (
+	OverwriteExisting FileWriteMode = iota
+	AppendToExisting
+	ErrorOnExisting
+)
+
+type CustomFile struct {
+	Content []byte
+	Mode    FileWriteMode
+}
+
 // ContainerTruststorePatcher provides a Docker API proxy that patches the container truststore while running.
 type ContainerTruststorePatcher struct {
 	cert                 x509.Certificate
@@ -414,7 +427,7 @@ type ContainerTruststorePatcher struct {
 	truststoreEnvVars    []string
 	javaTruststoreEnvVar bool
 	bazelTruststore      bool
-	customFiles          map[string][]byte
+	customFiles          map[string]CustomFile
 	networkOverride      string // TODO: Not a good fit for this abstraction
 	proxySocket          string
 	patchMap             map[string]*patchSet
@@ -428,7 +441,7 @@ type ContainerTruststorePatcherOpts struct {
 	TruststoreEnvVars    []string
 	JavaTruststoreEnvVar bool
 	BazelTruststore      bool
-	CustomFiles          map[string][]byte
+	CustomFiles          map[string]CustomFile
 	RecursiveProxy       bool
 	NetworkOverride      string
 }
@@ -667,11 +680,11 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 			}
 		}
 		customFilesFailed := false
-		for path, content := range d.customFiles {
+		for path, file := range d.customFiles {
 			f, err := dfs.OpenAndResolve(path)
 			if err != nil {
 				if err == iofs.ErrNotExist {
-					if err := createFile(dfs, content, path); err != nil {
+					if err := createFile(dfs, file.Content, path); err != nil {
 						log.Printf("Creating custom file %s: %v", path, err)
 						customFilesFailed = true
 						break
@@ -682,8 +695,20 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 					break
 				}
 			} else {
-				f.Contents = append(f.Contents[:], content...)
-				err = dfs.WriteFile(f)
+				switch file.Mode {
+				case OverwriteExisting:
+					f.Contents = file.Content
+					err = dfs.WriteFile(f)
+				case AppendToExisting:
+					f.Contents = append(f.Contents[:], file.Content...)
+					err = dfs.WriteFile(f)
+				case ErrorOnExisting:
+					log.Printf("Custom file %s already exists", path)
+					customFilesFailed = true
+				}
+				if customFilesFailed {
+					break
+				}
 				if err != nil {
 					log.Printf("Writing to custom file %s: %v", path, err)
 					customFilesFailed = true

--- a/pkg/proxy/docker/docker.go
+++ b/pkg/proxy/docker/docker.go
@@ -55,8 +55,8 @@ const (
 	// NOTE: /var/cache is chosen since it exists by default on almost every
 	// distro and since it, by its semantics, can be emptied without having a
 	// functional impact on running applications.
-	proxyCertPath    = "/var/cache/proxy.crt"
-	proxyCertJKSPath = "/var/cache/proxy.crt.jks"
+	ProxyCertPath    = "/var/cache/proxy.crt"
+	ProxyCertJKSPath = "/var/cache/proxy.crt.jks"
 	// Official interface for providing additional args to JVMs.
 	javaTruststoreEnvVar = "JAVA_TOOL_OPTIONS"
 	// Bazel configuration file that is interpreted first.
@@ -414,6 +414,7 @@ type ContainerTruststorePatcher struct {
 	truststoreEnvVars    []string
 	javaTruststoreEnvVar bool
 	bazelTruststore      bool
+	customFiles          map[string][]byte
 	networkOverride      string // TODO: Not a good fit for this abstraction
 	proxySocket          string
 	patchMap             map[string]*patchSet
@@ -427,6 +428,7 @@ type ContainerTruststorePatcherOpts struct {
 	TruststoreEnvVars    []string
 	JavaTruststoreEnvVar bool
 	BazelTruststore      bool
+	CustomFiles          map[string][]byte
 	RecursiveProxy       bool
 	NetworkOverride      string
 }
@@ -451,6 +453,7 @@ func NewContainerTruststorePatcher(cert x509.Certificate, opts ContainerTruststo
 		truststoreEnvVars:    opts.TruststoreEnvVars,
 		javaTruststoreEnvVar: opts.JavaTruststoreEnvVar,
 		bazelTruststore:      opts.BazelTruststore,
+		customFiles:          opts.CustomFiles,
 		networkOverride:      opts.NetworkOverride,
 		proxySocket:          sockName,
 		patchMap:             make(map[string]*patchSet),
@@ -558,7 +561,7 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 		// and commit operations on the container won't pick up any new files or
 		// directories written to the dir during its execution.
 		volName := fmt.Sprintf("proxy-vol%d", d.created.Add(1))
-		newBody, err = addBinding(newBody, volName, filepath.Dir(proxyCertPath), "rw")
+		newBody, err = addBinding(newBody, volName, filepath.Dir(ProxyCertPath), "rw")
 		if err != nil {
 			log.Fatalf("Failed to add volume for request %s: %s", req.URL.Path, err)
 		}
@@ -567,7 +570,7 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 			vars = append(vars, v)
 		}
 		for _, v := range d.truststoreEnvVars {
-			vars = append(vars, v+"="+proxyCertPath)
+			vars = append(vars, v+"="+ProxyCertPath)
 		}
 		if d.javaTruststoreEnvVar {
 			// NOTE: Since other user-provided values can be set in JAVA_TOOL_OPTIONS,
@@ -580,7 +583,7 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 			if val != "" {
 				newVal = trimQuotes(val) + " "
 			}
-			newVal += "-Djavax.net.ssl.trustStore=" + proxyCertJKSPath
+			newVal += "-Djavax.net.ssl.trustStore=" + ProxyCertJKSPath
 			vars = append(vars, javaTruststoreEnvVar+"="+newVal)
 			log.Printf("Updated %s [old=%s, new=%s]", javaTruststoreEnvVar, val, newVal)
 		}
@@ -625,7 +628,7 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 		certBytes := cert.ToPEM(&d.cert)
 		// NOTE: This doesn't need to be cleaned up due to the enclosing volume
 		// binding made at creation time.
-		if err := createFile(dfs, certBytes, proxyCertPath); err != nil {
+		if err := createFile(dfs, certBytes, ProxyCertPath); err != nil {
 			log.Printf("Creating proxy cert: %v", err)
 			break
 		}
@@ -635,13 +638,13 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 				log.Printf("Generating java proxy cert: %v", err)
 				break
 			}
-			if err := createFile(dfs, jks, proxyCertJKSPath); err != nil {
+			if err := createFile(dfs, jks, ProxyCertJKSPath); err != nil {
 				log.Printf("Creating java proxy cert: %v", err)
 				break
 			}
 		}
 		if d.bazelTruststore {
-			bazelRCContents := fmt.Sprintf("startup --host_jvm_args=-Djavax.net.ssl.trustStore=%s", proxyCertJKSPath)
+			bazelRCContents := fmt.Sprintf("startup --host_jvm_args=-Djavax.net.ssl.trustStore=%s", ProxyCertJKSPath)
 			bazelRCBytes := []byte(bazelRCContents)
 			f, err := dfs.OpenAndResolve(bazelSystemRCPath)
 			if err != nil {
@@ -662,6 +665,34 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 					break
 				}
 			}
+		}
+		customFilesFailed := false
+		for path, content := range d.customFiles {
+			f, err := dfs.OpenAndResolve(path)
+			if err != nil {
+				if err == iofs.ErrNotExist {
+					if err := createFile(dfs, content, path); err != nil {
+						log.Printf("Creating custom file %s: %v", path, err)
+						customFilesFailed = true
+						break
+					}
+				} else {
+					log.Printf("Reading custom file %s: %v", path, err)
+					customFilesFailed = true
+					break
+				}
+			} else {
+				f.Contents = append(f.Contents[:], content...)
+				err = dfs.WriteFile(f)
+				if err != nil {
+					log.Printf("Writing to custom file %s: %v", path, err)
+					customFilesFailed = true
+					break
+				}
+			}
+		}
+		if customFilesFailed {
+			break
 		}
 		patchset := d.leasePatchSet(id)
 		if len(patchset.Patches) > 0 {

--- a/pkg/proxy/docker/docker.go
+++ b/pkg/proxy/docker/docker.go
@@ -679,6 +679,7 @@ func (d *ContainerTruststorePatcher) proxyRequest(clientConn, serverConn net.Con
 				}
 			}
 		}
+		// TODO: Consider supporting templating in file content to allow dynamic insertion of cert paths.
 		customFilesFailed := false
 		for path, file := range d.customFiles {
 			f, err := dfs.OpenAndResolve(path)

--- a/pkg/proxy/docker/docker_test.go
+++ b/pkg/proxy/docker/docker_test.go
@@ -836,6 +836,88 @@ func TestPatchOnStartWithNewBazelRC(t *testing.T) {
 		t.Fatalf("Unexpected return code: want=%d got=%d", http.StatusOK, resp.StatusCode)
 	}
 }
+func TestPatchOnStartWithCustomFiles(t *testing.T) {
+	ctp, _ := NewContainerTruststorePatcher(CERT, ContainerTruststorePatcherOpts{
+		CustomFiles: map[string][]byte{
+			"/etc/custom.conf": []byte("my content"),
+		},
+	})
+	sock := tempSocketName(t)
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	osHeader, osTar := statAndOpen(t, "os-release", "NAME=\"Alpine Linux\"\nID=alpine\nVERSION_ID=3.16.0\n", "")
+	certHeader, certTar := statAndOpen(t, "cert.pem", "", "")
+	wants := []httpCall{
+		// Ping daemon.
+		{"/_ping", http.Response{StatusCode: http.StatusOK, Body: http.NoBody}},
+		// Create container.
+		{"/containers/create?name=abc", http.Response{StatusCode: http.StatusOK, Body: http.NoBody}},
+		// Start container.
+		{"/containers/abc/json", http.Response{StatusCode: http.StatusOK, Body: asBody([]byte(`{"Id": "def"}`))}},
+		{"/containers/def/archive?path=/var/cache/proxy.crt", http.Response{StatusCode: http.StatusNotFound}},
+		{"/containers/def/archive?path=/var/cache", http.Response{StatusCode: http.StatusOK}},
+		{"/containers/def/archive?path=/etc/custom.conf", http.Response{StatusCode: http.StatusNotFound}},
+		{"/containers/def/archive?path=/etc/custom.conf", http.Response{StatusCode: http.StatusNotFound}},
+		{"/containers/def/archive?path=/etc", http.Response{StatusCode: http.StatusOK}},
+		{"/containers/def/archive?path=/kaniko", http.Response{StatusCode: http.StatusNotFound}},
+		{"/containers/def/archive?path=/etc/os-release", http.Response{StatusCode: http.StatusOK, Header: osHeader}},
+		{"/containers/def/archive?path=/etc/os-release", http.Response{StatusCode: http.StatusOK, Body: osTar}},
+		{"/containers/def/archive?path=/etc/ssl/cert.pem", http.Response{StatusCode: http.StatusOK, Header: certHeader}},
+		{"/containers/def/archive?path=/etc/ssl/cert.pem", http.Response{StatusCode: http.StatusOK, Body: certTar}},
+		{"/containers/def/archive?path=/etc/ssl", http.Response{StatusCode: http.StatusOK, Body: http.NoBody}},
+		{"/containers/abc/start", http.Response{StatusCode: http.StatusOK, Body: http.NoBody}},
+	}
+	outcome := make(chan error, 1)
+	go fakeHTTPCalls(l, wants, outcome)
+	// Ping daemon.
+	clientIn := setupProxy(t, sock, ctp)
+	req, err := http.NewRequest(http.MethodHead, "/_ping", http.NoBody)
+	orFail(t, err)
+	orFail(t, req.Write(clientIn))
+	orFail(t, <-outcome) // HEAD /_ping
+	resp, err := http.ReadResponse(bufio.NewReader(clientIn), req)
+	orFail(t, err)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Unexpected return code: want=%d got=%d", http.StatusOK, resp.StatusCode)
+	}
+	// Create container.
+	clientIn = setupProxy(t, sock, ctp)
+	req, err = http.NewRequest(http.MethodPost, "/containers/create?name=abc", asBody([]byte(`{"HostConfig": {}}`)))
+	orFail(t, err)
+	orFail(t, req.Write(clientIn))
+	orFail(t, <-outcome) // POST /containers/create?name=abc
+	resp, err = http.ReadResponse(bufio.NewReader(clientIn), req)
+	orFail(t, err)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Unexpected return code: want=%d got=%d", http.StatusOK, resp.StatusCode)
+	}
+	// Start container.
+	clientIn = setupProxy(t, sock, ctp)
+	req, err = http.NewRequest(http.MethodPost, "/containers/abc/start", http.NoBody)
+	orFail(t, err)
+	orFail(t, req.Write(clientIn))
+	orFail(t, <-outcome) // GET /containers/abc/json
+	orFail(t, <-outcome) // HEAD /containers/def/archive?path=/var/cache/proxy.crt
+	orFail(t, <-outcome) // PUT /containers/def/archive?path=/var/cache
+	orFail(t, <-outcome) // HEAD /containers/def/archive?path=/etc/custom.conf
+	orFail(t, <-outcome) // HEAD /containers/def/archive?path=/etc/custom.conf
+	orFail(t, <-outcome) // PUT /containers/def/archive?path=/etc
+	orFail(t, <-outcome) // HEAD /containers/def/archive?path=/kaniko
+	orFail(t, <-outcome) // HEAD /containers/def/archive?path=/etc/os-release
+	orFail(t, <-outcome) // GET /containers/def/archive?path=/etc/os-release
+	orFail(t, <-outcome) // HEAD /containers/def/archive?path=/etc/ssl/cert.pem
+	orFail(t, <-outcome) // GET /containers/def/archive?path=/etc/ssl/cert.pem
+	orFail(t, <-outcome) // PUT /containers/def/archive?path=/etc/ssl
+	orFail(t, <-outcome) // POST /containers/abc/start
+	resp, err = http.ReadResponse(bufio.NewReader(clientIn), req)
+	orFail(t, err)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Unexpected return code: want=%d got=%d", http.StatusOK, resp.StatusCode)
+	}
+}
+
 func TestAddBinding(t *testing.T) {
 	for _, tc := range [](struct {
 		Body []byte

--- a/pkg/proxy/docker/docker_test.go
+++ b/pkg/proxy/docker/docker_test.go
@@ -838,8 +838,11 @@ func TestPatchOnStartWithNewBazelRC(t *testing.T) {
 }
 func TestPatchOnStartWithCustomFiles(t *testing.T) {
 	ctp, _ := NewContainerTruststorePatcher(CERT, ContainerTruststorePatcherOpts{
-		CustomFiles: map[string][]byte{
-			"/etc/custom.conf": []byte("my content"),
+		CustomFiles: map[string]CustomFile{
+			"/etc/custom.conf": {
+				Content: []byte("my content"),
+				Mode:    OverwriteExisting,
+			},
 		},
 	})
 	sock := tempSocketName(t)


### PR DESCRIPTION
Many tools and ecosystems (such as Bazel, apt, etc.) require special config files to be written to the filesystem to use custom CA certificates. This change adds a generic way to write arbitrary files to a Docker container so downstream consumers of this package can adapt to new ecosystems by passing in the filepaths and contents.