### PR TITLE
pkg/archive: reject symlinks that escape the extraction root in ExtractTar

### DIFF
--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -56,9 +56,18 @@ func ExtractTar(tr *tar.Reader, fs billy.Filesystem, opt ExtractOptions) error {
 		}
 		skip := slices.Contains(strings.Split(path, string(filepath.Separator)), "..")
 		if h.Linkname != "" {
+			if skip {
+				continue
+			}
 			linkpath, err := filepath.Rel(basepath, h.Linkname)
+			// filepath.Rel errors on absolute Linkname paths (e.g. "/etc/passwd")
+			// that cannot be made relative to basepath; skip such entries.
 			if err != nil {
-				return err
+				continue
+			}
+			// Reject symlink targets that escape the extraction root.
+			if slices.Contains(strings.Split(linkpath, string(filepath.Separator)), "..") {
+				continue
 			}
 			if err := fs.Symlink(linkpath, path); err != nil {
 				return err

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+)
+
+// buildTarWithSymlink creates a tar reader containing a single symlink entry.
+func buildTarWithSymlink(name, linkname string) *tar.Reader {
+	buf := &bytes.Buffer{}
+	tw := tar.NewWriter(buf)
+	_ = tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeSymlink,
+		Name:     name,
+		Linkname: linkname,
+	})
+	_ = tw.Close()
+	return tar.NewReader(bytes.NewReader(buf.Bytes()))
+}
+
+// TestExtractTarSymlinkTraversal verifies that symlink entries whose destination
+// path or target escapes the extraction root are silently skipped rather than
+// written to the filesystem.
+func TestExtractTarSymlinkTraversal(t *testing.T) {
+	tests := []struct {
+		desc     string
+		name     string
+		linkname string
+	}{
+		{
+			desc:     "symlink destination escapes via dotdot",
+			name:     "../../evil",
+			linkname: "safe_target",
+		},
+		{
+			desc:     "symlink target escapes via dotdot",
+			name:     "safe_link",
+			linkname: "../../../../etc/passwd",
+		},
+		{
+			desc:     "symlink target is absolute path",
+			name:     "safe_link2",
+			linkname: "/etc/passwd",
+		},
+		{
+			desc:     "both name and target escape",
+			name:     "../../link",
+			linkname: "../../../../etc/shadow",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			fs := memfs.New()
+			tr := buildTarWithSymlink(tc.name, tc.linkname)
+			if err := ExtractTar(tr, fs, ExtractOptions{SubDir: "."}); err != nil {
+				t.Fatalf("ExtractTar() returned unexpected error: %v", err)
+			}
+			// Verify that no symlink was created inside the memfs root.
+			entries, _ := fs.ReadDir(filepath.Clean("."))
+			if len(entries) != 0 {
+				t.Errorf("ExtractTar() created %d unexpected entries in root: %v", len(entries), entries)
+			}
+		})
+	}
+}
+
+// TestExtractTarSymlinkSafe verifies that a well-formed symlink (both name and
+// target within the extraction root) is extracted successfully.
+func TestExtractTarSymlinkSafe(t *testing.T) {
+	fs := memfs.New()
+	tr := buildTarWithSymlink("mylink", "target_file")
+	if err := ExtractTar(tr, fs, ExtractOptions{SubDir: "."}); err != nil {
+		t.Fatalf("ExtractTar() returned unexpected error: %v", err)
+	}
+	entries, err := fs.ReadDir(filepath.Clean("."))
+	if err != nil {
+		t.Fatalf("ReadDir() error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("ExtractTar() created %d entries, want 1", len(entries))
+	}
+}

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package archive
+package archive_test
 
 import (
 	"archive/tar"
@@ -10,29 +10,19 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/pkg/archive"
+	"github.com/google/oss-rebuild/pkg/archive/archivetest"
 )
 
-// buildTarWithSymlink creates a tar reader containing a single symlink entry.
-func buildTarWithSymlink(name, linkname string) *tar.Reader {
-	buf := &bytes.Buffer{}
-	tw := tar.NewWriter(buf)
-	_ = tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeSymlink,
-		Name:     name,
-		Linkname: linkname,
-	})
-	_ = tw.Close()
-	return tar.NewReader(bytes.NewReader(buf.Bytes()))
-}
-
-// TestExtractTarSymlinkTraversal verifies that symlink entries whose destination
-// path or target escapes the extraction root are silently skipped rather than
-// written to the filesystem.
-func TestExtractTarSymlinkTraversal(t *testing.T) {
+// TestExtractTarSymlink verifies that symlink entries whose destination path
+// or target escapes the extraction root are silently skipped, while
+// well-formed symlinks within the root are extracted.
+func TestExtractTarSymlink(t *testing.T) {
 	tests := []struct {
-		desc     string
-		name     string
-		linkname string
+		desc        string
+		name        string
+		linkname    string
+		wantEntries int
 	}{
 		{
 			desc:     "symlink destination escapes via dotdot",
@@ -54,36 +44,34 @@ func TestExtractTarSymlinkTraversal(t *testing.T) {
 			name:     "../../link",
 			linkname: "../../../../etc/shadow",
 		},
+		{
+			desc:        "well-formed symlink within root",
+			name:        "mylink",
+			linkname:    "target_file",
+			wantEntries: 1,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
+			buf, err := archivetest.TarFile([]archive.TarEntry{{
+				Header: &tar.Header{
+					Typeflag: tar.TypeSymlink,
+					Name:     tc.name,
+					Linkname: tc.linkname,
+				},
+			}})
+			if err != nil {
+				t.Fatalf("TarFile() error: %v", err)
+			}
 			fs := memfs.New()
-			tr := buildTarWithSymlink(tc.name, tc.linkname)
-			if err := ExtractTar(tr, fs, ExtractOptions{SubDir: "."}); err != nil {
+			tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+			if err := archive.ExtractTar(tr, fs, archive.ExtractOptions{SubDir: "."}); err != nil {
 				t.Fatalf("ExtractTar() returned unexpected error: %v", err)
 			}
-			// Verify that no symlink was created inside the memfs root.
 			entries, _ := fs.ReadDir(filepath.Clean("."))
-			if len(entries) != 0 {
-				t.Errorf("ExtractTar() created %d unexpected entries in root: %v", len(entries), entries)
+			if len(entries) != tc.wantEntries {
+				t.Errorf("ExtractTar() created %d entries, want %d: %v", len(entries), tc.wantEntries, entries)
 			}
 		})
-	}
-}
-
-// TestExtractTarSymlinkSafe verifies that a well-formed symlink (both name and
-// target within the extraction root) is extracted successfully.
-func TestExtractTarSymlinkSafe(t *testing.T) {
-	fs := memfs.New()
-	tr := buildTarWithSymlink("mylink", "target_file")
-	if err := ExtractTar(tr, fs, ExtractOptions{SubDir: "."}); err != nil {
-		t.Fatalf("ExtractTar() returned unexpected error: %v", err)
-	}
-	entries, err := fs.ReadDir(filepath.Clean("."))
-	if err != nil {
-		t.Fatalf("ReadDir() error: %v", err)
-	}
-	if len(entries) != 1 {
-		t.Errorf("ExtractTar() created %d entries, want 1", len(entries))
 	}
 }


### PR DESCRIPTION
## Summary

`ExtractTar` in `pkg/archive/tar.go` has two symlink path-traversal bypasses:

**Bypass 1 — symlink destination escapes the skip guard:**
The `if h.Linkname != ""` branch executes before the `if skip` check. A tar entry with `Name = "../../evil"` sets `skip = true`, but the symlink is still created because the skip guard only covers the `IsDir()` and regular-file branches.

**Bypass 2 — symlink target is not validated:**
`filepath.Rel(basepath, h.Linkname)` is called but its result is never checked for `..` components. A tar entry with `Name = "safe_link"` (skip=false) and `Linkname = "../../../../etc/passwd"` creates a symlink pointing outside the extraction root. An absolute `Linkname` (e.g. `/etc/passwd`) causes `filepath.Rel` to return an error that was previously propagated rather than handled.

Since `osfs.Symlink` calls `os.Symlink` directly (no chroot), the resulting symlink on the host filesystem is followed by subsequent `go-git` operations (`Open`, `Checkout`) outside `tmpDir`.

**Attack scenario:** A compromised or MITM'd gitcache server (or GCS bucket poisoning) serves a malicious `.tar.gz`. The rebuilder worker extracts it, creating a dangling symlink. Subsequent git operations follow the symlink outside the sandbox — enabling arbitrary file read/write on the rebuilder host.

## Fix

- Move the `skip` check to cover the symlink branch.
- Skip entries where `filepath.Rel` returns an error (absolute `Linkname`).
- Skip entries where the resolved `linkpath` contains `..` components.

## Tests

Added `TestExtractTarSymlinkTraversal` covering four escape patterns (dotdot name, dotdot target, absolute target, both) and `TestExtractTarSymlinkSafe` as a regression guard for well-formed symlinks.