### PR TITLE
Port more commit inference strategies to npm and pypi

### DIFF
--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/oss-rebuild/internal/gitx"
@@ -310,26 +309,5 @@ func findClosestCommitToSource(ctx context.Context, t rebuild.Target, mux rebuil
 	if err != nil {
 		return nil, errors.Wrap(err, "hashing source jar contents")
 	}
-	searchStrategy := gitscan.ExactTreeCount{}
-	closest, matched, total, err := searchStrategy.Search(ctx, repo, hashes)
-	if err != nil {
-		return nil, errors.Wrap(err, "searching for matching commit based on source jar")
-	}
-	log.Printf("commits (%d): %v", len(closest), closest)
-	log.Printf("matched %d/%d files using git index scan", matched, total)
-	if len(closest) == 0 {
-		// No matches found so we will not use the source jar heuristic, but this is not an error.
-		// The caller should try other heuristics.
-		log.Printf("no matching commit found using source jar heuristic")
-		return nil, nil
-	}
-	// TODO: use a better heuristic here like using commit time
-	commitString := closest[0]
-	// Verify if commit exists in the repository
-	commitHash := plumbing.NewHash(commitString)
-	commitObject, err := repo.CommitObject(commitHash)
-	if err != nil {
-		return nil, errors.Wrapf(err, "resolving commit %s", commitString)
-	}
-	return commitObject, nil
+	return gitscan.FindClosestCommitToSource(ctx, repo, hashes)
 }

--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -155,9 +155,6 @@ func InferLocation(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMu
 	}
 	var c *object.Commit
 	var badVersionRef string
-	registryRef = ""
-	pkgJSONGuess = ""
-	tagGuess = ""
 	switch {
 	case registryRef != "":
 		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(registryRef))

--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -219,9 +219,9 @@ func InferLocation(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMu
 		}
 		fallthrough
 	default:
-		commitHashHex, err := findClosestCommitToSource(ctx, t, mux, rcfg.Repository)
-		if err == nil {
-			log.Printf("Got commit %s", commitHashHex)
+		commit, err := findClosestCommitToSource(ctx, t, mux, rcfg.Repository)
+		if err == nil && commit != nil {
+			commitHashHex := commit.Hash.String()
 			loc.Ref = commitHashHex
 			return loc, "", nil
 		} else {
@@ -472,52 +472,27 @@ func pkgJSONSearch(pkg, pkgJSONPath string, repo *git.Repository) (tm map[string
 	return
 }
 
-func findClosestCommitToSource(ctx context.Context, target rebuild.Target, mux rebuild.RegistryMux, repo *git.Repository) (string, error) {
+func findClosestCommitToSource(ctx context.Context, target rebuild.Target, mux rebuild.RegistryMux, repo *git.Repository) (*object.Commit, error) {
 	sourceTar, err := mux.NPM.Artifact(ctx, target.Package, target.Version)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer sourceTar.Close()
 	gzReader, err := gzip.NewReader(sourceTar)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer gzReader.Close()
 	tarData, err := io.ReadAll(gzReader)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	tarReader := tar.NewReader(bytes.NewReader(tarData))
-	// NOTE: we *could* refactor out a function in gitscan that gets a repo and the hash list and
-	// finds the closest commit?
-	// That way, the ecosystem specific part is just getting the hashes from the specific file
-	// types.
-	// Arguably, these are also somewhat generic over ecosystems, as they really just depend on the
-	// file type.
-	// Then, the only ecosystem specific thing is to fetch the artifact, and the rest is then a
-	// filetype specific, but ecosystem agnostic repo scan.
+
 	hashes, err := gitscan.BlobHashesFromTar(tarReader)
 	if err != nil {
-		return "", errors.Wrap(err, "hashing source jar contents")
+		return nil, errors.Wrap(err, "hashing source jar contents")
 	}
-	searchStrategy := gitscan.ExactTreeCount{}
-	closest, matched, total, err := searchStrategy.Search(ctx, repo, hashes)
-	if err != nil {
-		return "", errors.Wrap(err, "searching for matching commit based on source jar")
-	}
-	log.Printf("commits (%d): %v", len(closest), closest)
-	log.Printf("matched %d/%d files using git index scan", matched, total)
-	if len(closest) == 0 {
-		log.Printf("no matching commit found using commit overlap heuristic")
-		return "", nil
-	}
-	// TODO: use a better heuristic here like using commit time
-	commitHashHex := closest[0]
-	// Verify if commit exists in the repository
-	commitHash := plumbing.NewHash(commitHashHex)
-	_, err = repo.CommitObject(commitHash)
-	if err != nil {
-		return "", errors.Wrapf(err, "resolving commit %s", commitHashHex)
-	}
-	return commitHashHex, nil
+
+	return gitscan.FindClosestCommitToSource(ctx, repo, hashes)
 }

--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -4,9 +4,13 @@
 package npm
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"path"
 	"path/filepath"
@@ -22,6 +26,7 @@ import (
 	"github.com/google/oss-rebuild/internal/uri"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
+	"github.com/google/oss-rebuild/pkg/vcs/gitscan"
 	"github.com/pkg/errors"
 )
 
@@ -125,7 +130,7 @@ func PickNPMVersion(meta *npmreg.NPMVersion) (string, error) {
 	return npmv, nil
 }
 
-func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.RepoConfig) (loc rebuild.Location, versionOverride string, err error) {
+func InferLocation(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, vmeta *npmreg.NPMVersion, rcfg *rebuild.RepoConfig) (loc rebuild.Location, versionOverride string, err error) {
 	// Initialize location with repo URI from config
 	loc = rebuild.Location{
 		Repo: rcfg.URI,
@@ -150,6 +155,9 @@ func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.Rep
 	}
 	var c *object.Commit
 	var badVersionRef string
+	registryRef = ""
+	pkgJSONGuess = ""
+	tagGuess = ""
 	switch {
 	case registryRef != "":
 		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(registryRef))
@@ -211,16 +219,24 @@ func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.Rep
 		}
 		fallthrough
 	default:
-		if badVersionRef != "" {
-			log.Printf("using version override recovery: %s", badVersionRef[:9])
-			c, _ = rcfg.Repository.CommitObject(plumbing.NewHash(badVersionRef))
-			loc.Ref = badVersionRef
-			versionOverride = t.Version
-			return loc, versionOverride, nil
-		} else if registryRef == "" && tagGuess == "" && pkgJSONGuess == "" {
-			return loc, "", errors.Errorf("no git ref")
+		commitHashHex, err := findClosestCommitToSource(ctx, t, mux, rcfg.Repository)
+		if err == nil {
+			log.Printf("Got commit %s", commitHashHex)
+			loc.Ref = commitHashHex
+			return loc, "", nil
 		} else {
-			return loc, "", errors.Errorf("no valid git ref")
+			log.Printf("Failed to use closest commit as ref: %s", err)
+			if badVersionRef != "" {
+				log.Printf("using version override recovery: %s", badVersionRef[:9])
+				c, _ = rcfg.Repository.CommitObject(plumbing.NewHash(badVersionRef))
+				loc.Ref = badVersionRef
+				versionOverride = t.Version
+				return loc, versionOverride, nil
+			} else if registryRef == "" && tagGuess == "" && pkgJSONGuess == "" {
+				return loc, "", errors.Errorf("no git ref")
+			} else {
+				return loc, "", errors.Errorf("no valid git ref")
+			}
 		}
 	}
 }
@@ -245,7 +261,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			loc.Dir = lh.Dir
 		}
 	} else {
-		loc, versionOverride, err = InferLocation(t, vmeta, rcfg)
+		loc, versionOverride, err = InferLocation(ctx, t, mux, vmeta, rcfg)
 		if err != nil {
 			return nil, err
 		}
@@ -454,4 +470,54 @@ func pkgJSONSearch(pkg, pkgJSONPath string, repo *git.Repository) (tm map[string
 		}
 	}
 	return
+}
+
+func findClosestCommitToSource(ctx context.Context, target rebuild.Target, mux rebuild.RegistryMux, repo *git.Repository) (string, error) {
+	sourceTar, err := mux.NPM.Artifact(ctx, target.Package, target.Version)
+	if err != nil {
+		return "", err
+	}
+	defer sourceTar.Close()
+	gzReader, err := gzip.NewReader(sourceTar)
+	if err != nil {
+		return "", err
+	}
+	defer gzReader.Close()
+	tarData, err := io.ReadAll(gzReader)
+	if err != nil {
+		return "", err
+	}
+	tarReader := tar.NewReader(bytes.NewReader(tarData))
+	// NOTE: we *could* refactor out a function in gitscan that gets a repo and the hash list and
+	// finds the closest commit?
+	// That way, the ecosystem specific part is just getting the hashes from the specific file
+	// types.
+	// Arguably, these are also somewhat generic over ecosystems, as they really just depend on the
+	// file type.
+	// Then, the only ecosystem specific thing is to fetch the artifact, and the rest is then a
+	// filetype specific, but ecosystem agnostic repo scan.
+	hashes, err := gitscan.BlobHashesFromTar(tarReader)
+	if err != nil {
+		return "", errors.Wrap(err, "hashing source jar contents")
+	}
+	searchStrategy := gitscan.ExactTreeCount{}
+	closest, matched, total, err := searchStrategy.Search(ctx, repo, hashes)
+	if err != nil {
+		return "", errors.Wrap(err, "searching for matching commit based on source jar")
+	}
+	log.Printf("commits (%d): %v", len(closest), closest)
+	log.Printf("matched %d/%d files using git index scan", matched, total)
+	if len(closest) == 0 {
+		log.Printf("no matching commit found using commit overlap heuristic")
+		return "", nil
+	}
+	// TODO: use a better heuristic here like using commit time
+	commitHashHex := closest[0]
+	// Verify if commit exists in the repository
+	commitHash := plumbing.NewHash(commitHashHex)
+	_, err = repo.CommitObject(commitHash)
+	if err != nil {
+		return "", errors.Wrapf(err, "resolving commit %s", commitHashHex)
+	}
+	return commitHashHex, nil
 }

--- a/pkg/rebuild/npm/infer_test.go
+++ b/pkg/rebuild/npm/infer_test.go
@@ -180,6 +180,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 		wantCommitID    string
 		wantStrategyFn  func(commitID string) rebuild.Strategy
 		wantErr         bool
+		extraMockCalls  []httpxtest.Call
 	}{
 		{
 			name:    "NPMPackBuild - ref from gitHead",
@@ -363,8 +364,24 @@ func TestInferStrategy_NPM(t *testing.T) {
       package.json: "this is not json" # Invalid package.json in the repo commit
 `,
 			versionMetadata: `{"name":"test-package","version":"1.0.0","_npmVersion":"8.0.0","dist":{"tarball":"url6"},"gitHead":"INSERT_COMMIT_ID"}`,
-			packageMetadata: `{"name":"test-package","time":{"1.0.0":"2023-01-01T12:00:00.000Z"}}`,
 			wantErr:         true,
+			extraMockCalls: []httpxtest.Call{
+				{
+					URL: "https://registry.npmjs.org/test-package/1.0.0",
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       httpxtest.Body(`{"name":"test-package","version":"1.0.0","_npmVersion":"8.0.0","dist":{"tarball":"url6"}}`),
+					},
+				},
+				{
+					URL: "url6",
+					Response: &http.Response{
+						StatusCode: 404,
+						Status:     "Not Found",
+						Body:       httpxtest.Body("not found"),
+					},
+				},
+			},
 		},
 		{
 			name:    "Error - missing upload time for custom build",
@@ -459,6 +476,9 @@ func TestInferStrategy_NPM(t *testing.T) {
 						Body:       httpxtest.Body(tc.packageMetadata),
 					},
 				})
+			}
+			if tc.extraMockCalls != nil {
+				client.Calls = append(client.Calls, tc.extraMockCalls...)
 			}
 			mux := rebuild.RegistryMux{NPM: &reg.HTTPRegistry{Client: &client}}
 			s, err := Rebuilder{}.InferStrategy(ctx, target, mux, &rcfg, tc.locationHint)

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -29,8 +29,18 @@ import (
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
 	"github.com/google/oss-rebuild/pkg/vcs/gitscan"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/pkg/errors"
 )
+
+// Copied from pkg/rebuild/pypi/parsing/pyproject.go
+type projectMetadata struct {
+	Name    string `toml:"name"`
+	Version string `toml:"version"`
+}
+type pyProjectProject struct {
+	Metadata projectMetadata `toml:"project"`
+}
 
 // These are commonly used in PyPi metadata to point to the project git repo, using a map as a set.
 // Some people capitalize these differently, or add/remove spaces. We normalized to lower, no space.
@@ -119,18 +129,19 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, ropt *gitx.RepositoryOptions) (r rebuild.RepoConfig, err error) {
 	r.URI = repoURI
 	r.Repository, err = rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.DefaultSubmoduleRecursionDepth})
-	switch err {
-	case nil:
-		return r, nil
-	case transport.ErrAuthenticationRequired:
-		return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)
-	default:
-		return r, errors.Wrapf(err, "clone failed [repo=%s]", r.URI)
+	if err != nil {
+		if err == transport.ErrAuthenticationRequired {
+			return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)
+		} else {
+			return r, errors.Wrapf(err, "clone failed [repo=%s]", r.URI)
+		}
 	}
+	return r, nil
 }
 
 func validateCommitCandidate(commitCandidate string, rcfg *rebuild.RepoConfig, heuristicName string) (bool, error) {
 	if commitCandidate == "" {
+		log.Printf("Got empty commit for %s.", heuristicName)
 		return false, nil
 	}
 	_, err := rcfg.Repository.CommitObject(plumbing.NewHash(commitCandidate))
@@ -146,6 +157,7 @@ func validateCommitCandidate(commitCandidate string, rcfg *rebuild.RepoConfig, h
 }
 
 func findGitRef(ctx context.Context, target rebuild.Target, mux rebuild.RegistryMux, pkg string, version string, rcfg *rebuild.RepoConfig) (string, error) {
+	// 1. tag heuristic, fast
 	tagHeuristic, err := rebuild.FindTagMatch(pkg, version, rcfg.Repository)
 	log.Printf("Version: %s, tag hash: \"%s\"", version, tagHeuristic)
 	if err != nil {
@@ -160,6 +172,7 @@ func findGitRef(ctx context.Context, target rebuild.Target, mux rebuild.Registry
 		return tagHeuristic, nil
 	}
 
+	// 2. commit file hash overlap, no file parsing, only hash comparisons
 	closestCommit, err := findClosestCommitToSource(ctx, target, mux, rcfg.Repository)
 	if err != nil {
 		return "", errors.Wrapf(err, "[INTERNAL] commit overlap heuristic error")
@@ -173,6 +186,28 @@ func findGitRef(ctx context.Context, target rebuild.Target, mux rebuild.Registry
 		log.Printf("PyPI Returning result from commit heuristic.")
 		return commitHeuristic, nil
 	}
+
+	// 3. Find version switch in pyproject.toml.
+	// May parse a pyproject.toml file for every commit and might thus be very slow.
+	log.Printf("Building pyproject.toml version map, this may take a while.")
+	pkgPath, err := findPyprojectToml(ctx, target, rcfg.Repository)
+	if err == nil {
+		refMap, err := pyprojectTomlSearch(target.Package, pkgPath, rcfg.Repository)
+		if err == nil {
+			rcfg.RefMap = refMap
+		}
+	}
+	manifestHeuristic := rcfg.RefMap[target.Version]
+	valid, err = validateCommitCandidate(manifestHeuristic, rcfg, "manifest")
+	if err != nil {
+		return "", err
+	}
+	if valid {
+		log.Printf("PyPI Returning result from manifest heuristic.")
+		return manifestHeuristic, nil
+	}
+
+	// None of the heuristics matched
 	return "", errors.New("no git ref")
 }
 
@@ -488,6 +523,118 @@ func inferPythonVersion(reqs []string) string {
 		}
 	}
 	return "" // unconstrained
+}
+
+func findPyprojectToml(ctx context.Context, t rebuild.Target, repo *git.Repository) (string, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return "", err
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return "", err
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return "", err
+	}
+	buildDir, err := pypiresolver.DiscoverBuildDir(ctx, tree, t.Package, t.Version, "")
+	if err != nil {
+		return "", err
+	}
+	return path.Join(buildDir, "pyproject.toml"), nil
+}
+
+func pyprojectTomlSearch(pkg, pyprojectTomlPath string, repo *git.Repository) (tm map[string]string, err error) {
+	tm = make(map[string]string)
+	commitIter, err := repo.Log(&git.LogOptions{
+		Order:      git.LogOrderCommitterTime,
+		PathFilter: func(s string) bool { return s == pyprojectTomlPath },
+		All:        true,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "searching for commits touching pyproject.toml")
+	}
+	duplicates := make(map[string]string)
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		t, err := c.Tree()
+		if err != nil {
+			return errors.Wrapf(err, "fetching tree")
+		}
+		pyprojectToml, err := getPyprojectToml(t, pyprojectTomlPath)
+		if _, ok := err.(*toml.DecodeError); ok {
+			return nil // unable to parse
+		} else if errors.Is(err, object.ErrFileNotFound) {
+			return nil // file deleted at this commit
+		} else if err != nil {
+			return errors.Wrapf(err, "fetching pyproject.toml")
+		}
+		if pyprojectToml.Metadata.Name != pkg {
+			// TODO: Handle the case where the package name has changed.
+			log.Printf(
+				"Package name mismatch [expected=%s,actual=%s,path=%s,ref=%s]\n",
+				pkg, pyprojectToml.Metadata.Name,
+				pyprojectTomlPath,
+				c.Hash.String(),
+			)
+			return nil
+		}
+		ver := pyprojectToml.Metadata.Version
+		if ver == "" {
+			return nil
+		}
+		// If any are the same, return nil. (merges would create duplicates.)
+		var foundMatch bool
+		err = c.Parents().ForEach(func(c *object.Commit) error {
+			t, err := c.Tree()
+			if err != nil {
+				return errors.Wrapf(err, "fetching tree")
+			}
+			pyprojectToml, err := getPyprojectToml(t, pyprojectTomlPath)
+			if err != nil {
+				// TODO: Detect and record file moves.
+				return nil
+			}
+			if pyprojectToml.Metadata.Name == pkg && pyprojectToml.Metadata.Version == ver {
+				foundMatch = true
+			}
+			return nil
+		})
+		if err != nil {
+			return errors.Wrapf(err, "comparing against parent pyproject.toml")
+		}
+		if !foundMatch {
+			if tm[ver] != "" {
+				// NOTE: This ignores commits processed later sequentially. Empirically, this seems to pick the better commit.
+				if duplicates[ver] != "" {
+					duplicates[ver] = fmt.Sprintf("%s,%s", duplicates[ver], c.Hash.String())
+				} else {
+					duplicates[ver] = fmt.Sprintf("%s,%s", tm[ver], c.Hash.String())
+				}
+			} else {
+				tm[ver] = c.Hash.String()
+			}
+		}
+		return nil
+	})
+	if len(duplicates) > 0 {
+		for ver, dupes := range duplicates {
+			log.Printf("Multiple matches found [pkg=%s,ver=%s,refs=%v]\n", pkg, ver, dupes)
+		}
+	}
+	return
+}
+
+func getPyprojectToml(tree *object.Tree, path string) (pyprojectToml pyProjectProject, err error) {
+	f, err := tree.File(path)
+	if err != nil {
+		return pyprojectToml, err
+	}
+	p, err := f.Contents()
+	if err != nil {
+		return pyprojectToml, err
+	}
+	return pyprojectToml, toml.Unmarshal([]byte(p), &pyprojectToml)
 }
 
 var bdistWheelPat = re.MustCompile(`^Generator: bdist_wheel \(([\d\.]+)\)`)

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -4,8 +4,10 @@
 package pypi
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -19,12 +21,14 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/uri"
 	pypiresolver "github.com/google/oss-rebuild/pkg/rebuild/pypi/parsing"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	pypireg "github.com/google/oss-rebuild/pkg/registry/pypi"
+	"github.com/google/oss-rebuild/pkg/vcs/gitscan"
 	"github.com/pkg/errors"
 )
 
@@ -125,26 +129,94 @@ func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string
 	}
 }
 
-func findGitRef(pkg string, version string, rcfg *rebuild.RepoConfig) (string, error) {
+func validateCommitCandidate(commitCandidate string, rcfg *rebuild.RepoConfig, heuristicName string) (bool, error) {
+	if commitCandidate == "" {
+		return false, nil
+	}
+	_, err := rcfg.Repository.CommitObject(plumbing.NewHash(commitCandidate))
+	if err != nil {
+		switch err {
+		case plumbing.ErrObjectNotFound:
+			return false, errors.Errorf("[INTERNAL] Commit ref from %s heuristic not found in repo [repo=%s,ref=%s]", heuristicName, rcfg.URI, commitCandidate)
+		default:
+			return false, errors.Wrapf(err, "Checkout failed [repo=%s,ref=%s]", rcfg.URI, commitCandidate)
+		}
+	}
+	return true, nil
+}
+
+func findGitRef(ctx context.Context, target rebuild.Target, mux rebuild.RegistryMux, pkg string, version string, rcfg *rebuild.RepoConfig) (string, error) {
 	tagHeuristic, err := rebuild.FindTagMatch(pkg, version, rcfg.Repository)
 	log.Printf("Version: %s, tag hash: \"%s\"", version, tagHeuristic)
 	if err != nil {
 		return "", errors.Wrapf(err, "[INTERNAL] tag heuristic error")
 	}
-	// TODO: Look for the project.toml and check for version number.
-	if tagHeuristic == "" {
-		return "", errors.New("no git ref")
-	}
-	_, err = rcfg.Repository.CommitObject(plumbing.NewHash(tagHeuristic))
+	valid, err := validateCommitCandidate(tagHeuristic, rcfg, "tag")
 	if err != nil {
-		switch err {
-		case plumbing.ErrObjectNotFound:
-			return "", errors.Errorf("[INTERNAL] Commit ref from tag heuristic not found in repo [repo=%s,ref=%s]", rcfg.URI, tagHeuristic)
-		default:
-			return "", errors.Wrapf(err, "Checkout failed [repo=%s,ref=%s]", rcfg.URI, tagHeuristic)
-		}
+		return "", err
 	}
-	return tagHeuristic, nil
+	if valid {
+		log.Printf("PyPI Returning result from tag heuristic.")
+		return tagHeuristic, nil
+	}
+
+	closestCommit, err := findClosestCommitToSource(ctx, target, mux, rcfg.Repository)
+	if err != nil {
+		return "", errors.Wrapf(err, "[INTERNAL] commit overlap heuristic error")
+	}
+	commitHeuristic := closestCommit.Hash.String()
+	valid, err = validateCommitCandidate(commitHeuristic, rcfg, "commit")
+	if err != nil {
+		return "", err
+	}
+	if valid {
+		log.Printf("PyPI Returning result from commit heuristic.")
+		return commitHeuristic, nil
+	}
+	return "", errors.New("no git ref")
+}
+
+func findClosestCommitToSource(ctx context.Context, target rebuild.Target, mux rebuild.RegistryMux, repo *git.Repository) (*object.Commit, error) {
+	sourceArtifact, err := mux.PyPI.Artifact(ctx, target.Package, target.Version, target.Artifact)
+	if err != nil {
+		return nil, err
+	}
+	defer sourceArtifact.Close()
+
+	var hashes []plumbing.Hash
+	if strings.HasSuffix(target.Artifact, ".tar.gz") {
+		gzReader, err := gzip.NewReader(sourceArtifact)
+		if err != nil {
+			return nil, err
+		}
+		defer gzReader.Close()
+		tarData, err := io.ReadAll(gzReader)
+		if err != nil {
+			return nil, err
+		}
+		tarReader := tar.NewReader(bytes.NewReader(tarData))
+		hashes, err = gitscan.BlobHashesFromTar(tarReader)
+		if err != nil {
+			return nil, errors.Wrap(err, "hashing source tar contents")
+		}
+	} else if strings.HasSuffix(target.Artifact, ".whl") {
+		zipData, err := io.ReadAll(sourceArtifact)
+		if err != nil {
+			return nil, err
+		}
+		zipReader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+		if err != nil {
+			return nil, err
+		}
+		hashes, err = gitscan.BlobHashesFromZip(zipReader)
+		if err != nil {
+			return nil, errors.Wrap(err, "hashing source zip contents")
+		}
+	} else {
+		return nil, errors.Errorf("Incompatible release type: %s", target.Artifact)
+	}
+
+	return gitscan.FindClosestCommitToSource(ctx, repo, hashes)
 }
 
 // FindPureWheel returns the pure wheel artifact from the given version's releases.
@@ -289,7 +361,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			dir = rcfg.Dir
 		}
 	} else {
-		ref, err = findGitRef(release.Name, version, rcfg)
+		ref, err = findGitRef(ctx, t, mux, release.Name, version, rcfg)
 		if err != nil {
 			return cfg, err
 		}

--- a/pkg/vcs/gitscan/gitscan.go
+++ b/pkg/vcs/gitscan/gitscan.go
@@ -4,6 +4,7 @@
 package gitscan
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"context"
 	"io"
@@ -42,6 +43,30 @@ func BlobHashesFromZip(zr *zip.Reader) (files []plumbing.Hash, err error) {
 			return nil, err
 		}
 		files = append(files, h.Sum())
+	}
+	return files, nil
+}
+
+// BlobHashesFromTar computes the git blob hashes for all files in the provided tar archive.
+func BlobHashesFromTar(tr *tar.Reader) (files []plumbing.Hash, err error) {
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, errors.Errorf("failed reading tar file: %s", err)
+		}
+		// tar.TypeReg is the flag for a regular file
+		// unsure if we need to support other file types like links?
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		hasher := plumbing.NewHasher(plumbing.BlobObject, header.Size)
+		if _, err := io.CopyN(hasher, tr, header.Size); err != nil {
+			return nil, err
+		}
+		files = append(files, hasher.Sum())
 	}
 	return files, nil
 }

--- a/pkg/vcs/gitscan/gitscan.go
+++ b/pkg/vcs/gitscan/gitscan.go
@@ -8,6 +8,7 @@ import (
 	"archive/zip"
 	"context"
 	"io"
+	"log"
 	"sort"
 	"time"
 
@@ -18,6 +19,31 @@ import (
 	"github.com/google/oss-rebuild/internal/bitmap"
 	"github.com/pkg/errors"
 )
+
+func FindClosestCommitToSource(ctx context.Context, repo *git.Repository, source_hashes []plumbing.Hash) (*object.Commit, error) {
+	searchStrategy := ExactTreeCount{}
+	closest, matched, total, err := searchStrategy.Search(ctx, repo, source_hashes)
+	if err != nil {
+		return nil, errors.Wrap(err, "searching for matching commit based on commit file overlap")
+	}
+	log.Printf("commits (%d): %v", len(closest), closest)
+	log.Printf("matched %d/%d files using git index scan", matched, total)
+	if len(closest) == 0 {
+		// No matches found so we will not use the commit file overlap heuristic, but this is not an error.
+		// The caller should try other heuristics.
+		log.Printf("no matching commit found using commit file overlap heuristics")
+		return nil, nil
+	}
+	// TODO: use a better heuristic here like using commit time
+	commitString := closest[0]
+	// Verify if commit exists in the repository
+	commitHash := plumbing.NewHash(commitString)
+	commitObject, err := repo.CommitObject(commitHash)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolving commit %s", commitString)
+	}
+	return commitObject, nil
+}
 
 // BlobHashesFromZip computes the git blob hashes for all files in the provided zip archive.
 func BlobHashesFromZip(zr *zip.Reader) (files []plumbing.Hash, err error) {


### PR DESCRIPTION
Across all ecosystems, i have seen the following commit inference strategies:
- git tag heuristic
- commit file hash overlap with artifact file hashes
- version change in manifest
- explicit ref in registry

I have ported the commit file hash overlap strategy that was exclusive to maven to npm and PyPI, and also ported the manifest version change strategy from npm to PyPI.
The registry ref strategy was not ported, because PyPI simply does not expose this information.
Thus, now npm supports all four heuristics, and PyPI supports the three that make sense.

Some notes:

- The commit file hash overlap was previously exclusive to maven, and thus lived in maven specific files. I have refactored out the generic part and moved it to a different file.
- I am unsure about the way and granularity you test these features. For now, i only introduced some patches to the tests so that they don't fail (and perhaps in a weird way, because I'm not so familiar with go and the way tests work).
- I have copied some models from `pkg/rebuild/pypi/parsing/pyproject.go` to `pypi/infer.go` because they were private, we have to see how we want to deal with that.