### PR TITLE
Make RebuildAttempt stateful

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -354,10 +355,42 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 	if req.BuildTimeout != 0 {
 		ctx = context.WithValue(ctx, rebuild.GCBCancelDeadlineID, time.Now().Add(req.BuildTimeout))
 	}
+
+	target := rebuild.Target{Ecosystem: req.Ecosystem, Package: req.Package, Version: req.Version, Artifact: req.Artifact}
+	et := rebuild.FirestoreTargetEncoding.Encode(target)
+	docRef := deps.FirestoreClient.Collection("ecosystem").Doc(string(et.Ecosystem)).Collection("packages").Doc(et.Package).Collection("versions").Doc(et.Version).Collection("artifacts").Doc(et.Artifact).Collection("attempts").Doc(req.ID)
+
+	attempt := schema.RebuildAttempt{
+		Ecosystem:       string(target.Ecosystem),
+		Package:         target.Package,
+		Version:         target.Version,
+		Artifact:        target.Artifact,
+		Status:          schema.RebuildStatusRunning,
+		ExecutorVersion: deps.ServiceRepo.Ref,
+		RunID:           req.ID,
+		Started:         started,
+		Created:         time.Now().UTC(),
+	}
+	if _, err := docRef.Set(ctx, attempt); err != nil {
+		return nil, errors.Wrap(err, "initial write to firestore")
+	}
+
+	finish := func(status schema.RebuildStatus) {
+		attempt.Status = status
+		attempt.Finished = time.Now().UTC()
+		// We use a background context for the terminal write to ensure it completes
+		// even if the request context is cancelled.
+		if _, err := docRef.Set(context.Background(), attempt); err != nil {
+			log.Printf("failed to write terminal RebuildAttempt %s (status=%s): %v", req.ID, status, err)
+		}
+	}
+
 	v, err := rebuildPackage(ctx, req, deps)
 	if err != nil {
+		finish(schema.RebuildStatusError)
 		return nil, err
 	}
+
 	var dockerfile string
 	r, err := deps.LocalMetadataStore.Reader(ctx, rebuild.DockerfileAsset.For(v.Target))
 	if err == nil {
@@ -374,26 +407,26 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 			log.Println("Failed to load build info:", err)
 		}
 	}
-	// Encode target for Firestore document IDs (handles NPM slashes, etc.)
-	et := rebuild.FirestoreTargetEncoding.Encode(v.Target)
-	_, err = deps.FirestoreClient.Collection("ecosystem").Doc(string(et.Ecosystem)).Collection("packages").Doc(et.Package).Collection("versions").Doc(et.Version).Collection("artifacts").Doc(et.Artifact).Collection("attempts").Doc(req.ID).Set(ctx, schema.RebuildAttempt{
-		Ecosystem:       string(v.Target.Ecosystem),
-		Package:         v.Target.Package,
-		Version:         v.Target.Version,
-		Artifact:        v.Target.Artifact,
-		Success:         v.Message == "",
-		Message:         v.Message,
-		Strategy:        v.StrategyOneof,
-		Dockerfile:      dockerfile,
-		ExecutorVersion: deps.ServiceRepo.Ref,
-		RunID:           req.ID,
-		BuildID:         bi.BuildID,
-		ObliviousID:     bi.ObliviousID,
-		Started:         started,
-		Created:         time.Now().UTC(),
-	})
-	if err != nil {
-		log.Print(errors.Wrap(err, "storing results in firestore"))
+
+	attempt.Success = v.Message == ""
+	attempt.Message = v.Message
+	attempt.Strategy = v.StrategyOneof
+	attempt.Timings = v.Timings
+	attempt.Dockerfile = dockerfile
+	attempt.BuildID = bi.BuildID
+	attempt.ObliviousID = bi.ObliviousID
+
+	status := schema.RebuildStatusSuccess
+	if !attempt.Success {
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			status = schema.RebuildStatusCancelled
+		} else if strings.Contains(v.Message, "rebuild content mismatch") {
+			status = schema.RebuildStatusFailure
+		} else {
+			status = schema.RebuildStatusError
+		}
 	}
+	finish(status)
+
 	return v, nil
 }

--- a/internal/rundex/firestore.go
+++ b/internal/rundex/firestore.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"path"
 	"slices"
-	"strings"
 	"sync"
 
 	"cloud.google.com/go/firestore"
@@ -211,11 +210,7 @@ func (f *FirestoreClient) RecentPackageRebuilds(ctx context.Context, eco rebuild
 func (f *FirestoreClient) fetchRebuildsQuery(ctx context.Context, q firestore.Query) ([]Rebuild, error) {
 	all := make(chan Rebuild)
 	cerr := doQuery(ctx, q, newRebuildFromFirestore, all)
-	var rebuilds []Rebuild
-	for r := range all {
-		r.Message = strings.ReplaceAll(r.Message, "\n", "\\n")
-		rebuilds = append(rebuilds, r)
-	}
+	rebuilds := filterRebuilds(all, &FetchRebuildRequest{}) // filter pending attempts and clean Message
 	if err := <-cerr; err != nil {
 		return nil, errors.Wrap(err, "query error")
 	}
@@ -280,6 +275,9 @@ func (f *FirestoreClient) LatestTrackedPackages(ctx context.Context, tracked fee
 				break
 			}
 			r := newRebuildFromFirestore(doc)
+			if r.Status == schema.RebuildStatusRunning {
+				continue
+			}
 			if _, seen := latest[r.Package]; !seen {
 				latest[r.Package] = r
 				out <- r

--- a/internal/rundex/rundex.go
+++ b/internal/rundex/rundex.go
@@ -69,9 +69,10 @@ func FromRun(r schema.Run) Run {
 }
 
 type FetchRebuildOpts struct {
-	Clean   bool
-	Prefix  string
-	Pattern string
+	Clean          bool
+	Prefix         string
+	Pattern        string
+	IncludePending bool
 }
 
 // FetchRebuildRequest describes which Rebuild results you would like to fetch from firestore.
@@ -222,6 +223,13 @@ func cleanVerdict(m string) string {
 
 func filterRebuilds(all <-chan Rebuild, req *FetchRebuildRequest) []Rebuild {
 	p := pipe.From(all)
+	if !req.Opts.IncludePending {
+		p = p.Do(func(in Rebuild, out chan<- Rebuild) {
+			if in.Status != schema.RebuildStatusRunning {
+				out <- in
+			}
+		})
+	}
 	if req.Target != nil {
 		p = p.Do(func(in Rebuild, out chan<- Rebuild) {
 			if (req.Target.Ecosystem == "" || rebuild.Ecosystem(in.Ecosystem) == req.Target.Ecosystem) &&

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -309,12 +309,25 @@ func (req CreateRunRequest) Validate() error {
 	return nil
 }
 
+// RebuildStatus is the status of a rebuild attempt.
+type RebuildStatus string
+
+const (
+	RebuildStatusUnspecified RebuildStatus = "" // zero value; old records
+	RebuildStatusRunning     RebuildStatus = "RUNNING"
+	RebuildStatusSuccess     RebuildStatus = "SUCCESS"
+	RebuildStatusFailure     RebuildStatus = "FAILURE" // ran, verification didn't match
+	RebuildStatusError       RebuildStatus = "ERROR"   // infra/internal error
+	RebuildStatusCancelled   RebuildStatus = "CANCELLED"
+)
+
 // RebuildAttempt stores rebuild and execution metadata on a single smoketest run.
 type RebuildAttempt struct {
 	Ecosystem       string          `firestore:"ecosystem,omitempty"`
 	Package         string          `firestore:"package,omitempty"`
 	Version         string          `firestore:"version,omitempty"`
 	Artifact        string          `firestore:"artifact,omitempty"`
+	Status          RebuildStatus   `firestore:"status,omitempty"`
 	Success         bool            `firestore:"success,omitempty"`
 	Message         string          `firestore:"message,omitempty"`
 	Strategy        StrategyOneOf   `firestore:"strategyoneof,omitempty"`
@@ -324,8 +337,9 @@ type RebuildAttempt struct {
 	RunID           string          `firestore:"run_id,omitempty"`
 	BuildID         string          `firestore:"build_id,omitempty"`
 	ObliviousID     string          `firestore:"oblivious_id,omitempty"`
-	Started         time.Time       `firestore:"started,omitempty"` // The time rebuild started
-	Created         time.Time       `firestore:"created,omitempty"` // The time this record was created
+	Started         time.Time       `firestore:"started,omitempty"`  // The time rebuild started
+	Finished        time.Time       `firestore:"finished,omitempty"` // The time rebuild finished
+	Created         time.Time       `firestore:"created,omitempty"`  // The time this record was created
 }
 
 // Run stores metadata on an execution grouping.

--- a/tools/ctl/command/export/export.go
+++ b/tools/ctl/command/export/export.go
@@ -75,9 +75,10 @@ func buildFetchRebuildRequest(bench, run, prefix, pattern string, clean, latestP
 	req := rundex.FetchRebuildRequest{
 		Runs: runs,
 		Opts: rundex.FetchRebuildOpts{
-			Prefix:  prefix,
-			Pattern: pattern,
-			Clean:   clean,
+			Prefix:         prefix,
+			Pattern:        pattern,
+			Clean:          clean,
+			IncludePending: false, // TODO: Add support for including pending attempts.
 		},
 		LatestPerPackage: latestPerPackage,
 	}

--- a/tools/ctl/command/getresults/getresults.go
+++ b/tools/ctl/command/getresults/getresults.go
@@ -76,9 +76,10 @@ func buildFetchRebuildRequest(bench, run, prefix, pattern string, clean, latestP
 	req := rundex.FetchRebuildRequest{
 		Runs: runs,
 		Opts: rundex.FetchRebuildOpts{
-			Prefix:  prefix,
-			Pattern: pattern,
-			Clean:   clean,
+			Prefix:         prefix,
+			Pattern:        pattern,
+			Clean:          clean,
+			IncludePending: false, // TODO: Add support for including pending attempts.
 		},
 	}
 	// Load the benchmark, if provided.

--- a/tools/ctl/command/tui/tui.go
+++ b/tools/ctl/command/tui/tui.go
@@ -182,7 +182,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 	}
 	benches := benchmark.NewFSRepository(osfs.New(cfg.BenchmarkDir))
 	prebuildConfig := rebuild.PrebuildConfig{Bucket: cfg.BootstrapBucket, Dir: cfg.BootstrapVersion}
-	tapp := ide.NewTuiApp(dex, watcher, rundex.FetchRebuildOpts{Clean: cfg.Clean}, benches, buildDefs, butler, aiClient, prebuildConfig)
+	tapp := ide.NewTuiApp(dex, watcher, rundex.FetchRebuildOpts{Clean: cfg.Clean, IncludePending: false}, benches, buildDefs, butler, aiClient, prebuildConfig)
 	if err := tapp.Run(ctx); err != nil {
 		// TODO: This cleanup will be unnecessary once NewTuiApp does split logging.
 		log.Default().SetOutput(os.Stdout)


### PR DESCRIPTION
This change allows us to track pending attempts out-of-band of the
request. This helps with the implementation of a long-running operation
API as we can use the attempt object itself to represent the incomplete
state in the Operation.