### PR TITLE
Refactor web fetch to only use curl

### DIFF
--- a/pkg/build/gcb/planner.go
+++ b/pkg/build/gcb/planner.go
@@ -244,7 +244,7 @@ var gcbDockerfileTpl = template.Must(
 	template.New("gcb dockerfile").Funcs(template.FuncMap{
 		"indent": func(s string) string { return strings.ReplaceAll(s, "\n", "\n ") },
 		"join":   func(sep string, s []string) string { return strings.Join(s, sep) },
-		"list":   func(s string) []string { return []string{s} },
+		"list":   func(items ...string) []string { return items },
 	}).Parse(
 		textwrap.Dedent(`
 			#syntax=docker/dockerfile:1.10
@@ -252,20 +252,17 @@ var gcbDockerfileTpl = template.Must(
 			RUN {{if or .TimewarpAuth .ProxyAuth}}--mount=type=secret,id=auth_header {{end}}sed 's/^ //' <<'EOF' | sh
 			 set -eux
 			{{- if .UseTimewarp}}
-			 {{- $hasCurl := or (eq .OS "debian") (eq .OS "ubuntu")}}
-			 {{- $hasWget := eq .OS "alpine"}}
-			 {{- if .TimewarpAuth}}
-			 {{if not $hasCurl}}{{.PackageManager.InstallCommand (list "curl")}} && {{end}}curl -H @/run/secrets/auth_header {{.TimewarpURL}} > timewarp
-			 {{- else if $hasWget}}
-			 wget -O timewarp {{.TimewarpURL}}
-			 {{- else if $hasCurl}}
-			 curl {{.TimewarpURL}} > timewarp
-			 {{- end}}
-			 chmod +x timewarp
-			{{- end}}
-			 {{- if eq .OS "debian"}}
+			 {{- if eq .OS "alpine"}}
+			 {{.PackageManager.InstallCommand (list "curl")}}
+			 {{- else}}
 			 {{.PackageManager.UpdateCmd}}
+			 {{.PackageManager.InstallCommand (list "curl" "netcat-openbsd")}}
 			 {{- end}}
+			 curl {{if .TimewarpAuth}}-H @/run/secrets/auth_header {{end}}{{.TimewarpURL}} > timewarp
+			 chmod +x timewarp
+			{{- else if eq .OS "debian"}}
+			 {{.PackageManager.UpdateCmd}}
+			{{- end}}
 			 {{.PackageManager.InstallCommand .Instructions.Requires.SystemDeps}}
 			EOF
 			RUN sed 's/^ //' <<'EOF' | sh

--- a/pkg/build/gcb/planner_test.go
+++ b/pkg/build/gcb/planner_test.go
@@ -30,6 +30,9 @@ func TestMakeDockerfile(t *testing.T) {
 	baseImageConfig := build.BaseImageConfig{
 		Default: "docker.io/library/alpine:3.19",
 	}
+	debianBaseImageConfig := build.BaseImageConfig{
+		Default: "docker.io/library/debian:stable-20251103-slim",
+	}
 
 	testCases := []testCase{
 		{
@@ -103,7 +106,8 @@ ENTRYPOINT ["/bin/sh","/build"]
 FROM docker.io/library/alpine:3.19
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux
- wget -O timewarp https://my-bucket.storage.googleapis.com/timewarp
+ apk add curl
+ curl https://my-bucket.storage.googleapis.com/timewarp > timewarp
  chmod +x timewarp
  apk add git make
 EOF
@@ -154,9 +158,115 @@ ENTRYPOINT ["/bin/sh","/build"]
 FROM docker.io/library/alpine:3.19
 RUN --mount=type=secret,id=auth_header sed 's/^ //' <<'EOF' | sh
  set -eux
- apk add curl && curl -H @/run/secrets/auth_header https://my-bucket.storage.googleapis.com/timewarp > timewarp
+ apk add curl
+ curl -H @/run/secrets/auth_header https://my-bucket.storage.googleapis.com/timewarp > timewarp
  chmod +x timewarp
  apk add git make
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ ./timewarp -port 8080 &
+ while ! nc -z localhost 8080;do sleep 1;done
+ mkdir /src && cd /src
+ git clone github.com/example .
+ git checkout --force 'main'
+ make deps ...
+EOF
+RUN sed 's/^ //' <<'EOF' >/build
+ set -eux
+ make build ...
+ mkdir /out && cp /src/output/foo.tgz /out/
+EOF
+WORKDIR "/src"
+ENTRYPOINT ["/bin/sh","/build"]
+`,
+		},
+		{
+			name: "Debian base, with Timewarp",
+			input: rebuild.Input{
+				Target: rebuild.Target{},
+				Strategy: &rebuild.ManualStrategy{
+					Location: rebuild.Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
+					Requires: rebuild.RequiredEnv{
+						SystemDeps: []string{"git", "make"},
+					},
+					Deps:       "make deps ...",
+					Build:      "make build ...",
+					OutputPath: "output/foo.tgz",
+				},
+			},
+			opts: build.PlanOptions{
+				UseTimewarp:     true,
+				UseNetworkProxy: false,
+				Resources: build.Resources{
+					BaseImageConfig: debianBaseImageConfig,
+					ToolURLs: map[build.ToolType]string{
+						build.TimewarpTool: "https://my-bucket.storage.googleapis.com/timewarp",
+					},
+				},
+			},
+			expected: `#syntax=docker/dockerfile:1.10
+FROM docker.io/library/debian:stable-20251103-slim
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ apt update
+ apt install -y curl netcat-openbsd
+ curl https://my-bucket.storage.googleapis.com/timewarp > timewarp
+ chmod +x timewarp
+ apt install -y git make
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ ./timewarp -port 8080 &
+ while ! nc -z localhost 8080;do sleep 1;done
+ mkdir /src && cd /src
+ git clone github.com/example .
+ git checkout --force 'main'
+ make deps ...
+EOF
+RUN sed 's/^ //' <<'EOF' >/build
+ set -eux
+ make build ...
+ mkdir /out && cp /src/output/foo.tgz /out/
+EOF
+WORKDIR "/src"
+ENTRYPOINT ["/bin/sh","/build"]
+`,
+		},
+		{
+			name: "Debian base, with Timewarp and auth",
+			input: rebuild.Input{
+				Target: rebuild.Target{},
+				Strategy: &rebuild.ManualStrategy{
+					Location: rebuild.Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
+					Requires: rebuild.RequiredEnv{
+						SystemDeps: []string{"git", "make"},
+					},
+					Deps:       "make deps ...",
+					Build:      "make build ...",
+					OutputPath: "output/foo.tgz",
+				},
+			},
+			opts: build.PlanOptions{
+				UseTimewarp:     true,
+				UseNetworkProxy: false,
+				Resources: build.Resources{
+					BaseImageConfig: debianBaseImageConfig,
+					ToolURLs: map[build.ToolType]string{
+						build.TimewarpTool: "https://my-bucket.storage.googleapis.com/timewarp",
+					},
+					ToolAuthRequired: []string{"https://my-bucket.storage.googleapis.com/"},
+				},
+			},
+			expected: `#syntax=docker/dockerfile:1.10
+FROM docker.io/library/debian:stable-20251103-slim
+RUN --mount=type=secret,id=auth_header sed 's/^ //' <<'EOF' | sh
+ set -eux
+ apt update
+ apt install -y curl netcat-openbsd
+ curl -H @/run/secrets/auth_header https://my-bucket.storage.googleapis.com/timewarp > timewarp
+ chmod +x timewarp
+ apt install -y git make
 EOF
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux

--- a/pkg/build/local/build_planner.go
+++ b/pkg/build/local/build_planner.go
@@ -32,7 +32,7 @@ var dockerBuildDockerfileTpl = template.Must(
 	template.New("docker build dockerfile").Funcs(template.FuncMap{
 		"indent": func(s string) string { return strings.ReplaceAll(s, "\n", "\n ") },
 		"join":   func(sep string, s []string) string { return strings.Join(s, sep) },
-		"list":   func(s string) []string { return []string{s} },
+		"list":   func(items ...string) []string { return items },
 	}).Parse(
 		textwrap.Dedent(`
 			#syntax=docker/dockerfile:1.10
@@ -40,15 +40,13 @@ var dockerBuildDockerfileTpl = template.Must(
 			RUN {{if .TimewarpAuth}}--mount=type=secret,id=auth_header {{end}} sed 's/^ //' <<'EOF' | sh
 			 set -eux
 			{{- if .UseTimewarp}}
-			 {{- $hasCurl := or (eq .OS "debian") (eq .OS "ubuntu")}}
-			 {{- $hasWget := eq .OS "alpine"}}
-			 {{- if .TimewarpAuth}}
-			 {{if not $hasCurl}}{{.PackageManager.InstallCommand (list "curl" "netcat-openbsd")}} && {{end}}curl -H @/run/secrets/auth_header
-			 {{- else if $hasWget}}
-			 wget -O -
-			 {{- else if $hasCurl}}
-			 curl
-			 {{- end}} {{.TimewarpURL}} > timewarp
+			 {{- if eq .OS "alpine"}}
+			 {{.PackageManager.InstallCommand (list "curl")}}
+			 {{- else}}
+			 {{.PackageManager.UpdateCmd}}
+			 {{.PackageManager.InstallCommand (list "curl" "netcat-openbsd")}}
+			 {{- end}}
+			 curl {{if .TimewarpAuth}}-H @/run/secrets/auth_header {{end}}{{.TimewarpURL}} > timewarp
 			 chmod +x timewarp
 			{{- end}}
 			 {{.PackageManager.UpdateCmd}}


### PR DESCRIPTION
Debian slim doesn't provide any web / TLS capabilities by default. For
cases where we need to fetch e.g. timewarp during the build, we need
this ability. The options are to either continue to prefer wget where
possible or to move to curl unconditionally. The latter ends up being
roughly similar in time (+8s for debian, +2s for alpine), gives us
modern TLS support, file-based header inclusion, and a more actively
supported dependency.