### PR TITLE
ci: add explicit contents: read permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -8,6 +8,9 @@ on:
     branches: ["main"]
     paths: ["**/*.tf"]
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,6 +8,9 @@ on:
     branches: ["main"]
     paths: ["**/*.md", "**/*.yml", "**/*.yaml"]
 
+permissions:
+  contents: read
+
 jobs:
   prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`gh-pages.yml` in this repo declares `permissions:` explicitly; the other three CI workflows leave it implicit. This makes them consistent.

- `go.yml` — go build/test/lint/format/imports/license-check on the matrix. Reads only.
- `opentofu.yml` — `tofu fmt -check`. Reads only.
- `prettier.yml` — `prettier --check`. Reads only.

None of them push commits, comment, or call any GitHub write endpoint. `contents: read` is the minimum scope needed for the `actions/checkout` step.