### PR TITLE
docs: fix two typos in content docs

### DIFF
--- a/docs/content/development.md
+++ b/docs/content/development.md
@@ -12,7 +12,7 @@ This guide provides a comprehensive overview of how to run and develop OSS Rebui
 
 Benchmarks are the core unit of work for OSS Rebuild systems. They define specific sets of ecosystem, packages, versions, and artifacts to be rebuilt and verified. Taken together, these four values (ecosystem, package, version, artifact name) combine to represent a single rebuild goal, which OSS Rebuild refers to as a "Target".
 
-Benchmark files themselves are JSON documents that provide a structured manifest which runners use to orchestrate builds. The structure is definined in (defined in tools/benchmark/benchmark.go)
+Benchmark files themselves are JSON documents that provide a structured manifest which runners use to orchestrate builds. The structure is defined in (defined in tools/benchmark/benchmark.go)
 
 For example, a benchmark with one package and version would look like this:
 

--- a/docs/content/stabilizers.md
+++ b/docs/content/stabilizers.md
@@ -57,7 +57,7 @@ The full stabilization process is simply the composition of all configured stabi
 stabilization(package) = stabilizerN(...(stabilizer2(stabilizer1(package))))
 ```
 
-And the equivalence between two pacakges is then the equality of their
+And the equivalence between two packages is then the equality of their
 independent stabilizations:
 
 ```


### PR DESCRIPTION
Two small typos in `docs/content/`:

- `development.md` line 15: `definined` → `defined`
- `stabilizers.md` line 60: `pacakges` → `packages`

Codespell also flagged `intoto` in `storage.md` and `builds/NetworkRebuild@v0.1.md`, but `in-toto` is the [supply-chain attestation framework](https://in-toto.io/), so that one is deliberately left alone.