### PR TITLE
Fix docs linkification

### DIFF
--- a/docs/layouts/_default/_markup/render-link.html
+++ b/docs/layouts/_default/_markup/render-link.html
@@ -7,15 +7,14 @@
 {{- $title := .Title -}}
 {{- $text := .Text -}}
 
-{{- if strings.HasSuffix $destination ".md" -}}
-  {{- $destination = strings.TrimSuffix ".md" $destination -}}
-  {{- with .Page.GetPage $destination -}}
-    <a href="{{ .RelPermalink }}"{{- with $title }} title="{{ . }}"{{- end }}>{{ $text | safeHTML }}</a>
-  {{- else -}}
-    {{- /* Fallback if page not found - use destination as-is */ -}}
-    <a href="{{ $destination | relURL }}"{{- with $title }} title="{{ . }}"{{- end }}>{{ $text | safeHTML }}</a>
+{{- $href := $destination -}}
+{{- $u := urls.Parse $destination -}}
+{{- if and (not $u.IsAbs) (strings.HasSuffix $u.Path ".md") -}}
+  {{- /* Rewrite relative .md links to permalinks */ -}}
+  {{- with .Page.GetPage (strings.TrimSuffix ".md" $u.Path) -}}
+    {{- $href = .RelPermalink -}}
+    {{- with $u.RawQuery }}{{- $href = printf "%s?%s" $href . -}}{{- end -}}
+    {{- with $u.Fragment }}{{- $href = printf "%s#%s" $href . -}}{{- end -}}
   {{- end -}}
-{{- else -}}
-  {{- /* Not a .md link, pass through normally */ -}}
-  <a href="{{ $destination | relURL }}"{{- with $title }} title="{{ . }}"{{- end }}>{{ $text | safeHTML }}</a>
 {{- end -}}
+<a href="{{ $href | safeURL }}"{{- with $title }} title="{{ . }}"{{- end }}>{{ $text | safeHTML }}</a>{{- "" -}}


### PR DESCRIPTION
As surfaced in #1255, the previous version broke anchor links (#foo -> /#foo)
and also all markdown links of remote URLs
(github.com/foo/bar/blob/main/README.md -> .md stripped leading to 404).
This new linkifier only targets the site-local markdown links we'd initially
intended to fix.

The new version parses the URL to isolate rewrites to relative markdown
links. We then reconstruct it and materialize the link in the same
callsite as all others.