### PR TITLE
Add gem metadata stabilizers

### DIFF
--- a/pkg/stabilize/constraints.go
+++ b/pkg/stabilize/constraints.go
@@ -53,3 +53,14 @@ type MinDepth int
 func (c MinDepth) Matches(ctx *StabilizationContext) bool {
 	return ctx.Depth() >= int(c)
 }
+
+// ArchivePath matches when the current archive level's path equals the given value.
+type ArchivePath string
+
+// Matches returns true if the innermost archive level's path matches.
+func (c ArchivePath) Matches(ctx *StabilizationContext) bool {
+	if len(ctx.Levels) == 0 {
+		return false
+	}
+	return ctx.Levels[len(ctx.Levels)-1].Path == string(c)
+}

--- a/pkg/stabilize/gem.go
+++ b/pkg/stabilize/gem.go
@@ -5,6 +5,7 @@ package stabilize
 
 import (
 	"bytes"
+	"regexp"
 	"slices"
 
 	"github.com/google/oss-rebuild/pkg/archive"
@@ -13,6 +14,8 @@ import (
 // AllGemStabilizers is the list of all available gem stabilizers.
 var AllGemStabilizers = []Stabilizer{
 	StableGemExcludeChecksums,
+	StableGemMetadataDate,
+	StableGemMetadataRubygemsVersion,
 	StableGemInnerArchives,
 }
 
@@ -25,6 +28,28 @@ var StableGemExcludeChecksums = Stabilizer{
 	ta.Files = slices.DeleteFunc(ta.Files, func(e *archive.TarEntry) bool {
 		return e.Name == "checksums.yaml.gz"
 	})
+}))
+
+var gemMetadataDateRe = regexp.MustCompile(`(?m)^date: [^\r\n]+`)
+var gemMetadataRubygemsVersionRe = regexp.MustCompile(`(?m)^rubygems_version: [^\r\n]+`)
+
+// StableGemMetadataDate normalizes the date field in gem metadata YAML.
+// The date is stamped by `gem build` at build time and so varies across rebuilds.
+// The replacement value matches RubyGems' DEFAULT_SOURCE_DATE_EPOCH (1980-01-02 UTC):
+// https://github.com/rubygems/rubygems/blob/0b469ed/lib/rubygems.rb#L151
+var StableGemMetadataDate = Stabilizer{
+	Name: "gem-metadata-date",
+}.WithConstraints(AtDepth(1), ArchivePath("metadata.gz")).WithFn(GzipContentFn(func(b []byte) []byte {
+	return gemMetadataDateRe.ReplaceAll(b, []byte("date: 1980-01-02 00:00:00.000000000 Z"))
+}))
+
+// StableGemMetadataRubygemsVersion normalizes the rubygems_version field in gem metadata YAML.
+// This field records the RubyGems version used to build the
+// gem and may differ between the original and rebuild environments.
+var StableGemMetadataRubygemsVersion = Stabilizer{
+	Name: "gem-metadata-rubygems-version",
+}.WithConstraints(AtDepth(1), ArchivePath("metadata.gz")).WithFn(GzipContentFn(func(b []byte) []byte {
+	return gemMetadataRubygemsVersionRe.ReplaceAll(b, []byte("rubygems_version: 0.0.0"))
 }))
 
 // StableGemInnerArchives recursively stabilizes the inner archives within a gem.

--- a/pkg/stabilize/gem_test.go
+++ b/pkg/stabilize/gem_test.go
@@ -86,6 +86,68 @@ func TestStableGemInnerArchives(t *testing.T) {
 	}
 }
 
+func TestStableGemMetadata(t *testing.T) {
+	libBody := []byte("hello")
+	stableEntry := func(name string) *tar.Header {
+		h := stableTarHeader
+		h.Name = name
+		h.Typeflag = tar.TypeReg
+		return &h
+	}
+	allStabs := append(append(append([]Stabilizer{}, AllTarStabilizers...), AllGzipStabilizers...), AllGemStabilizers...)
+
+	for _, tc := range []struct {
+		name, in, want string
+	}{
+		{
+			name: "rewrites top-level date and rubygems_version",
+			in:   "name: foo\ndate: 2024-06-15 00:00:00.000000000 Z\nrubygems_version: 3.5.11\n",
+			want: "name: foo\ndate: 1980-01-02 00:00:00.000000000 Z\nrubygems_version: 0.0.0\n",
+		},
+		{
+			name: "preserves CRLF terminator",
+			in:   "date: 2024-06-15 00:00:00.000000000 Z\r\n",
+			want: "date: 1980-01-02 00:00:00.000000000 Z\r\n",
+		},
+		{
+			name: "leaves indented (nested) date untouched",
+			in:   "dependencies:\n  date: 2020-01-01\n",
+			want: "dependencies:\n  date: 2020-01-01\n",
+		},
+		{
+			name: "no-op when target fields absent",
+			in:   "name: foo\n",
+			want: "name: foo\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := must(archivetest.TarFile([]archive.TarEntry{
+				{Header: &tar.Header{Name: "data.tar.gz", Typeflag: tar.TypeReg}, Body: must(archivetest.TgzFile([]archive.TarEntry{
+					{Header: &tar.Header{Name: "lib/foo.rb", Typeflag: tar.TypeReg}, Body: libBody},
+				})).Bytes()},
+				{Header: &tar.Header{Name: "metadata.gz", Typeflag: tar.TypeReg}, Body: must(archivetest.GzFile([]byte(tc.in), gzip.Header{})).Bytes()},
+				{Header: &tar.Header{Name: "checksums.yaml.gz", Typeflag: tar.TypeReg}, Body: []byte("sums")},
+			}))
+			want := must(archivetest.TarFile([]archive.TarEntry{
+				{Header: stableEntry("data.tar.gz"), Body: must(archivetest.GzFile(
+					must(archivetest.TarFile([]archive.TarEntry{
+						{Header: stableEntry("lib/foo.rb"), Body: libBody},
+					})).Bytes(),
+					stableGzipHeader, gzip.NoCompression,
+				)).Bytes()},
+				{Header: stableEntry("metadata.gz"), Body: must(archivetest.GzFile(
+					[]byte(tc.want), stableGzipHeader, gzip.NoCompression,
+				)).Bytes()},
+			}))
+			var got bytes.Buffer
+			orDie(StabilizeWithOpts(&got, bytes.NewReader(input.Bytes()), archive.TarFormat, StabilizeOpts{Stabilizers: allStabs}))
+			if diff := cmp.Diff(want.Bytes(), got.Bytes()); diff != "" {
+				t.Errorf("StabilizeWithOpts() output mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestStableGemIdempotent(t *testing.T) {
 	nonEpoch := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	gemTar := must(archivetest.TarFile([]archive.TarEntry{

--- a/pkg/stabilize/gzip.go
+++ b/pkg/stabilize/gzip.go
@@ -28,6 +28,15 @@ func (GzipFn) Constraints() Constraints {
 	return []Constraint{Formats(gzipFormats)}
 }
 
+// GzipContentFn applies stabilization to the decompressed content of a
+// standalone gzip archive. It is only applied for GzipFormat (not TarGzFormat,
+// where the inner content is a tar archive handled by tar stabilizers).
+type GzipContentFn func([]byte) []byte
+
+func (GzipContentFn) Constraints() Constraints {
+	return []Constraint{Format(archive.GzipFormat)}
+}
+
 // defaultCompression enables us to configure the default compression value
 // used in tests.
 var defaultCompression = gzip.DefaultCompression

--- a/pkg/stabilize/stabilizer.go
+++ b/pkg/stabilize/stabilizer.go
@@ -177,8 +177,18 @@ func stabilizeWithCtx(dst io.Writer, src io.Reader, f archive.Format, ctx *Stabi
 			return errors.Wrap(err, "stabilizing gzip")
 		}
 		defer gzw.Close()
-		if _, err := io.Copy(gzw, gzr); err != nil {
-			return errors.Wrap(err, "copying gzip content")
+		// NOTE: Memory-intensive. Buffers the full decompressed payload so GzipContentFn stabilizers can operate on it as a whole.
+		content, err := io.ReadAll(gzr)
+		if err != nil {
+			return errors.Wrap(err, "reading gzip content")
+		}
+		for _, s := range ctx.Stabilizers {
+			if fn, ok := s.FnFor(ctx).(GzipContentFn); ok {
+				content = fn(content)
+			}
+		}
+		if _, err := gzw.Write(content); err != nil {
+			return errors.Wrap(err, "writing gzip content")
 		}
 	case archive.TarFormat:
 		err := StabilizeTar(tar.NewReader(src), tar.NewWriter(dst), ctx)


### PR DESCRIPTION
These are regrettably implemented as regexes but the "yaml" used as
metadata is foreign enough to standard serialization that round-tripping
would introduce an unacceptable level of deviation from the common form.