### PR TITLE
Add Resource.Upsert

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -365,7 +365,7 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 		Started:         started,
 		Created:         time.Now().UTC(),
 	}
-	if err := deps.Attempts.Insert(ctx, attempt); err != nil {
+	if err := deps.Attempts.Upsert(ctx, attempt); err != nil {
 		return nil, errors.Wrap(err, "initial write to db")
 	}
 

--- a/internal/api/apiservice/rebuild_lro_test.go
+++ b/internal/api/apiservice/rebuild_lro_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,6 +100,72 @@ func TestCreateAndGetRebuildOp(t *testing.T) {
 	}
 	if got.Result == nil || got.Result.Message != "success" {
 		t.Errorf("expected success result, got %+v", got.Result)
+	}
+}
+
+func TestRebuildPackageDuplicateInsert(t *testing.T) {
+	ctx := context.Background()
+	attempts := db.NewMemoryAttempts()
+
+	target := rebuild.Target{Ecosystem: rebuild.PyPI, Package: "absl-py", Version: "2.0.0", Artifact: "absl_py-2.0.0-py3-none-any.whl"}
+	req := schema.RebuildPackageRequest{
+		Ecosystem: target.Ecosystem,
+		Package:   target.Package,
+		Version:   target.Version,
+		Artifact:  target.Artifact,
+		ID:        "duplicate-run-id",
+	}
+
+	// Pre-insert the attempt (simulating CreateRebuildOp)
+	attempt := schema.RebuildAttempt{
+		Ecosystem: string(req.Ecosystem),
+		Package:   req.Package,
+		Version:   req.Version,
+		Artifact:  req.Artifact,
+		RunID:     req.ID,
+		Status:    schema.RebuildStatusRunning,
+	}
+	if err := attempts.Insert(ctx, attempt); err != nil {
+		t.Fatalf("Initial Insert failed: %v", err)
+	}
+
+	// Now call RebuildPackage, which will call Upsert.
+	// We need to provide minimal deps.
+	var d RebuildPackageDeps
+	d.Attempts = attempts
+	d.ServiceRepo = rebuild.Location{Ref: "test-ref"}
+	mfs := memfs.New()
+	d.AttestationStore = rebuild.NewFilesystemAssetStore(mfs)
+	d.LocalMetadataStore = rebuild.NewFilesystemAssetStore(mfs)
+	d.HTTPClient = &httpxtest.MockClient{}
+	d.Signer = must(dsse.NewEnvelopeSigner(&FakeSigner{}))
+
+	// Mock other things to fail fast after the initial write
+	d.InferStub = func(context.Context, schema.InferenceRequest) (*schema.StrategyOneOf, error) {
+		return nil, io.EOF // arbitrary error
+	}
+
+	// RebuildPackage should not fail on the initial write.
+	// It will return a verdict with an error message later due to InferStub returning EOF.
+	v, err := RebuildPackage(ctx, req, &d)
+	if err != nil {
+		t.Errorf("expected no error from RebuildPackage, got %v", err)
+	}
+	if v == nil || !strings.Contains(v.Message, "fetching inference") {
+		t.Errorf("expected fetching inference error in verdict, got %+v", v)
+	}
+
+	// Verify it didn't fail at the initial write by checking the fields that RebuildPackage sets.
+	got, err := attempts.Get(ctx, db.AttemptKey{Target: target, RunID: req.ID})
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	// RebuildPackage would have set Started and ExecutorVersion
+	if got.ExecutorVersion != "test-ref" {
+		t.Errorf("Expected ExecutorVersion test-ref, got %s", got.ExecutorVersion)
+	}
+	if got.Started.IsZero() {
+		t.Error("Expected Started time to be set")
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -21,6 +21,7 @@ type Resource[T, K any] interface {
 	Get(ctx context.Context, key K) (T, error)
 	Insert(ctx context.Context, v T) error
 	Update(ctx context.Context, v T) error
+	Upsert(ctx context.Context, v T) error
 }
 
 var (
@@ -86,6 +87,11 @@ func (r *firestoreResource[T, K]) Update(ctx context.Context, v T) error {
 	return err
 }
 
+func (r *firestoreResource[T, K]) Upsert(ctx context.Context, v T) error {
+	_, err := r.doc(r.pathFor(v)).Set(ctx, v)
+	return err
+}
+
 // memoryResource is an internal generic implementation of Resource using an in-memory map.
 type memoryResource[T, K any] struct {
 	mu         sync.Mutex
@@ -123,6 +129,14 @@ func (r *memoryResource[T, K]) Update(ctx context.Context, v T) error {
 	if _, ok := r.data[p]; !ok {
 		return ErrNotFound
 	}
+	r.data[p] = v
+	return nil
+}
+
+func (r *memoryResource[T, K]) Upsert(ctx context.Context, v T) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p := path.Join(r.pathFor(v)...)
 	r.data[p] = v
 	return nil
 }


### PR DESCRIPTION
The /rebuild/op/create endpoint creates the Attempt document, which is a
problem when RebuildPackage calls Attempts.Insert() at the beginning.
One option would be to modify RebuildPackage to assume the Attempt
object already exists, and always call Attemps.Update(). However, in the
legacy path <api>/rebuild?q=... the RebuildPackage handler is called
directly, so it needs to gracefully handle no Attempt document. It also
seems generally more robust for this helper to gracefully handle both
existing and non-existing documents.