### PR TITLE
Handle equivalent .dist-info names in PyPI wheel inference

### DIFF
--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"path"
 	re "regexp"
 	"slices"
 	"strconv"
@@ -37,6 +38,8 @@ var commonRepoLinks = []string{
 	"project",
 	"github",
 }
+
+var distInfoFieldPat = re.MustCompile(`[-_.]+`)
 
 // There are two places to find the repo:
 // 1. In the ProjectURLs (project links)
@@ -164,10 +167,7 @@ func FindSourceDist(artifacts []pypireg.Artifact) (*pypireg.Artifact, error) {
 }
 
 func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
-	// Name and version have "-" replaced with "_". See https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory
-	// TODO: Search for dist-info in the gzip using a regex. It sounds like many tools do varying amounts of normalization on the path name.
-	wheelPath := fmt.Sprintf("%s-%s.dist-info/WHEEL", strings.ReplaceAll(name, "-", "_"), strings.ReplaceAll(version, "-", "_"))
-	wheel, err := getFile(wheelPath, zr)
+	wheel, wheelPath, err := getDistInfoFile(name, version, "WHEEL", zr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream %s", wheelPath)
 	}
@@ -180,9 +180,7 @@ func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
 		// setuptools already set.
 		return reqs, nil
 	}
-	// TODO: Also find this with a regex.
-	metadataPath := fmt.Sprintf("%s-%s.dist-info/METADATA", strings.ReplaceAll(name, "-", "_"), strings.ReplaceAll(version, "-", "_"))
-	metadata, err := getFile(metadataPath, zr)
+	metadata, _, err := getDistInfoFile(name, version, "METADATA", zr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream dist-info/METADATA")
 	}
@@ -201,6 +199,50 @@ func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
 		reqs = append(reqs, "setuptools==67.7.2")
 	}
 	return reqs, nil
+}
+
+func normalizeDistInfoName(name string) string {
+	normalized := distInfoFieldPat.ReplaceAllString(name, "-")
+	return strings.ReplaceAll(strings.ToLower(normalized), "-", "_")
+}
+
+func normalizeDistInfoVersion(version string) string {
+	return strings.ReplaceAll(strings.ToLower(version), "-", "_")
+}
+
+func getDistInfoFile(name, version, fileName string, zr *zip.Reader) ([]byte, string, error) {
+	expectedPath := fmt.Sprintf("%s-%s.dist-info/%s", normalizeDistInfoName(name), normalizeDistInfoVersion(version), fileName)
+	b, err := getFile(expectedPath, zr)
+	if err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return b, expectedPath, err
+	}
+	for _, f := range zr.File {
+		if path.Base(f.Name) != fileName {
+			continue
+		}
+		if strings.Count(f.Name, "/") != 1 {
+			continue
+		}
+		dir := path.Base(path.Dir(f.Name))
+		stem, ok := strings.CutSuffix(dir, ".dist-info")
+		if !ok {
+			continue
+		}
+		dash := strings.LastIndexByte(stem, '-')
+		if dash == -1 {
+			continue
+		}
+		foundName, foundVersion := stem[:dash], stem[dash+1:]
+		if normalizeDistInfoName(foundName) != normalizeDistInfoName(name) {
+			continue
+		}
+		if normalizeDistInfoVersion(foundVersion) != normalizeDistInfoVersion(version) {
+			continue
+		}
+		b, err := getFile(f.Name, zr)
+		return b, f.Name, err
+	}
+	return nil, expectedPath, fs.ErrNotExist
 }
 
 func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, rcfg *rebuild.RepoConfig, hint rebuild.Strategy) (rebuild.Strategy, error) {

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -167,7 +167,13 @@ func FindSourceDist(artifacts []pypireg.Artifact) (*pypireg.Artifact, error) {
 }
 
 func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
-	wheel, wheelPath, err := getDistInfoFile(name, version, "WHEEL", zr)
+	distInfoDir, err := getDistInfoDir(name, version, zr)
+	if err != nil {
+		wheelPath := path.Join(expectedDistInfoDir(name, version), "WHEEL")
+		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream %s", wheelPath)
+	}
+	wheelPath := path.Join(distInfoDir, "WHEEL")
+	wheel, err := getFile(wheelPath, zr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream %s", wheelPath)
 	}
@@ -180,9 +186,10 @@ func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
 		// setuptools already set.
 		return reqs, nil
 	}
-	metadata, _, err := getDistInfoFile(name, version, "METADATA", zr)
+	metadataPath := path.Join(distInfoDir, "METADATA")
+	metadata, err := getFile(metadataPath, zr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream dist-info/METADATA")
+		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream %s", metadataPath)
 	}
 	switch {
 	case !bytes.Contains(metadata, []byte("License-File")):
@@ -201,6 +208,10 @@ func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
 	return reqs, nil
 }
 
+// Wheel dist-info names use escaped distribution/version components:
+// https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode
+// Name comparisons use PyPA name normalization:
+// https://packaging.python.org/en/latest/specifications/name-normalization/
 func normalizeDistInfoName(name string) string {
 	normalized := distInfoFieldPat.ReplaceAllString(name, "-")
 	return strings.ReplaceAll(strings.ToLower(normalized), "-", "_")
@@ -210,20 +221,22 @@ func normalizeDistInfoVersion(version string) string {
 	return strings.ReplaceAll(strings.ToLower(version), "-", "_")
 }
 
-func getDistInfoFile(name, version, fileName string, zr *zip.Reader) ([]byte, string, error) {
-	expectedPath := fmt.Sprintf("%s-%s.dist-info/%s", normalizeDistInfoName(name), normalizeDistInfoVersion(version), fileName)
-	b, err := getFile(expectedPath, zr)
-	if err == nil || !errors.Is(err, fs.ErrNotExist) {
-		return b, expectedPath, err
+func expectedDistInfoDir(name, version string) string {
+	return fmt.Sprintf("%s-%s.dist-info", normalizeDistInfoName(name), normalizeDistInfoVersion(version))
+}
+
+func getDistInfoDir(name, version string, zr *zip.Reader) (string, error) {
+	expectedDir := expectedDistInfoDir(name, version)
+	if hasZipDir(expectedDir, zr) {
+		return expectedDir, nil
 	}
+	// Older wheels may use equivalent but unescaped names with uppercase letters
+	// or "." separators; the wheel spec requires consumers to accept them.
 	for _, f := range zr.File {
-		if path.Base(f.Name) != fileName {
+		dir := path.Dir(f.Name)
+		if dir == "." || path.Dir(dir) != "." {
 			continue
 		}
-		if strings.Count(f.Name, "/") != 1 {
-			continue
-		}
-		dir := path.Base(path.Dir(f.Name))
 		stem, ok := strings.CutSuffix(dir, ".dist-info")
 		if !ok {
 			continue
@@ -239,10 +252,19 @@ func getDistInfoFile(name, version, fileName string, zr *zip.Reader) ([]byte, st
 		if normalizeDistInfoVersion(foundVersion) != normalizeDistInfoVersion(version) {
 			continue
 		}
-		b, err := getFile(f.Name, zr)
-		return b, f.Name, err
+		return dir, nil
 	}
-	return nil, expectedPath, fs.ErrNotExist
+	return "", fs.ErrNotExist
+}
+
+func hasZipDir(dir string, zr *zip.Reader) bool {
+	prefix := dir + "/"
+	for _, f := range zr.File {
+		if f.Name == dir || strings.HasPrefix(f.Name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, rcfg *rebuild.RepoConfig, hint rebuild.Strategy) (rebuild.Strategy, error) {

--- a/pkg/rebuild/pypi/infer_test.go
+++ b/pkg/rebuild/pypi/infer_test.go
@@ -4,6 +4,8 @@
 package pypi
 
 import (
+	"archive/zip"
+	"bytes"
 	"testing"
 )
 
@@ -72,4 +74,97 @@ func TestInferPythonVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInferRequirementsAcceptsEquivalentDistInfoNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		pkg     string
+		version string
+		files   map[string]string
+		want    []string
+	}{
+		{
+			name:    "exact normalized path",
+			pkg:     "friendly-bard",
+			version: "1.2.3",
+			files: map[string]string{
+				"friendly_bard-1.2.3.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
+				"friendly_bard-1.2.3.dist-info/METADATA": "Metadata-Version: 2.1\nName: friendly-bard\n",
+			},
+			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+		},
+		{
+			name:    "lowercased historical path",
+			pkg:     "128Autograder",
+			version: "5.2.3",
+			files: map[string]string{
+				"128autograder-5.2.3.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
+				"128autograder-5.2.3.dist-info/METADATA": "Metadata-Version: 2.1\nName: 128Autograder\n",
+			},
+			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+		},
+		{
+			name:    "dot and hyphen equivalence",
+			pkg:     "Friendly.Bard",
+			version: "2.0.0",
+			files: map[string]string{
+				"friendly_bard-2.0.0.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
+				"friendly_bard-2.0.0.dist-info/METADATA": "Metadata-Version: 2.1\nName: Friendly.Bard\n",
+			},
+			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+		},
+		{
+			name:    "historical uppercase hyphenated path",
+			pkg:     "friendly-bard",
+			version: "3.1.4",
+			files: map[string]string{
+				"Friendly-Bard-3.1.4.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
+				"Friendly-Bard-3.1.4.dist-info/METADATA": "Metadata-Version: 2.1\nName: friendly-bard\n",
+			},
+			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zr := testZipReader(t, tt.files)
+			got, err := inferRequirements(tt.pkg, tt.version, zr)
+			if err != nil {
+				t.Fatalf("inferRequirements() error = %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("inferRequirements() len = %d, want %d; got %v", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("inferRequirements()[%d] = %q, want %q; got %v", i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+func testZipReader(t *testing.T, files map[string]string) *zip.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("Create(%q): %v", name, err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatalf("Write(%q): %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("NewReader(): %v", err)
+	}
+	return zr
 }

--- a/pkg/rebuild/pypi/infer_test.go
+++ b/pkg/rebuild/pypi/infer_test.go
@@ -7,6 +7,9 @@ import (
 	"archive/zip"
 	"bytes"
 	"testing"
+
+	"github.com/google/oss-rebuild/pkg/archive"
+	"github.com/google/oss-rebuild/pkg/archive/archivetest"
 )
 
 func TestInferPythonVersion(t *testing.T) {
@@ -76,91 +79,83 @@ func TestInferPythonVersion(t *testing.T) {
 	}
 }
 
-func TestInferRequirementsAcceptsEquivalentDistInfoNames(t *testing.T) {
+func TestGetDistInfoDirAcceptsEquivalentNames(t *testing.T) {
 	tests := []struct {
 		name    string
 		pkg     string
 		version string
-		files   map[string]string
-		want    []string
+		files   []string
+		want    string
 	}{
 		{
 			name:    "exact normalized path",
 			pkg:     "friendly-bard",
 			version: "1.2.3",
-			files: map[string]string{
-				"friendly_bard-1.2.3.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
-				"friendly_bard-1.2.3.dist-info/METADATA": "Metadata-Version: 2.1\nName: friendly-bard\n",
+			files: []string{
+				"friendly_bard-1.2.3.dist-info/WHEEL",
+				"friendly_bard-1.2.3.dist-info/METADATA",
 			},
-			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+			want: "friendly_bard-1.2.3.dist-info",
 		},
 		{
 			name:    "lowercased historical path",
 			pkg:     "128Autograder",
 			version: "5.2.3",
-			files: map[string]string{
-				"128autograder-5.2.3.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
-				"128autograder-5.2.3.dist-info/METADATA": "Metadata-Version: 2.1\nName: 128Autograder\n",
+			files: []string{
+				"128autograder-5.2.3.dist-info/WHEEL",
+				"128autograder-5.2.3.dist-info/METADATA",
 			},
-			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+			want: "128autograder-5.2.3.dist-info",
 		},
 		{
 			name:    "dot and hyphen equivalence",
 			pkg:     "Friendly.Bard",
 			version: "2.0.0",
-			files: map[string]string{
-				"friendly_bard-2.0.0.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
-				"friendly_bard-2.0.0.dist-info/METADATA": "Metadata-Version: 2.1\nName: Friendly.Bard\n",
+			files: []string{
+				"friendly_bard-2.0.0.dist-info/WHEEL",
+				"friendly_bard-2.0.0.dist-info/METADATA",
 			},
-			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+			want: "friendly_bard-2.0.0.dist-info",
 		},
 		{
 			name:    "historical uppercase hyphenated path",
 			pkg:     "friendly-bard",
 			version: "3.1.4",
-			files: map[string]string{
-				"Friendly-Bard-3.1.4.dist-info/WHEEL":    "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.43.0)\nTag: py3-none-any\n",
-				"Friendly-Bard-3.1.4.dist-info/METADATA": "Metadata-Version: 2.1\nName: friendly-bard\n",
+			files: []string{
+				"Friendly-Bard-3.1.4.dist-info/WHEEL",
+				"Friendly-Bard-3.1.4.dist-info/METADATA",
 			},
-			want: []string{"wheel==0.43.0", "setuptools==56.2.0"},
+			want: "Friendly-Bard-3.1.4.dist-info",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			zr := testZipReader(t, tt.files)
-			got, err := inferRequirements(tt.pkg, tt.version, zr)
+			got, err := getDistInfoDir(tt.pkg, tt.version, zr)
 			if err != nil {
-				t.Fatalf("inferRequirements() error = %v", err)
+				t.Fatalf("getDistInfoDir() error = %v", err)
 			}
-			if len(got) != len(tt.want) {
-				t.Fatalf("inferRequirements() len = %d, want %d; got %v", len(got), len(tt.want), got)
-			}
-			for i := range tt.want {
-				if got[i] != tt.want[i] {
-					t.Fatalf("inferRequirements()[%d] = %q, want %q; got %v", i, got[i], tt.want[i], got)
-				}
+			if got != tt.want {
+				t.Fatalf("getDistInfoDir() = %q, want %q", got, tt.want)
 			}
 		})
 	}
 }
 
-func testZipReader(t *testing.T, files map[string]string) *zip.Reader {
+func testZipReader(t *testing.T, files []string) *zip.Reader {
 	t.Helper()
 
-	var buf bytes.Buffer
-	zw := zip.NewWriter(&buf)
-	for name, body := range files {
-		w, err := zw.Create(name)
-		if err != nil {
-			t.Fatalf("Create(%q): %v", name, err)
-		}
-		if _, err := w.Write([]byte(body)); err != nil {
-			t.Fatalf("Write(%q): %v", name, err)
-		}
+	entries := make([]archive.ZipEntry, 0, len(files))
+	for _, name := range files {
+		entries = append(entries, archive.ZipEntry{
+			FileHeader: &zip.FileHeader{Name: name},
+			Body:       []byte("data"),
+		})
 	}
-	if err := zw.Close(); err != nil {
-		t.Fatalf("Close(): %v", err)
+	buf, err := archivetest.ZipFile(entries)
+	if err != nil {
+		t.Fatalf("ZipFile(): %v", err)
 	}
 	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	if err != nil {


### PR DESCRIPTION
Fixes #1123

Follow-up to #1213; the original PR could not be reopened after the fork/head repository link was lost.

PyPI wheel inference currently assumes that `.dist-info` paths match the registry package name after replacing `-` with `_`. This breaks on wheels whose `.dist-info` directory uses an equivalent historical form, for example `128autograder-5.2.3.dist-info/WHEEL` for `128Autograder`.

This change first resolves the matching `.dist-info` directory, then uses that directory when reading `WHEEL` and `METADATA`. The fallback accepts equivalent historical name/version forms while remaining restricted to top-level `.dist-info` directories.

Added regression tests covering normalized and historical equivalent `.dist-info` names.

Validated with `go run ./ci -v build`, `go run ./ci -v test`, `go run ./ci -v lint`, `go run ./ci -v fmt-check`, and `go run ./ci -v imports-check`.