### PR TITLE
Update rebuild job cpu allocation to 1000m

### DIFF
--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -392,7 +392,7 @@ resource "google_cloud_run_v2_job" "rebuild-job" {
         image = data.google_artifact_registry_docker_image.rebuild-job.self_link
         resources {
           limits = {
-            cpu    = "100m"
+            cpu    = "1000m"
             memory = "512Mi"
           }
         }


### PR DESCRIPTION
It seems like cloud run does not allow jobs to reserve less than 1 full
cpu.