### PR TITLE
Add Stabilizer set to StabilizationContext

### DIFF
--- a/pkg/stabilize/context.go
+++ b/pkg/stabilize/context.go
@@ -5,10 +5,12 @@ package stabilize
 
 import "github.com/google/oss-rebuild/pkg/archive"
 
-// StabilizationContext tracks position within potentially nested archives.
+// StabilizationContext tracks position within potentially nested archives
+// and carries the stabilizer pipeline for recursive application.
 type StabilizationContext struct {
-	Levels []ArchiveLevel
-	Entry  *EntryInfo
+	Levels      []ArchiveLevel
+	Entry       *EntryInfo
+	Stabilizers []Stabilizer
 }
 
 // ArchiveLevel represents a single level in a nested archive.
@@ -45,10 +47,17 @@ func (ctx *StabilizationContext) Format() archive.Format {
 	return ctx.Levels[len(ctx.Levels)-1].Format
 }
 
+// WithStabilizers returns a new context with the given stabilizers.
+func (ctx *StabilizationContext) WithStabilizers(stabilizers []Stabilizer) *StabilizationContext {
+	ctx.Stabilizers = stabilizers
+	return ctx
+}
+
 // WithEntry returns a new context with the given entry information.
 func (ctx *StabilizationContext) WithEntry(path string) *StabilizationContext {
 	return &StabilizationContext{
-		Levels: ctx.Levels,
-		Entry:  &EntryInfo{Path: path},
+		Levels:      ctx.Levels,
+		Entry:       &EntryInfo{Path: path},
+		Stabilizers: ctx.Stabilizers,
 	}
 }

--- a/pkg/stabilize/custom_test.go
+++ b/pkg/stabilize/custom_test.go
@@ -719,7 +719,7 @@ func TestCustomStabilizers_EndToEnd_Tar(t *testing.T) {
 			allStabilizers := append(AllTarStabilizers, customStabilizers...)
 			var output bytes.Buffer
 			tr := tar.NewReader(bytes.NewReader(input.Bytes()))
-			err = StabilizeTar(tr, tar.NewWriter(&output), StabilizeOpts{Stabilizers: allStabilizers}, NewContext(archive.TarFormat))
+			err = StabilizeTar(tr, tar.NewWriter(&output), NewContext(archive.TarFormat).WithStabilizers(allStabilizers))
 			if err != nil {
 				if tc.wantErr {
 					return
@@ -822,8 +822,7 @@ func TestReplacePattern_NestedTar(t *testing.T) {
 			err = StabilizeTar(
 				tar.NewReader(bytes.NewReader(outer.Bytes())),
 				tar.NewWriter(&output),
-				StabilizeOpts{Stabilizers: append(AllTarStabilizers, customStabilizers...)},
-				NewContext(archive.TarFormat),
+				NewContext(archive.TarFormat).WithStabilizers(append(AllTarStabilizers, customStabilizers...)),
 			)
 			if err != nil {
 				t.Fatalf("StabilizeTar() error: %v", err)
@@ -1011,7 +1010,7 @@ func TestCustomStabilizers_EndToEnd_Zip(t *testing.T) {
 			}
 			var output bytes.Buffer
 			zipWriter := zip.NewWriter(&output)
-			err = StabilizeZip(zipReader, zipWriter, StabilizeOpts{Stabilizers: allStabilizers}, NewContext(archive.ZipFormat))
+			err = StabilizeZip(zipReader, zipWriter, NewContext(archive.ZipFormat).WithStabilizers(allStabilizers))
 			if err != nil {
 				if tc.wantErr {
 					return

--- a/pkg/stabilize/gzip.go
+++ b/pkg/stabilize/gzip.go
@@ -39,10 +39,10 @@ var defaultCompression = gzip.DefaultCompression
 // compression level used in the gzip.Writer is not configurable after
 // construction. As a result, a raw writer must be provided and a gzip.Writer
 // returned to ensure a configurable compression level.
-func NewStabilizedGzipWriter(gr *gzip.Reader, w io.Writer, opts StabilizeOpts, ctx *StabilizationContext) (*gzip.Writer, error) {
+func NewStabilizedGzipWriter(gr *gzip.Reader, w io.Writer, ctx *StabilizationContext) (*gzip.Writer, error) {
 	header := gr.Header
 	mh := archive.MutableGzipHeader{Header: &header, Compression: defaultCompression}
-	for _, s := range opts.Stabilizers {
+	for _, s := range ctx.Stabilizers {
 		if fn, ok := s.FnFor(ctx).(GzipFn); ok {
 			fn(&mh)
 		}

--- a/pkg/stabilize/gzip_test.go
+++ b/pkg/stabilize/gzip_test.go
@@ -103,7 +103,7 @@ func TestNewStabilizedGzipWriter(t *testing.T) {
 			// Apply stabilization to gzip data
 			outBuf := &bytes.Buffer{}
 			gr := must(gzip.NewReader(bytes.NewReader(inBuf.Bytes())))
-			gw = must(NewStabilizedGzipWriter(gr, outBuf, StabilizeOpts{Stabilizers: tt.stabilizers}, NewContext(archive.GzipFormat)))
+			gw = must(NewStabilizedGzipWriter(gr, outBuf, NewContext(archive.GzipFormat).WithStabilizers(tt.stabilizers)))
 			must(io.Copy(gw, gr))
 			orDie(gw.Close())
 

--- a/pkg/stabilize/jar_test.go
+++ b/pkg/stabilize/jar_test.go
@@ -149,9 +149,7 @@ func TestStableJARBuildMetadata(t *testing.T) {
 			// Process with stabilizer
 			var output bytes.Buffer
 			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
-			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
-				Stabilizers: []Stabilizer{StableJARBuildMetadata},
-			}, NewContext(archive.ZipFormat))
+			err := StabilizeZip(zr, zip.NewWriter(&output), NewContext(archive.ZipFormat).WithStabilizers([]Stabilizer{StableJARBuildMetadata}))
 			if err != nil {
 				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
 			}
@@ -348,9 +346,7 @@ func TestStableOrderOfAttributeValues(t *testing.T) {
 			// Process with stabilizer
 			var output bytes.Buffer
 			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
-			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
-				Stabilizers: []Stabilizer{StableJAROrderOfAttributeValues},
-			}, NewContext(archive.ZipFormat))
+			err := StabilizeZip(zr, zip.NewWriter(&output), NewContext(archive.ZipFormat).WithStabilizers([]Stabilizer{StableJAROrderOfAttributeValues}))
 			if err != nil {
 				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
 			}
@@ -498,9 +494,7 @@ func TestStableGitProperties(t *testing.T) {
 			// Process with stabilizer
 			var output bytes.Buffer
 			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
-			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
-				Stabilizers: []Stabilizer{StableGitProperties},
-			}, NewContext(archive.ZipFormat))
+			err := StabilizeZip(zr, zip.NewWriter(&output), NewContext(archive.ZipFormat).WithStabilizers([]Stabilizer{StableGitProperties}))
 			if err != nil {
 				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
 			}

--- a/pkg/stabilize/stabilizer.go
+++ b/pkg/stabilize/stabilizer.go
@@ -131,7 +131,7 @@ func Stabilize(dst io.Writer, src io.Reader, f archive.Format) error {
 
 // StabilizeWithOpts selects and applies the provided stabilization routine for the given archive format.
 func StabilizeWithOpts(dst io.Writer, src io.Reader, f archive.Format, opts StabilizeOpts) error {
-	ctx := NewContext(f)
+	ctx := NewContext(f).WithStabilizers(opts.Stabilizers)
 	switch f {
 	case archive.ZipFormat:
 		srcReader, size, err := archive.ToZipCompatibleReader(src)
@@ -144,7 +144,7 @@ func StabilizeWithOpts(dst io.Writer, src io.Reader, f archive.Format, opts Stab
 		}
 		zw := zip.NewWriter(dst)
 		defer zw.Close()
-		err = StabilizeZip(zr, zw, opts, ctx)
+		err = StabilizeZip(zr, zw, ctx)
 		if err != nil {
 			return errors.Wrap(err, "stabilizing zip")
 		}
@@ -154,12 +154,12 @@ func StabilizeWithOpts(dst io.Writer, src io.Reader, f archive.Format, opts Stab
 			return errors.Wrap(err, "initializing gzip reader")
 		}
 		defer gzr.Close()
-		gzw, err := NewStabilizedGzipWriter(gzr, dst, opts, ctx)
+		gzw, err := NewStabilizedGzipWriter(gzr, dst, ctx)
 		if err != nil {
 			return errors.Wrap(err, "initializing gzip writer")
 		}
 		defer gzw.Close()
-		err = StabilizeTar(tar.NewReader(gzr), tar.NewWriter(gzw), opts, ctx)
+		err = StabilizeTar(tar.NewReader(gzr), tar.NewWriter(gzw), ctx)
 		if err != nil {
 			return errors.Wrap(err, "stabilizing tar.gz")
 		}
@@ -169,7 +169,7 @@ func StabilizeWithOpts(dst io.Writer, src io.Reader, f archive.Format, opts Stab
 			return errors.Wrap(err, "initializing gzip reader")
 		}
 		defer gzr.Close()
-		gzw, err := NewStabilizedGzipWriter(gzr, dst, opts, ctx)
+		gzw, err := NewStabilizedGzipWriter(gzr, dst, ctx)
 		if err != nil {
 			return errors.Wrap(err, "stabilizing gzip")
 		}
@@ -178,7 +178,7 @@ func StabilizeWithOpts(dst io.Writer, src io.Reader, f archive.Format, opts Stab
 			return errors.Wrap(err, "copying gzip content")
 		}
 	case archive.TarFormat:
-		err := StabilizeTar(tar.NewReader(src), tar.NewWriter(dst), opts, ctx)
+		err := StabilizeTar(tar.NewReader(src), tar.NewWriter(dst), ctx)
 		if err != nil {
 			return errors.Wrap(err, "stabilizing tar")
 		}

--- a/pkg/stabilize/tar.go
+++ b/pkg/stabilize/tar.go
@@ -128,7 +128,7 @@ var StabilizeCargoVCSHash = Stabilizer{
 }))
 
 // StabilizeTar strips volatile metadata and re-writes the provided archive in a standard form.
-func StabilizeTar(tr *tar.Reader, tw *tar.Writer, opts StabilizeOpts, ctx *StabilizationContext) error {
+func StabilizeTar(tr *tar.Reader, tw *tar.Writer, ctx *StabilizationContext) error {
 	defer tw.Close()
 	var ents []*archive.TarEntry
 	for header, err := range iterx.ToSeq2(tr, io.EOF) {
@@ -150,7 +150,7 @@ func StabilizeTar(tr *tar.Reader, tw *tar.Writer, opts StabilizeOpts, ctx *Stabi
 	}
 	f := archive.TarArchive{Files: ents}
 	// TODO: This ordering is inefficient as it lacks reuse for entryCtx
-	for _, s := range opts.Stabilizers {
+	for _, s := range ctx.Stabilizers {
 		if fn, ok := s.FnFor(ctx).(TarArchiveFn); ok && fn != nil {
 			fn(&f)
 		} else {

--- a/pkg/stabilize/tar_test.go
+++ b/pkg/stabilize/tar_test.go
@@ -68,7 +68,7 @@ func TestStabilizeTar(t *testing.T) {
 			}
 			var output bytes.Buffer
 			zr := tar.NewReader(bytes.NewReader(input.Bytes()))
-			err := StabilizeTar(zr, tar.NewWriter(&output), StabilizeOpts{Stabilizers: AllTarStabilizers}, NewContext(archive.TarFormat))
+			err := StabilizeTar(zr, tar.NewWriter(&output), NewContext(archive.TarFormat).WithStabilizers(AllTarStabilizers))
 			if err != nil {
 				t.Fatalf("StabilizeTar(%v) = %v, want nil", tc.test, err)
 			}
@@ -178,7 +178,7 @@ version = "1.0.0"`)},
 			}
 			var output bytes.Buffer
 			zr := tar.NewReader(bytes.NewReader(input.Bytes()))
-			err := StabilizeTar(zr, tar.NewWriter(&output), StabilizeOpts{Stabilizers: tc.stabilizers}, NewContext(archive.TarFormat))
+			err := StabilizeTar(zr, tar.NewWriter(&output), NewContext(archive.TarFormat).WithStabilizers(tc.stabilizers))
 			if err != nil {
 				t.Fatalf("StabilizeTar(%v) = %v, want nil", tc.test, err)
 			}

--- a/pkg/stabilize/zip.go
+++ b/pkg/stabilize/zip.go
@@ -105,11 +105,11 @@ var StableZipMisc = Stabilizer{
 }))
 
 // StabilizeZip strips volatile metadata and rewrites the provided archive in a standard form.
-func StabilizeZip(zr *zip.Reader, zw *zip.Writer, opts StabilizeOpts, ctx *StabilizationContext) error {
+func StabilizeZip(zr *zip.Reader, zw *zip.Writer, ctx *StabilizationContext) error {
 	defer zw.Close()
 	mr := archive.NewMutableReader(zr)
 	// TODO: This ordering is inefficient as it lacks reuse for entryCtx
-	for _, s := range opts.Stabilizers {
+	for _, s := range ctx.Stabilizers {
 		if fn, ok := s.FnFor(ctx).(ZipArchiveFn); ok && fn != nil {
 			fn(&mr)
 		} else {

--- a/pkg/stabilize/zip_test.go
+++ b/pkg/stabilize/zip_test.go
@@ -74,7 +74,7 @@ func TestStabilizeZip(t *testing.T) {
 			}
 			var output bytes.Buffer
 			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
-			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{Stabilizers: AllZipStabilizers}, NewContext(archive.ZipFormat))
+			err := StabilizeZip(zr, zip.NewWriter(&output), NewContext(archive.ZipFormat).WithStabilizers(AllZipStabilizers))
 			if err != nil {
 				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
 			}


### PR DESCRIPTION
This simplifies the representation of the stabilizer state into a single
struct. Opts only holds the set of stabilizers so the extra layer of
abstraction is being carried through into the implementation for a
really minor purpose. Projecting it onto the context should be a strict
improvement.