### PR TITLE
Update rundex to have more specific request types

### DIFF
--- a/internal/rundex/filesystem.go
+++ b/internal/rundex/filesystem.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/util"
+	"github.com/google/oss-rebuild/pkg/feed"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/tools/benchmark"
 	"github.com/google/oss-rebuild/tools/ctl/layout"
 	"github.com/pkg/errors"
 )
@@ -177,4 +179,53 @@ func (f *FilesystemClient) WriteRun(ctx context.Context, r Run) error {
 		}()
 	}
 	return nil
+}
+
+func (f *FilesystemClient) RecentRebuilds(ctx context.Context) ([]Rebuild, error) {
+	return f.FetchRebuilds(ctx, &FetchRebuildRequest{Limit: 100})
+}
+
+// RecentEcosystemRebuilds fetches the 100 most recent rebuild results for a specific ecosystem.
+func (f *FilesystemClient) RecentEcosystemRebuilds(ctx context.Context, eco rebuild.Ecosystem) ([]Rebuild, error) {
+	return f.FetchRebuilds(ctx, &FetchRebuildRequest{Target: &rebuild.Target{Ecosystem: eco}, Limit: 100})
+}
+
+// RecentPackageRebuilds fetches the 100 most recent rebuild results for a specific package.
+func (f *FilesystemClient) RecentPackageRebuilds(ctx context.Context, eco rebuild.Ecosystem, pkg string) ([]Rebuild, error) {
+	return f.FetchRebuilds(ctx, &FetchRebuildRequest{Target: &rebuild.Target{Ecosystem: eco, Package: pkg}, Limit: 100})
+}
+
+// FetchAttempt fetches a specific Rebuild object from local path.
+func (f *FilesystemClient) FetchAttempt(ctx context.Context, target rebuild.Target, runID string) (Rebuild, error) {
+	et := rebuild.FilesystemTargetEncoding.Encode(target)
+	path := filepath.Join(layout.RundexRebuildsDir, runID, string(et.Ecosystem), et.Package, et.Version, et.Artifact, rebuildFileName)
+	file, err := f.fs.Open(path)
+	if err != nil {
+		return Rebuild{}, errors.Wrap(err, "opening rebuild file")
+	}
+	defer file.Close()
+	var r Rebuild
+	if err := json.NewDecoder(file).Decode(&r); err != nil {
+		return Rebuild{}, errors.Wrap(err, "decoding rebuild file")
+	}
+	return r, nil
+}
+
+// LatestTrackedPackages fetches the most recent rebuild result for each tracked package.
+func (f *FilesystemClient) LatestTrackedPackages(ctx context.Context, tracked feed.TrackedPackageIndex) ([]Rebuild, error) {
+	var packages []benchmark.Package
+	for eco, pkgs := range tracked {
+		for pkg := range pkgs {
+			packages = append(packages, benchmark.Package{Ecosystem: string(eco), Name: pkg})
+		}
+	}
+	return f.FetchRebuilds(ctx, &FetchRebuildRequest{
+		Bench: &benchmark.PackageSet{
+			Packages: packages,
+			Metadata: benchmark.Metadata{
+				Count: len(packages),
+			},
+		},
+		LatestPerPackage: true,
+	})
 }

--- a/internal/rundex/firestore.go
+++ b/internal/rundex/firestore.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"path"
 	"slices"
+	"strings"
 	"sync"
 
 	"cloud.google.com/go/firestore"
 	"github.com/google/oss-rebuild/internal/iterx"
 	"github.com/google/oss-rebuild/internal/pipe"
+	"github.com/google/oss-rebuild/pkg/feed"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/pkg/errors"
@@ -91,6 +93,14 @@ func (f *FirestoreClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRe
 			if len(req.Runs) != 0 {
 				q = q.Where("run_id", "in", req.Runs)
 			}
+			// Avoid composite index requirement for 'in' queries + OrderBy.
+			// Results are sorted in memory by filterRebuilds anyway.
+			if len(req.Executors) == 0 && len(req.Runs) == 0 {
+				q = q.OrderBy("created", firestore.Desc)
+			}
+			if req.Limit > 0 {
+				q = q.Limit(req.Limit)
+			}
 			iter := q.Documents(pctx)
 			for doc, err := range iterx.ToSeq2(iter, iterator.Done) {
 				if err != nil {
@@ -119,24 +129,50 @@ func (f *FirestoreClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRe
 		return filterRebuilds(allChan, req), nil
 	}
 
+	isCollectionGroup := true
 	q := f.client.CollectionGroup("attempts").Query
 	if req.Target != nil {
 		t := *req.Target
-		if t.Artifact == "" {
-			if a, err := f.findArtifactName(ctx, t); err != nil {
-				return nil, errors.Wrap(err, "inferring missing artifact")
-			} else {
-				t.Artifact = a
+		if t.Ecosystem != "" && t.Package != "" && t.Version != "" {
+			if t.Artifact == "" {
+				if a, err := f.findArtifactName(ctx, t); err == nil {
+					t.Artifact = a
+				}
+			}
+			if t.Artifact != "" {
+				et := rebuild.FirestoreTargetEncoding.Encode(t)
+				q = f.client.Collection(path.Join("ecosystem", string(et.Ecosystem), "packages", et.Package, "versions", et.Version, "artifacts", et.Artifact, "attempts")).Query
+				isCollectionGroup = false
 			}
 		}
-		et := rebuild.FirestoreTargetEncoding.Encode(t)
-		q = f.client.Collection(path.Join("ecosystem", string(et.Ecosystem), "packages", et.Package, "versions", et.Version, "artifacts", et.Artifact, "attempts")).Query
+		if isCollectionGroup {
+			if t.Ecosystem != "" {
+				q = q.Where("ecosystem", "==", string(t.Ecosystem))
+			}
+			if t.Package != "" {
+				q = q.Where("package", "==", t.Package)
+			}
+			if t.Version != "" {
+				q = q.Where("version", "==", t.Version)
+			}
+			if t.Artifact != "" {
+				q = q.Where("artifact", "==", t.Artifact)
+			}
+		}
 	}
 	if len(req.Executors) != 0 {
 		q = q.Where("executor_version", "in", req.Executors)
 	}
 	if len(req.Runs) != 0 {
 		q = q.Where("run_id", "in", req.Runs)
+	}
+	// Avoid composite index requirement for 'in' queries + OrderBy.
+	// Results are sorted in memory by filterRebuilds anyway.
+	if len(req.Executors) == 0 && len(req.Runs) == 0 {
+		q = q.OrderBy("created", firestore.Desc)
+	}
+	if req.Limit > 0 {
+		q = q.Limit(req.Limit)
 	}
 	all := make(chan Rebuild)
 	cerr := doQuery(ctx, q, newRebuildFromFirestore, all)
@@ -147,20 +183,133 @@ func (f *FirestoreClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRe
 	return rebuilds, nil
 }
 
+// RecentRebuilds fetches the 100 most recent rebuild results.
+func (f *FirestoreClient) RecentRebuilds(ctx context.Context) ([]Rebuild, error) {
+	q := f.client.CollectionGroup("attempts").Query.OrderBy("created", firestore.Desc).Limit(100)
+	return f.fetchRebuildsQuery(ctx, q)
+}
+
+// RecentEcosystemRebuilds fetches the 100 most recent rebuild results for a specific ecosystem.
+func (f *FirestoreClient) RecentEcosystemRebuilds(ctx context.Context, eco rebuild.Ecosystem) ([]Rebuild, error) {
+	q := f.client.CollectionGroup("attempts").Query.
+		Where("ecosystem", "==", string(eco)).
+		OrderBy("created", firestore.Desc).
+		Limit(100)
+	return f.fetchRebuildsQuery(ctx, q)
+}
+
+// RecentPackageRebuilds fetches the 100 most recent rebuild results for a specific package.
+func (f *FirestoreClient) RecentPackageRebuilds(ctx context.Context, eco rebuild.Ecosystem, pkg string) ([]Rebuild, error) {
+	q := f.client.CollectionGroup("attempts").Query.
+		Where("ecosystem", "==", string(eco)).
+		Where("package", "==", pkg).
+		OrderBy("created", firestore.Desc).
+		Limit(100)
+	return f.fetchRebuildsQuery(ctx, q)
+}
+
+func (f *FirestoreClient) fetchRebuildsQuery(ctx context.Context, q firestore.Query) ([]Rebuild, error) {
+	all := make(chan Rebuild)
+	cerr := doQuery(ctx, q, newRebuildFromFirestore, all)
+	var rebuilds []Rebuild
+	for r := range all {
+		r.Message = strings.ReplaceAll(r.Message, "\n", "\\n")
+		rebuilds = append(rebuilds, r)
+	}
+	if err := <-cerr; err != nil {
+		return nil, errors.Wrap(err, "query error")
+	}
+	return rebuilds, nil
+}
+
+// FetchAttempt fetches a specific Rebuild object out of firestore.
+func (f *FirestoreClient) FetchAttempt(ctx context.Context, target rebuild.Target, runID string) (Rebuild, error) {
+	et := rebuild.FirestoreTargetEncoding.Encode(target)
+	doc, err := f.client.Collection(path.Join("ecosystem", string(et.Ecosystem), "packages", et.Package, "versions", et.Version, "artifacts", et.Artifact, "attempts")).Doc(runID).Get(ctx)
+	if err != nil {
+		return Rebuild{}, err
+	}
+	return newRebuildFromFirestore(doc), nil
+}
+
+// LatestTrackedPackages fetches the most recent rebuild result for each tracked package.
+func (f *FirestoreClient) LatestTrackedPackages(ctx context.Context, tracked feed.TrackedPackageIndex) ([]Rebuild, error) {
+	type queryBatch struct {
+		ecosystem string
+		packages  []string
+	}
+	var batches []queryBatch
+	const batchSize = 30 // Firestore 'in' queries are limited to 30 values.
+	for eco, pkgs := range tracked {
+		var pkgList []string
+		for pkg := range pkgs {
+			pkgList = append(pkgList, pkg)
+		}
+		for i := 0; i < len(pkgList); i += batchSize {
+			end := i + batchSize
+			if end > len(pkgList) {
+				end = len(pkgList)
+			}
+			batches = append(batches, queryBatch{ecosystem: string(eco), packages: pkgList[i:end]})
+		}
+	}
+
+	p := pipe.FromSlice(batches)
+
+	var queryErr error
+	var once sync.Once
+	pctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	const queryConcurrency = 10
+	rebuildsPipe := pipe.ParInto(queryConcurrency, p, func(batch queryBatch, out chan<- Rebuild) {
+		if pctx.Err() != nil {
+			return
+		}
+		q := f.client.CollectionGroup("attempts").Query.Where("ecosystem", "==", batch.ecosystem).Where("package", "in", batch.packages)
+		q = q.OrderBy("created", firestore.Desc)
+		iter := q.Documents(pctx)
+		// Track latest per package in this batch.
+		latest := make(map[string]Rebuild)
+		for doc, err := range iterx.ToSeq2(iter, iterator.Done) {
+			if err != nil {
+				once.Do(func() {
+					queryErr = errors.Wrap(err, "query error")
+					cancel()
+				})
+				break
+			}
+			r := newRebuildFromFirestore(doc)
+			if _, seen := latest[r.Package]; !seen {
+				latest[r.Package] = r
+				out <- r
+			}
+		}
+	})
+	var res []Rebuild
+	for r := range rebuildsPipe.Out() {
+		res = append(res, r)
+	}
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	return res, nil
+}
+
 // FetchRuns fetches Runs out of firestore.
 func (f *FirestoreClient) FetchRuns(ctx context.Context, opts FetchRunsOpts) ([]Run, error) {
 	q := f.client.CollectionGroup("runs").Query
 	if opts.BenchmarkHash != "" {
 		q = q.Where("benchmark_hash", "==", opts.BenchmarkHash)
 	}
-	if opts.BenchmarkName != "" {
-		q = q.Where("benchmark_name", "==", opts.BenchmarkName)
-	}
 	runs := make(chan Run)
 	cerr := doQuery(ctx, q, newRunFromFirestore, runs)
 	var runSlice []Run
 	for r := range runs {
 		if len(opts.IDs) != 0 && !slices.Contains(opts.IDs, r.ID) {
+			continue
+		}
+		if opts.BenchmarkName != "" && r.BenchmarkName != opts.BenchmarkName {
 			continue
 		}
 		runSlice = append(runSlice, r)

--- a/internal/rundex/gcs.go
+++ b/internal/rundex/gcs.go
@@ -14,7 +14,9 @@ import (
 	gcs "cloud.google.com/go/storage"
 	"github.com/google/oss-rebuild/internal/iterx"
 	"github.com/google/oss-rebuild/internal/pipe"
+	"github.com/google/oss-rebuild/pkg/feed"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/tools/benchmark"
 	"github.com/google/oss-rebuild/tools/ctl/layout"
 	"github.com/pkg/errors"
 	"google.golang.org/api/iterator"
@@ -129,6 +131,57 @@ func (g *GCSClient) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest)
 		return nil, err
 	}
 	return rebuilds, nil
+}
+
+// RecentRebuilds fetches the 100 most recent rebuild results.
+func (g *GCSClient) RecentRebuilds(ctx context.Context) ([]Rebuild, error) {
+	return g.FetchRebuilds(ctx, &FetchRebuildRequest{Limit: 100})
+}
+
+// RecentEcosystemRebuilds fetches the 100 most recent rebuild results for a specific ecosystem.
+func (g *GCSClient) RecentEcosystemRebuilds(ctx context.Context, eco rebuild.Ecosystem) ([]Rebuild, error) {
+	return g.FetchRebuilds(ctx, &FetchRebuildRequest{Target: &rebuild.Target{Ecosystem: eco}, Limit: 100})
+}
+
+// RecentPackageRebuilds fetches the 100 most recent rebuild results for a specific package.
+func (g *GCSClient) RecentPackageRebuilds(ctx context.Context, eco rebuild.Ecosystem, pkg string) ([]Rebuild, error) {
+	return g.FetchRebuilds(ctx, &FetchRebuildRequest{Target: &rebuild.Target{Ecosystem: eco, Package: pkg}, Limit: 100})
+}
+
+// FetchAttempt fetches a specific Rebuild object from GCS.
+func (g *GCSClient) FetchAttempt(ctx context.Context, target rebuild.Target, runID string) (Rebuild, error) {
+	et := rebuild.FilesystemTargetEncoding.Encode(target)
+	p := path.Join(g.prefix, layout.RundexRebuildsPath, runID, string(et.Ecosystem), et.Package, et.Version, et.Artifact, rebuildFileName)
+	obj := g.client.Bucket(g.bucket).Object(p)
+	r, err := obj.NewReader(ctx)
+	if err != nil {
+		return Rebuild{}, errors.Wrap(err, "creating reader for rebuild file")
+	}
+	defer r.Close()
+	var rebuild Rebuild
+	if err := json.NewDecoder(r).Decode(&rebuild); err != nil {
+		return Rebuild{}, errors.Wrap(err, "decoding rebuild file")
+	}
+	return rebuild, nil
+}
+
+// LatestTrackedPackages fetches the most recent rebuild result for each tracked package.
+func (g *GCSClient) LatestTrackedPackages(ctx context.Context, tracked feed.TrackedPackageIndex) ([]Rebuild, error) {
+	var packages []benchmark.Package
+	for eco, pkgs := range tracked {
+		for pkg := range pkgs {
+			packages = append(packages, benchmark.Package{Ecosystem: string(eco), Name: pkg})
+		}
+	}
+	return g.FetchRebuilds(ctx, &FetchRebuildRequest{
+		Bench: &benchmark.PackageSet{
+			Packages: packages,
+			Metadata: benchmark.Metadata{
+				Count: len(packages),
+			},
+		},
+		LatestPerPackage: true,
+	})
 }
 
 func (g *GCSClient) WriteRebuild(ctx context.Context, r Rebuild) error {

--- a/internal/rundex/rundex.go
+++ b/internal/rundex/rundex.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/pipe"
+	"github.com/google/oss-rebuild/pkg/feed"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/google/oss-rebuild/tools/benchmark"
@@ -81,6 +82,7 @@ type FetchRebuildRequest struct {
 	Runs             []string
 	Opts             FetchRebuildOpts
 	LatestPerPackage bool
+	Limit            int
 }
 
 // FetchRunsOpts describes which Runs you would like to fetch from firestore.
@@ -106,6 +108,11 @@ type FetchIterationsReq struct {
 type Reader interface {
 	FetchRuns(context.Context, FetchRunsOpts) ([]Run, error)
 	FetchRebuilds(context.Context, *FetchRebuildRequest) ([]Rebuild, error)
+	FetchAttempt(ctx context.Context, target rebuild.Target, runID string) (Rebuild, error)
+	RecentRebuilds(context.Context) ([]Rebuild, error)
+	RecentEcosystemRebuilds(context.Context, rebuild.Ecosystem) ([]Rebuild, error)
+	RecentPackageRebuilds(context.Context, rebuild.Ecosystem, string) ([]Rebuild, error)
+	LatestTrackedPackages(context.Context, feed.TrackedPackageIndex) ([]Rebuild, error)
 }
 
 // TOOD: Move SessionReader into Reader when more impls exist.
@@ -215,13 +222,23 @@ func cleanVerdict(m string) string {
 
 func filterRebuilds(all <-chan Rebuild, req *FetchRebuildRequest) []Rebuild {
 	p := pipe.From(all)
+	if req.Target != nil {
+		p = p.Do(func(in Rebuild, out chan<- Rebuild) {
+			if (req.Target.Ecosystem == "" || rebuild.Ecosystem(in.Ecosystem) == req.Target.Ecosystem) &&
+				(req.Target.Package == "" || in.Package == req.Target.Package) &&
+				(req.Target.Version == "" || in.Version == req.Target.Version) &&
+				(req.Target.Artifact == "" || in.Artifact == req.Target.Artifact) {
+				out <- in
+			}
+		})
+	}
 	if req.Bench != nil {
 		benchMap := make(map[string]benchmark.Package)
 		for _, bp := range req.Bench.Packages {
 			benchMap[bp.Name] = bp
 		}
 		p = p.Do(func(in Rebuild, out chan<- Rebuild) {
-			if bp, ok := benchMap[in.Package]; ok && slices.Contains(bp.Versions, in.Version) && bp.Ecosystem == in.Ecosystem {
+			if bp, ok := benchMap[in.Package]; ok && (len(bp.Versions) == 0 || slices.Contains(bp.Versions, in.Version)) && bp.Ecosystem == in.Ecosystem {
 				out <- in
 			}
 		})
@@ -267,6 +284,12 @@ func filterRebuilds(all <-chan Rebuild, req *FetchRebuildRequest) []Rebuild {
 		for r := range p.Out() {
 			res = append(res, r)
 		}
+	}
+	slices.SortFunc(res, func(a, b Rebuild) int {
+		return b.Created.Compare(a.Created)
+	})
+	if req.Limit > 0 && len(res) > req.Limit {
+		res = res[:req.Limit]
 	}
 	return res
 }


### PR DESCRIPTION
This doesn't remove any capabilities yet, although I think we should try
to deprecate the swiss-army-knife FetchRebuilds because that's becoming
a very complex operation to support.

For firestore I implemented them as separate queries, for the other
backends I re-used the FetchRebuilds impl.