### PR TITLE
Use HEAD as default checkout target for NativeClone

### DIFF
--- a/internal/gitx/clone.go
+++ b/internal/gitx/clone.go
@@ -289,7 +289,8 @@ func NativeClone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt
 		if err != nil {
 			return nil, errors.Wrap(err, "getting worktree")
 		}
-		checkoutOpts := &git.CheckoutOptions{}
+		// Default to HEAD so checkout follows the repo's actual default branch.
+		checkoutOpts := &git.CheckoutOptions{Branch: plumbing.HEAD}
 		if opt.ReferenceName != "" {
 			checkoutOpts.Branch = opt.ReferenceName
 		}


### PR DESCRIPTION
As opposed to master, this default will avoid reference not found errors
for repos where the master branch does not exist. This does leave us in
a detached HEAD state but, for rebuild purposes, this is no worse than
the alternative since we're not modifying any content.