### PR TITLE
Handle npm prerelease tarball versions

### DIFF
--- a/internal/netclassify/classify.go
+++ b/internal/netclassify/classify.go
@@ -39,8 +39,10 @@ var (
 
 // NPM
 var (
-	npmAPIRegex  = regexp.MustCompile(`^https://registry\.(npmjs\.org|yarnpkg\.com)/((@[^/]+/)?[^/]+)/([^/]+)/?$`)
-	npmFileRegex = regexp.MustCompile(`^https://registry\.(npmjs\.org|yarnpkg\.com)/((@[^/]+/)?[^/]+)/-/([^/]+)-([^/-]+)\.tgz$`)
+	npmAPIRegex                 = regexp.MustCompile(`^https://registry\.(npmjs\.org|yarnpkg\.com)/((@[^/]+/)?[^/]+)/([^/]+)/?$`)
+	npmFileRegex                = regexp.MustCompile(`^https://registry\.(npmjs\.org|yarnpkg\.com)/((@[^/]+/)?[^/]+)/-/([^/]+)\.tgz$`)
+	npmVersionSuffixRegex       = regexp.MustCompile(`-(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$`)
+	npmLegacyVersionSuffixRegex = regexp.MustCompile(`-(\d+\.\d+\.\d+)(alpha|beta|dev|pre|rc)(\d*)$`)
 )
 
 // Maven
@@ -248,8 +250,14 @@ func classifyNPMURL(rawURL string) (string, error) {
 		return "", errors.New("invalid NPM download URL format")
 	}
 	packagePath := matches[2]
-	version := matches[5]
-	return fmt.Sprintf("pkg:npm/%s@%s", packagePath, version), nil
+	tarball := matches[4]
+	if matches := npmVersionSuffixRegex.FindStringSubmatch(tarball); len(matches) >= 2 {
+		return fmt.Sprintf("pkg:npm/%s@%s", packagePath, matches[1]), nil
+	}
+	if matches := npmLegacyVersionSuffixRegex.FindStringSubmatch(tarball); len(matches) >= 4 {
+		return fmt.Sprintf("pkg:npm/%s@%s-%s%s", packagePath, matches[1], matches[2], matches[3]), nil
+	}
+	return "", errors.New("invalid NPM download URL format")
 }
 
 func classifyCratesURL(rawURL string) (string, error) {

--- a/internal/netclassify/classify_test.go
+++ b/internal/netclassify/classify_test.go
@@ -109,6 +109,26 @@ func TestClassifyURL(t *testing.T) {
 			want: "pkg:npm/@invisionag/eslint-config-ivx@0.0.2",
 		},
 		{
+			name: "npm_download_prerelease",
+			url:  "https://registry.npmjs.org/vite/-/vite-5.0.0-beta.0.tgz",
+			want: "pkg:npm/vite@5.0.0-beta.0",
+		},
+		{
+			name: "npm_download_scoped_prerelease",
+			url:  "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.56.tgz",
+			want: "pkg:npm/@babel/core@7.0.0-beta.56",
+		},
+		{
+			name: "npm_download_hyphenated_package_prerelease",
+			url:  "https://registry.npmjs.org/react-router/-/react-router-7.0.0-pre.0.tgz",
+			want: "pkg:npm/react-router@7.0.0-pre.0",
+		},
+		{
+			name: "npm_download_legacy_prerelease",
+			url:  "https://registry.npmjs.org/express/-/express-2.0.0rc.tgz",
+			want: "pkg:npm/express@2.0.0-rc",
+		},
+		{
 			name: "npm_yarn_download_simple",
 			url:  "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz",
 			want: "pkg:npm/express@4.17.1",


### PR DESCRIPTION
This preserves the full npm prerelease version when classifying registry tarball URLs.

For example, `vite-5.0.0-beta.0.tgz` should classify as `pkg:npm/vite@5.0.0-beta.0` rather than `pkg:npm/vite@beta.0`.

Tests:
```
go test -mod=readonly ./internal/netclassify -count=1
```
