### PR TITLE
Limit version-override prefix flag

### DIFF
--- a/pkg/rebuild/npm/strategy.go
+++ b/pkg/rebuild/npm/strategy.go
@@ -110,7 +110,7 @@ var toolkit = []*flow.Tool{
 			Runs: textwrap.Dedent(`
 				{{if ne .With.version "" -}}
 				{{- /* NOTE: Prefer builtin npm for 'npm version' as it wasn't introduced until NPM v6. */ -}}
-				PATH=/usr/bin:/bin:/usr/local/bin npm version --ignore-scripts --prefix {{.With.dir}} --no-git-tag-version {{.With.version}}
+				PATH=/usr/bin:/bin:/usr/local/bin npm version --ignore-scripts{{if and (ne .With.dir ".") (ne .With.dir "")}} --prefix {{.With.dir}}{{end}} --no-git-tag-version {{.With.version}}
 				{{- end -}}`)[1:],
 			Needs: []string{"npm"},
 		}},


### PR DESCRIPTION
This brings version-override to parity with the other npm steps which
condition on a non-empty, non-current directory to include the --prefix
flag.