### PR TITLE
Extract go-git error messages from git cli

### DIFF
--- a/internal/gitx/clone.go
+++ b/internal/gitx/clone.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/go-git/go-billy/v5"
@@ -19,6 +21,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
@@ -61,6 +64,40 @@ var (
 	// ErrRemoteNotTracked is returned when a reuse is attempted but the remote does not match.
 	ErrRemoteNotTracked = errors.New("existing repository does not track desired remote")
 )
+
+// fatalLineRe matches the `fatal: <reason>` line(s) that `git clone` always emits as the last line of stderr on failure.
+var fatalLineRe = regexp.MustCompile(`(?m)^fatal: (.+)$`)
+
+// classifyCloneError converts `git clone` errors into go-git errors.
+// It extracts the last `fatal: <reason>` line from git's output and
+// classifies known failure modes; anything else is returned as
+// "git clone failed: <reason>" with no env-specific path information.
+func classifyCloneError(output []byte, execErr error) error {
+	matches := fatalLineRe.FindAllSubmatch(output, -1)
+	var reason string
+	if len(matches) > 0 {
+		// The last fatal line is the proximate cause.
+		reason = string(matches[len(matches)-1][1])
+	} else {
+		return errors.Wrap(execErr, "git clone unknown failure")
+	}
+	switch {
+	// NOTE: Must precede the generic "not found" arm since it can also contain this string.
+	case strings.Contains(reason, "couldn't find remote ref"),
+		strings.Contains(reason, "Remote branch") && strings.Contains(reason, "not found"):
+		return errors.Wrap(git.ErrBranchNotFound, reason)
+	case strings.Contains(reason, "not found"),
+		strings.Contains(reason, "does not exist"):
+		return errors.Wrap(transport.ErrRepositoryNotFound, reason)
+	case strings.Contains(reason, "Permission denied"),
+		strings.Contains(reason, "Authentication failed"),
+		strings.Contains(reason, "could not read Username"),
+		strings.Contains(reason, "could not read Password"):
+		return errors.Wrap(transport.ErrAuthenticationRequired, reason)
+	default:
+		return errors.Errorf("git clone unknown failure: %s", reason)
+	}
+}
 
 // Reuse reuses the existing git repo in Storer and Filesystem.
 func Reuse(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*git.Repository, error) {
@@ -225,7 +262,7 @@ func NativeClone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt
 	cmd := exec.CommandContext(ctx, "git", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, errors.Wrapf(err, "native git clone failed: %s", string(output))
+		return nil, classifyCloneError(output, err)
 	}
 	// Copy staging to target storage if needed
 	if needsStaging {

--- a/internal/gitx/clone_test.go
+++ b/internal/gitx/clone_test.go
@@ -5,6 +5,7 @@ package gitx
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-billy/v5/memfs"
@@ -13,11 +14,13 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
+	"github.com/pkg/errors"
 )
 
 // setupLocalRepo creates a local git repo on disk for testing with native git.
@@ -546,5 +549,63 @@ commits:
 	}
 	if originMaster.Hash() != newCommitHash {
 		t.Errorf("origin/master hash mismatch: expected %s, got %s", newCommitHash, originMaster.Hash())
+	}
+}
+
+func TestClassifyCloneError(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		output    string
+		wantErrIs error
+		// Substring expected in the wrap message (the `errors.Wrap(typed, msg)`
+		// case message). Empty string skips the substring check.
+		wantSub string
+	}{
+		{
+			name:      "repo not found (https 404)",
+			output:    "Cloning into bare repository '/tmp/foo'...\nfatal: repository 'https://github.com/unknown/repo/' not found\n",
+			wantErrIs: transport.ErrRepositoryNotFound,
+			wantSub:   "repository 'https://github.com/unknown/repo/' not found",
+		},
+		{
+			name:      "auth: terminal prompts disabled",
+			output:    "Cloning into bare repository '/tmp/foo'...\nfatal: could not read Username for 'https://github.com': terminal prompts disabled\n",
+			wantErrIs: transport.ErrAuthenticationRequired,
+		},
+		{
+			name:      "auth: explicit authentication failed",
+			output:    "fatal: Authentication failed for 'https://github.com/private/repo/'\n",
+			wantErrIs: transport.ErrAuthenticationRequired,
+		},
+		{
+			name:      "ref not found with --branch",
+			output:    "fatal: Remote branch nonsense not found in upstream origin\n",
+			wantErrIs: git.ErrBranchNotFound,
+		},
+		{
+			name:      "unrecognized: surfaces sanitized reason, drops tmpdir",
+			output:    "Cloning into bare repository '/tmp/foo'...\nfatal: some unknown failure\n",
+			wantErrIs: nil, // matches none of the typed errors
+			wantSub:   "git clone unknown failure: some unknown failure",
+		},
+		{
+			name:      "no fatal: line",
+			output:    "remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0\n",
+			wantErrIs: nil,
+			wantSub:   "git clone unknown failure:",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := classifyCloneError([]byte(tc.output), errors.New("exit status 128"))
+			if tc.wantErrIs != nil && !errors.Is(err, tc.wantErrIs) {
+				t.Errorf("got err %v; want errors.Is(_, %v)", err, tc.wantErrIs)
+			}
+			if tc.wantSub != "" && !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("got err %q; want substring %q", err.Error(), tc.wantSub)
+			}
+			if strings.Contains(err.Error(), "/tmp/foo") {
+				t.Errorf("error leaks dir path: %q", err.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
This ensures we have roughly the same shaped error messages coming out
of the dynamic dispatch clone interface.