### PR TITLE
Reject symlink sources during local artifact upload

### DIFF
--- a/cmd/gsutil_writeonly/main.go
+++ b/cmd/gsutil_writeonly/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/fileio"
 	"github.com/pkg/errors"
 )
 
@@ -46,7 +47,7 @@ func copyFile(ctx context.Context, c *storage.Client, src, dest string) error {
 			return err
 		}
 	} else {
-		srcR, err = os.Open(src)
+		srcR, err = fileio.OpenRegular(src)
 		if err != nil {
 			return err
 		}

--- a/cmd/gsutil_writeonly/main_test.go
+++ b/cmd/gsutil_writeonly/main_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCopyFileRejectsLocalSourceSymlink(t *testing.T) {
+	base := t.TempDir()
+	outside := filepath.Join(base, "outside-file")
+	if err := os.WriteFile(outside, []byte("outside marker"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(base, "artifact.tgz")
+	if err := os.Symlink(outside, src); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(base, "uploaded")
+	err := copyFile(context.Background(), nil, src, dest)
+	if err == nil {
+		t.Fatal("copyFile succeeded for symlink source, want error")
+	}
+	if !strings.Contains(err.Error(), "failed to open regular file") {
+		t.Fatalf("copyFile error = %v, want regular file error", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("destination exists after rejected copy: %v", statErr)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/crypto v0.45.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.18.0
+	golang.org/x/sys v0.38.0
 	google.golang.org/api v0.242.0
 	google.golang.org/genai v1.24.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250804133106-a7a43d27e69b
@@ -110,7 +111,6 @@ require (
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/fileio/open_nofollow_other.go
+++ b/internal/fileio/open_nofollow_other.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !unix
+
+package fileio
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func openNoFollow(path string) (*os.File, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.Errorf("refusing to open non-regular file %s (mode %s)", path, info.Mode())
+	}
+	return os.Open(path)
+}

--- a/internal/fileio/open_nofollow_unix.go
+++ b/internal/fileio/open_nofollow_unix.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package fileio
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openNoFollow(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|unix.O_NOFOLLOW, 0)
+}

--- a/internal/fileio/regular.go
+++ b/internal/fileio/regular.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package fileio
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// OpenRegular opens path for reading only when path names a regular file.
+func OpenRegular(path string) (*os.File, error) {
+	file, err := openNoFollow(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open regular file %s", path)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, errors.Wrapf(err, "failed to stat regular file %s", path)
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, errors.Errorf("refusing to open non-regular file %s (mode %s)", path, info.Mode())
+	}
+	return file, nil
+}

--- a/pkg/build/local/build_executor.go
+++ b/pkg/build/local/build_executor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/bufiox"
+	"github.com/google/oss-rebuild/internal/fileio"
 	"github.com/google/oss-rebuild/internal/syncx"
 	"github.com/google/oss-rebuild/pkg/build"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -322,9 +323,9 @@ func (e *DockerBuildExecutor) uploadAssets(ctx context.Context, plan *DockerBuil
 
 // uploadFile uploads a local file to the asset store.
 func (e *DockerBuildExecutor) uploadFile(ctx context.Context, store rebuild.AssetStore, asset rebuild.Asset, filePath string) error {
-	file, err := os.Open(filePath)
+	file, err := fileio.OpenRegular(filePath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open file %s", filePath)
+		return errors.Wrapf(err, "failed to open file for upload %s", filePath)
 	}
 	defer file.Close()
 	writer, err := store.Writer(ctx, asset)

--- a/pkg/build/local/run_executor.go
+++ b/pkg/build/local/run_executor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/bufiox"
+	"github.com/google/oss-rebuild/internal/fileio"
 	"github.com/google/oss-rebuild/internal/syncx"
 	"github.com/google/oss-rebuild/pkg/build"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -308,9 +309,9 @@ func (e *DockerRunExecutor) executeBuild(ctx context.Context, handle *localHandl
 
 // uploadFile uploads a local file to the asset store
 func (e *DockerRunExecutor) uploadFile(ctx context.Context, store rebuild.AssetStore, asset rebuild.Asset, filePath string) error {
-	file, err := os.Open(filePath)
+	file, err := fileio.OpenRegular(filePath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open file %s", filePath)
+		return errors.Wrapf(err, "failed to open file for upload %s", filePath)
 	}
 	defer file.Close()
 	writer, err := store.Writer(ctx, asset)

--- a/pkg/build/local/upload_file_test.go
+++ b/pkg/build/local/upload_file_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+func TestDockerRunExecutorUploadFileRejectsSymlink(t *testing.T) {
+	assertUploadFileRejectsSymlink(t, func(ctx context.Context, store rebuild.AssetStore, asset rebuild.Asset, filePath string) error {
+		return (&DockerRunExecutor{}).uploadFile(ctx, store, asset, filePath)
+	})
+}
+
+func TestDockerBuildExecutorUploadFileRejectsSymlink(t *testing.T) {
+	assertUploadFileRejectsSymlink(t, func(ctx context.Context, store rebuild.AssetStore, asset rebuild.Asset, filePath string) error {
+		return (&DockerBuildExecutor{}).uploadFile(ctx, store, asset, filePath)
+	})
+}
+
+func assertUploadFileRejectsSymlink(t *testing.T, upload func(context.Context, rebuild.AssetStore, rebuild.Asset, string) error) {
+	t.Helper()
+	base := t.TempDir()
+	outside := filepath.Join(base, "outside-file")
+	if err := os.WriteFile(outside, []byte("outside marker"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(base, "artifact.tgz")
+	if err := os.Symlink(outside, src); err != nil {
+		t.Fatal(err)
+	}
+
+	store := rebuild.NewFilesystemAssetStore(memfs.New())
+	asset := rebuild.RebuildAsset.For(rebuild.Target{
+		Ecosystem: rebuild.NPM,
+		Package:   "test-pkg",
+		Version:   "1.0.0",
+		Artifact:  "artifact.tgz",
+	})
+	err := upload(context.Background(), store, asset, src)
+	if err == nil {
+		t.Fatal("uploadFile succeeded for symlink source, want error")
+	}
+	if !strings.Contains(err.Error(), "failed to open regular file") {
+		t.Fatalf("uploadFile error = %v, want regular file error", err)
+	}
+	if _, readErr := store.Reader(context.Background(), asset); readErr == nil {
+		t.Fatal("asset store contains rejected symlink source")
+	}
+}


### PR DESCRIPTION
## Summary

This change rejects symlink and other non-regular local files before uploading rebuild artifacts to an asset store.

The upload paths previously opened local upload sources with `os.Open`, which follows symlinks. This patch adds `internal/fileio.OpenRegular`, uses `O_NOFOLLOW` on Unix, verifies the opened handle is a regular file, and wires it into:

- `cmd/gsutil_writeonly.copyFile` for local source uploads;
- `DockerRunExecutor.uploadFile`;
- `DockerBuildExecutor.uploadFile`.

## Tests

```bash
go test ./internal/fileio ./cmd/gsutil_writeonly ./pkg/build/local
go mod tidy -diff
```
