### PR TITLE
Remove X-Compile-Release-JDK from JAR metadata

### DIFF
--- a/pkg/stabilize/jar.go
+++ b/pkg/stabilize/jar.go
@@ -100,6 +100,7 @@ var StableJARBuildMetadata = Stabilizer{
 		"TODAY",
 		"Tool",
 		"TSTAMP",
+		"X-Compile-Release-JDK",
 		"url",
 	} {
 		manifest.MainSection.Delete(attr)

--- a/pkg/stabilize/jar_test.go
+++ b/pkg/stabilize/jar_test.go
@@ -121,6 +121,7 @@ func TestStableJARBuildMetadata(t *testing.T) {
 							"SCM-Git-Commit-Description: feat: new feature\r\n" +
 							"SCM-Git-Commit-Timestamp: 1671890378\r\n" +
 							"Source-Date-Epoch: 1671890378\r\n" +
+							"X-Compile-Release-JDK: 8\r\n" +
 							"Implementation-Title: Test Project\r\n" +
 							"Implementation-Version: 1.0.0\r\n\r\n"),
 				},


### PR DESCRIPTION
Fixes #426.

`X-Compile-Release-JDK` is build metadata emitted in JAR manifests and can vary across rebuilds. Treat it like the existing JDK build metadata attributes by removing it in `jar-build-metadata`.

Testing:
- `go test ./pkg/stabilize -count=1`
- `go run ./ci -v fmt-check`
- `go run ./ci -v imports-check`
- `go run ./ci -v build`
- `go run ./ci -v test`
- `go run ./ci -v lint`
- `go run ./ci -v license-check`
