### PR TITLE
Handle anchor URLs specifically to prevent navigating to site root in render-link.html

### DIFF
--- a/docs/layouts/_default/_markup/render-link.html
+++ b/docs/layouts/_default/_markup/render-link.html
@@ -17,5 +17,10 @@
   {{- end -}}
 {{- else -}}
   {{- /* Not a .md link, pass through normally */ -}}
-  <a href="{{ $destination | relURL }}"{{- with $title }} title="{{ . }}"{{- end }}>{{ $text | safeHTML }}</a>
+  {{- $href := $destination | relURL -}}
+  {{- if strings.HasPrefix $destination "#" -}}
+    {{- /* Bypass relURL for bare anchors to prevent navigating to the site root */ -}}
+    {{- $href = $destination -}}
+  {{- end -}}
+  <a href="{{ $href }}"{{- with $title }} title="{{ . }}"{{- end }}>{{ $text | safeHTML }}</a>
 {{- end -}}


### PR DESCRIPTION
Ref: https://docs.oss-rebuild.dev/builds/ArtifactEquivalence@v0.1/  "section below" is transformed by hugo to `<a href="/#artifact-stabilization-details">section below</a>`.

Feel free to suggest if there are simpler ways to do this or to discard if there are other plans to handle this, etc.