### PR TITLE
Default ctl diffr to arbitrary archive depth

### DIFF
--- a/tools/ctl/difftool/diffr.go
+++ b/tools/ctl/difftool/diffr.go
@@ -58,13 +58,13 @@ func (d Diffr) Diff(ctx context.Context, rebuildPath, upstreamPath string, targe
 	defer stabilizedUpstream.Close()
 	// Create output buffer
 	var output bytes.Buffer
-	// Run diffr
-	maxDepth := target.ArchiveType().Layers()
+	// Run diffr. MaxDepth defaults to 0 (unlimited): the static format layer count
+	// undercounts nested archives (e.g. .gem tars contain data.tar.gz inside).
 	err = diffr.Diff(
 		ctx,
 		diffr.File{Name: rebuildPath, Reader: stabilizedRebuild},
 		diffr.File{Name: upstreamPath, Reader: stabilizedUpstream},
-		diffr.Options{MaxDepth: maxDepth, Output: &output},
+		diffr.Options{Output: &output},
 	)
 	if err != nil && !errors.Is(err, diffr.ErrNoDiff) {
 		return nil, errors.Wrap(err, "running diffr")

--- a/tools/ctl/ide/commands/commands.go
+++ b/tools/ctl/ide/commands/commands.go
@@ -296,15 +296,13 @@ func NewRebuildCmds(app *tview.Application, executor build.Executor, prebuildCon
 						return
 					}
 					defer rbFile.Close()
-					// Use MaxDepth based on archive format layers
-					maxDepth := example.Target().ArchiveType().Layers()
 					var left, diff, right []string
 					var root diffr.DiffNode
 					err = diffr.Diff(
 						ctx,
 						diffr.File{Name: rebuildPath, Reader: rbFile},
 						diffr.File{Name: upstreamPath, Reader: upFile},
-						diffr.Options{MaxDepth: maxDepth, OutputNode: &root},
+						diffr.Options{OutputNode: &root}, // NOTE: MaxDepth is unlimited
 					)
 					if err != nil && !errors.Is(err, diffr.ErrNoDiff) {
 						log.Println(errors.Wrap(err, "running diffr"))


### PR DESCRIPTION
RubyGems' deep archive structure was resuling in truncated diffr output.
There's not a strong reason to limit this depth other than risking
memory pressure but we can revisit this if that ends up becoming an
issue.