### PR TITLE
Unconditionally populate Result for rebuild LROs

### DIFF
--- a/internal/api/apiservice/rebuild_lro.go
+++ b/internal/api/apiservice/rebuild_lro.go
@@ -34,16 +34,16 @@ func NewRebuildView(attempts db.Attempts) *RebuildView {
 func ProjectRebuildAttempt(a schema.RebuildAttempt) longrunning.Operation[schema.Verdict] {
 	op := longrunning.Operation[schema.Verdict]{
 		ID: toOperationID(db.AttemptKey{Target: a.Target(), RunID: a.RunID}),
-	}
-	switch a.Status {
-	case schema.RebuildStatusSuccess, schema.RebuildStatusFailure:
-		op.Done = true
-		op.Result = &schema.Verdict{
+		Result: &schema.Verdict{
 			Target:        a.Target(),
 			Message:       a.Message,
 			StrategyOneof: a.Strategy,
 			Timings:       a.Timings,
-		}
+		},
+	}
+	switch a.Status {
+	case schema.RebuildStatusSuccess, schema.RebuildStatusFailure:
+		op.Done = true
 	case schema.RebuildStatusError:
 		op.Done = true
 		op.Error = &longrunning.OperationError{


### PR DESCRIPTION
We use the Result field as both metadata and response value. We also use
schema.RebuildStatusError for many application-level rebuild failures
(inference failures, build failures, etc). So refusing to return
Verdicts (which is effectively metadata at the moment) seems
undesirable.