### PR TITLE
Handle JAR manifest attributes case-insensitively

### DIFF
--- a/pkg/stabilize/jar_test.go
+++ b/pkg/stabilize/jar_test.go
@@ -88,6 +88,24 @@ func TestStableJARBuildMetadata(t *testing.T) {
 			},
 		},
 		{
+			test: "build_metadata_attribute_names_are_case_insensitive",
+			input: []*archive.ZipEntry{
+				{
+					FileHeader: &zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					Body: []byte("Manifest-Version: 1.0\r\n" +
+						"Build-Os: Linux\r\n" +
+						"Scm-Revision: abcdef\r\n" +
+						"Implementation-Title: Test Project\r\n\r\n"),
+				},
+			},
+			expected: []*archive.ZipEntry{
+				{
+					FileHeader: &zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					Body:       []byte("Manifest-Version: 1.0\r\nImplementation-Title: Test Project\r\n\r\n"),
+				},
+			},
+		},
+		{
 			test: "all_build_metadata_attributes",
 			input: []*archive.ZipEntry{
 				{

--- a/pkg/stabilize/manifest.go
+++ b/pkg/stabilize/manifest.go
@@ -32,30 +32,43 @@ func NewSection() *Section {
 	}
 }
 
+func (s *Section) attributeName(name string) (string, bool) {
+	for _, existing := range s.Names {
+		if strings.EqualFold(existing, name) {
+			return existing, true
+		}
+	}
+	return "", false
+}
+
 // Set adds or updates an attribute while maintaining order
 func (s *Section) Set(name, value string) {
-	if _, exists := s.attributes[name]; !exists {
-		s.Names = append(s.Names, name)
+	if existing, exists := s.attributeName(name); exists {
+		s.attributes[existing] = value
+		return
 	}
+	s.Names = append(s.Names, name)
 	s.attributes[name] = value
 }
 
 // Get retrieves an attribute value
 func (s *Section) Get(name string) (string, bool) {
-	v, ok := s.attributes[name]
-	return v, ok
+	if v, ok := s.attributes[name]; ok {
+		return v, true
+	}
+	if existing, ok := s.attributeName(name); ok {
+		return s.attributes[existing], true
+	}
+	return "", false
 }
 
 // Delete removes an attribute
 func (s *Section) Delete(name string) {
-	if _, ok := s.attributes[name]; !ok {
-		return
-	}
-	delete(s.attributes, name)
 	for i, n := range s.Names {
-		if n == name {
+		if strings.EqualFold(n, name) {
+			delete(s.attributes, n)
 			s.Names = slices.Delete(s.Names, i, i+1)
-			break
+			return
 		}
 	}
 }

--- a/pkg/stabilize/manifest_test.go
+++ b/pkg/stabilize/manifest_test.go
@@ -302,3 +302,39 @@ func TestWriteManifestOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestSectionAttributeNamesAreCaseInsensitive(t *testing.T) {
+	section := NewSection()
+	section.Set("Build-Os", "Linux")
+
+	if got, ok := section.Get("Build-OS"); !ok || got != "Linux" {
+		t.Fatalf("Get(Build-OS) = %q, %v; want Linux, true", got, ok)
+	}
+
+	section.Set("BUILD-OS", "Darwin")
+	if got, ok := section.Get("Build-Os"); !ok || got != "Darwin" {
+		t.Fatalf("Get(Build-Os) after Set(BUILD-OS) = %q, %v; want Darwin, true", got, ok)
+	}
+	if diff := cmp.Diff([]string{"Build-Os"}, section.Names); diff != "" {
+		t.Fatalf("Names differ after case-insensitive update (-want,+got):\n%s", diff)
+	}
+
+	section.Delete("build-os")
+	if _, ok := section.Get("Build-Os"); ok {
+		t.Fatal("Get(Build-Os) after Delete(build-os) succeeded; want deleted")
+	}
+	if len(section.Names) != 0 {
+		t.Fatalf("Names after Delete(build-os) = %v, want empty", section.Names)
+	}
+}
+
+func TestParseManifestRejectsCaseInsensitiveDuplicateAttributes(t *testing.T) {
+	input := "Manifest-Version: 1.0\r\n" +
+		"Build-Os: Linux\r\n" +
+		"BUILD-OS: Darwin\r\n" +
+		"\r\n"
+
+	if _, err := ParseManifest(strings.NewReader(input)); err == nil {
+		t.Fatal("ParseManifest() error = nil, want duplicate attribute error")
+	}
+}


### PR DESCRIPTION
JAR manifest attribute names are case-insensitive, but the manifest section lookup currently matches names exactly. This can cause stabilizers to miss build metadata entries when a JAR uses different casing, such as `Build-Os` or `Scm-Revision`.

Make section lookup, updates, deletes, and duplicate detection case-insensitive while preserving the original attribute spelling and order when writing the manifest.

Testing:
- `go test ./pkg/stabilize -count=1`
- `go run ./ci -v check`