### PR TITLE
Update cli.RunE to set SilenceUsage after input parsing

### DIFF
--- a/pkg/act/cli/cli.go
+++ b/pkg/act/cli/cli.go
@@ -45,6 +45,10 @@ func RunE[I act.Input, O any, D Deps](
 		if err != nil {
 			return errors.Wrap(err, "initializing dependencies")
 		}
+		// Beyond this point in the code, failures are not usually related to command usage.
+		// Instead, they're application failures which should be reflected in the error message.
+		// See this discussion for more details: https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+		cmd.SilenceUsage = true
 		deps.SetIO(IO{
 			In:  cmd.InOrStdin(),
 			Out: cmd.OutOrStdout(),


### PR DESCRIPTION
By default, any error returned by RunE causes Cobra to print the usage string. This is confusing and noisy when a command fails for runtime reasons.

By keeping SilenceUsage=false for the first half of execution, any input argument failures, args parsing, Validate() or initDeps() failures will result in the usage string printing. Beyond this point in the code, failures will be logged and non-zero status will be returned, but the usage string will no longer be printed.