### PR TITLE
Set prebuild file names inside the build

### DIFF
--- a/pkg/build/gcb/planner.go
+++ b/pkg/build/gcb/planner.go
@@ -255,11 +255,11 @@ var gcbDockerfileTpl = template.Must(
 			 {{- $hasCurl := or (eq .OS "debian") (eq .OS "ubuntu")}}
 			 {{- $hasWget := eq .OS "alpine"}}
 			 {{- if .TimewarpAuth}}
-			 {{if not $hasCurl}}{{.PackageManager.InstallCommand (list "curl")}} && {{end}}curl -O -H @/run/secrets/auth_header {{.TimewarpURL}}
+			 {{if not $hasCurl}}{{.PackageManager.InstallCommand (list "curl")}} && {{end}}curl -H @/run/secrets/auth_header {{.TimewarpURL}} > timewarp
 			 {{- else if $hasWget}}
-			 wget {{.TimewarpURL}}
+			 wget -O timewarp {{.TimewarpURL}}
 			 {{- else if $hasCurl}}
-			 curl -O {{.TimewarpURL}}
+			 curl {{.TimewarpURL}} > timewarp
 			 {{- end}}
 			 chmod +x timewarp
 			{{- end}}
@@ -311,7 +311,7 @@ var gcbStandardBuildTpl = template.Must(
 			(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 			{{- end}}
 			{{- if .TetragonSysgraphURL}}
-			curl -O {{if .TetragonSysgraphAuth}}-H @/tmp/auth_header {{end}}{{.TetragonSysgraphURL}}
+			curl {{if .TetragonSysgraphAuth}}-H @/tmp/auth_header {{end}}{{.TetragonSysgraphURL}} > tetragon_sysgraph
 			chmod +x tetragon_sysgraph
 			docker run --name=sysgraph --detach --cpu-shares=5120 -v=/workspace/:/workspace/ docker.io/library/alpine:3.21 /workspace/tetragon_sysgraph -server unix:///workspace/tetragon/tetragon.sock -output /workspace/sysgraph.zip
 			docker logs --follow sysgraph &
@@ -398,7 +398,7 @@ var gcbProxyBuildTpl = template.Must(
 			apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq .access_token > /tmp/token
 			(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 			{{- end}}
-			curl -O {{if .ProxyAuth}}-H @/tmp/auth_header {{end -}} {{.ProxyURL}}
+			curl {{if .ProxyAuth}}-H @/tmp/auth_header {{end -}} {{.ProxyURL}} > proxy
 			chmod +x proxy
 			docker network create proxynet
 			useradd --system {{.User}}
@@ -443,7 +443,7 @@ var gcbProxyBuildTpl = template.Must(
 			grep -q "Listening for events..." <(docker logs --follow $TID 2>&1) || (docker logs $TID && exit 1)
 			TETRAGON_PID=$(docker inspect -f '{{printf "%s" "{{.State.Pid}}"}}' tetragon)
 			{{- if .TetragonSysgraphURL}}
-			curl -O {{if .TetragonSysgraphAuth}}-H @/tmp/auth_header {{end}}{{.TetragonSysgraphURL}}
+			curl {{if .TetragonSysgraphAuth}}-H @/tmp/auth_header {{end}}{{.TetragonSysgraphURL}} > tetragon_sysgraph
 			chmod +x tetragon_sysgraph
 			docker run --name=sysgraph --detach --cpu-shares=5120 -v=/workspace/:/workspace/ docker.io/library/alpine:3.21 /workspace/tetragon_sysgraph -server unix:///workspace/tetragon/tetragon.sock -output /workspace/sysgraph.zip
 			docker logs --follow sysgraph &
@@ -816,9 +816,9 @@ var gcbAssetUploadTpl = template.Must(
 			{{- if .GSUtilAuth}}
 			apk add curl jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq .access_token > /tmp/token
 			(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
-			curl -O -H @/tmp/auth_header {{.GSUtilURL}}
+			curl -H @/tmp/auth_header {{.GSUtilURL}} > gsutil_writeonly
 			{{- else}}
-			wget {{.GSUtilURL}}
+			wget -O gsutil_writeonly {{.GSUtilURL}}
 			{{- end}}
 			chmod +x gsutil_writeonly
 			{{- range .Uploads}}

--- a/pkg/build/gcb/planner_test.go
+++ b/pkg/build/gcb/planner_test.go
@@ -103,7 +103,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 FROM docker.io/library/alpine:3.19
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux
- wget https://my-bucket.storage.googleapis.com/timewarp
+ wget -O timewarp https://my-bucket.storage.googleapis.com/timewarp
  chmod +x timewarp
  apk add git make
 EOF
@@ -154,7 +154,7 @@ ENTRYPOINT ["/bin/sh","/build"]
 FROM docker.io/library/alpine:3.19
 RUN --mount=type=secret,id=auth_header sed 's/^ //' <<'EOF' | sh
  set -eux
- apk add curl && curl -O -H @/run/secrets/auth_header https://my-bucket.storage.googleapis.com/timewarp
+ apk add curl && curl -H @/run/secrets/auth_header https://my-bucket.storage.googleapis.com/timewarp > timewarp
  chmod +x timewarp
  apk add git make
 EOF
@@ -481,7 +481,7 @@ func TestGCBPlannerBuildScriptWithSysgraph(t *testing.T) {
 					export TID=$(docker run --name=tetragon --detach --pid=host --cgroupns=host --privileged -v=/workspace/tetragon/:/workspace/tetragon/ -v=/sys/kernel/btf/vmlinux:/var/lib/tetragon/btf quay.io/cilium/tetragon:v1.4.1 /usr/bin/tetragon --tracing-policy-dir=/workspace/tetragon/ --server-address=unix:///workspace/tetragon/tetragon.sock --rb-size=10M --rb-queue-size=10M --event-queue-size=10000000)
 					grep -q "Listening for events..." <(docker logs --follow $TID 2>&1) || (docker logs $TID && exit 1)
 					TETRAGON_PID=$(docker inspect -f '{{.State.Pid}}' tetragon)
-					curl -O https://storage.googleapis.com/bucket/tetragon_sysgraph
+					curl https://storage.googleapis.com/bucket/tetragon_sysgraph > tetragon_sysgraph
 					chmod +x tetragon_sysgraph
 					docker run --name=sysgraph --detach --cpu-shares=5120 -v=/workspace/:/workspace/ docker.io/library/alpine:3.21 /workspace/tetragon_sysgraph -server unix:///workspace/tetragon/tetragon.sock -output /workspace/sysgraph.zip
 					docker logs --follow sysgraph &
@@ -523,7 +523,7 @@ func TestGCBPlannerBuildScriptWithSysgraph(t *testing.T) {
 					TETRAGON_PID=$(docker inspect -f '{{.State.Pid}}' tetragon)
 					apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/test@test.iam.gserviceaccount.com/token | jq .access_token > /tmp/token
 					(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
-					curl -O -H @/tmp/auth_header https://storage.googleapis.com/bucket/tetragon_sysgraph
+					curl -H @/tmp/auth_header https://storage.googleapis.com/bucket/tetragon_sysgraph > tetragon_sysgraph
 					chmod +x tetragon_sysgraph
 					docker run --name=sysgraph --detach --cpu-shares=5120 -v=/workspace/:/workspace/ docker.io/library/alpine:3.21 /workspace/tetragon_sysgraph -server unix:///workspace/tetragon/tetragon.sock -output /workspace/sysgraph.zip
 					docker logs --follow sysgraph &
@@ -560,7 +560,7 @@ func TestGCBPlannerBuildScriptWithSysgraph(t *testing.T) {
 					#!/usr/bin/env bash
 					set -eux
 					echo 'Starting rebuild for {Ecosystem:npm Package:test-package Version:1.0.0 Artifact:test-package-1.0.0.tgz}'
-					curl -O https://storage.googleapis.com/bucket/proxy
+					curl https://storage.googleapis.com/bucket/proxy > proxy
 					chmod +x proxy
 					docker network create proxynet
 					useradd --system proxyu
@@ -594,7 +594,7 @@ func TestGCBPlannerBuildScriptWithSysgraph(t *testing.T) {
 					export TID=$(docker run --name=tetragon --detach --pid=host --cgroupns=host --privileged -v=/workspace/tetragon/:/workspace/tetragon/ -v=/sys/kernel/btf/vmlinux:/var/lib/tetragon/btf quay.io/cilium/tetragon:v1.4.1 /usr/bin/tetragon --tracing-policy-dir=/workspace/tetragon/ --server-address=unix:///workspace/tetragon/tetragon.sock --rb-size=10M --rb-queue-size=10M --event-queue-size=10000000)
 					grep -q "Listening for events..." <(docker logs --follow $TID 2>&1) || (docker logs $TID && exit 1)
 					TETRAGON_PID=$(docker inspect -f '{{.State.Pid}}' tetragon)
-					curl -O https://storage.googleapis.com/bucket/tetragon_sysgraph
+					curl https://storage.googleapis.com/bucket/tetragon_sysgraph > tetragon_sysgraph
 					chmod +x tetragon_sysgraph
 					docker run --name=sysgraph --detach --cpu-shares=5120 -v=/workspace/:/workspace/ docker.io/library/alpine:3.21 /workspace/tetragon_sysgraph -server unix:///workspace/tetragon/tetragon.sock -output /workspace/sysgraph.zip
 					docker logs --follow sysgraph &
@@ -696,7 +696,7 @@ func TestGCBPlannerSavePostBuildContainer(t *testing.T) {
 		{
 			Name: "docker.io/library/alpine:3.19",
 			Script: `set -eux
-wget https://storage.googleapis.com/test-bucket/gsutil_writeonly
+wget -O gsutil_writeonly https://storage.googleapis.com/test-bucket/gsutil_writeonly
 chmod +x gsutil_writeonly
 ./gsutil_writeonly cp /workspace/test-package-1.0.0.tgz file:///npm/test-package/1.0.0/test-package-1.0.0.tgz/test-package-1.0.0.tgz
 ./gsutil_writeonly cp /workspace/image_postbuild.tgz file:///npm/test-package/1.0.0/test-package-1.0.0.tgz/image_postbuild.tgz


### PR DESCRIPTION
Previously, the code assumed the filenames of the bootstrap containers.
While expected, this isn't guaranteed to be true. Additionally, the name
selection rules are sufficiently complex (and differ slightly between
wget and curl) that doing so statically is not reliable.