### PR TITLE
Add initial agent scratch framework

### DIFF
--- a/cmd/agent-api/main.go
+++ b/cmd/agent-api/main.go
@@ -15,6 +15,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/oss-rebuild/internal/api"
 	"github.com/google/oss-rebuild/internal/api/agentapiservice"
+	"github.com/google/oss-rebuild/internal/db"
 	"github.com/google/oss-rebuild/internal/serviceid"
 	buildgcb "github.com/google/oss-rebuild/pkg/build/gcb"
 	"github.com/google/oss-rebuild/pkg/gcb"
@@ -33,6 +34,12 @@ var (
 	prebuildVersion      = flag.String("prebuild-version", "", "golang version identifier of the prebuild binary builds")
 	prebuildAuth         = flag.Bool("prebuild-auth", false, "whether to authenticate requests to the prebuild tools bucket")
 	port                 = flag.Int("port", 8080, "port on which to serve")
+
+	// Scratch flags. Gated by --scratch-enabled.
+	scratchEnabled      = flag.Bool("scratch-enabled", false, "register the scratch routes")
+	scratchZone         = flag.String("scratch-zone", "", "GCE zone for scratch VMs (required when scratch enabled)")
+	scratchStandardTmpl = flag.String("scratch-instance-standard-template", "", "GCE instance template URL for the standard machine class (required when scratch enabled)")
+	scratchJumboTmpl    = flag.String("scratch-instance-jumbo-template", "", "GCE instance template URL for the jumbo machine class (optional)")
 )
 
 // Link-time configured service identity
@@ -116,11 +123,66 @@ func AgentCompleteInit(ctx context.Context) (*agentapiservice.AgentCompleteDeps,
 	return &d, nil
 }
 
+func ScratchCreateInit(ctx context.Context) (*agentapiservice.ScratchCreateDeps, error) {
+	fs, err := firestore.NewClient(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "firestore client")
+	}
+	gce, err := agentapiservice.NewComputeGCE(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "compute client")
+	}
+	return &agentapiservice.ScratchCreateDeps{
+		Scratches: db.NewFirestoreScratch(fs),
+		GCE:       gce,
+		Standard: agentapiservice.ClassConfig{
+			InstanceTemplate: *scratchStandardTmpl,
+		},
+		Jumbo: func() *agentapiservice.ClassConfig {
+			if *scratchJumboTmpl == "" {
+				return nil
+			}
+			return &agentapiservice.ClassConfig{
+				InstanceTemplate: *scratchJumboTmpl,
+			}
+		}(),
+		Zone: *scratchZone,
+	}, nil
+}
+
+func ScratchGetInit(ctx context.Context) (*agentapiservice.ScratchGetDeps, error) {
+	fs, err := firestore.NewClient(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "firestore client")
+	}
+	return &agentapiservice.ScratchGetDeps{Scratches: db.NewFirestoreScratch(fs)}, nil
+}
+
+func ScratchDeleteInit(ctx context.Context) (*agentapiservice.ScratchDeleteDeps, error) {
+	fs, err := firestore.NewClient(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "firestore client")
+	}
+	gce, err := agentapiservice.NewComputeGCE(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "compute client")
+	}
+	return &agentapiservice.ScratchDeleteDeps{Scratches: db.NewFirestoreScratch(fs), GCE: gce}, nil
+}
+
 func main() {
 	flag.Parse()
-	http.HandleFunc("/agent/session/iteration", api.Handler(AgentCreateIterationInit, agentapiservice.AgentCreateIteration))
-	http.HandleFunc("/agent/session/complete", api.Handler(AgentCompleteInit, agentapiservice.AgentComplete))
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil); err != nil {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/agent/session/iteration", api.Handler(AgentCreateIterationInit, agentapiservice.AgentCreateIteration))
+	mux.HandleFunc("/agent/session/complete", api.Handler(AgentCompleteInit, agentapiservice.AgentComplete))
+
+	if *scratchEnabled {
+		mux.HandleFunc("/scratch/create", api.Handler(ScratchCreateInit, agentapiservice.ScratchCreate))
+		mux.HandleFunc("/scratch/get", api.Handler(ScratchGetInit, agentapiservice.ScratchGet))
+		mux.HandleFunc("/scratch/delete", api.Handler(ScratchDeleteInit, agentapiservice.ScratchDelete))
+	}
+
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), mux); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/deployments/iam.tf
+++ b/deployments/iam.tf
@@ -385,6 +385,12 @@ resource "google_project_iam_member" "orchestrator-creates-run-jobs" {
   role    = "roles/run.jobsExecutorWithOverrides"
   member  = google_service_account.orchestrator.member
 }
+resource "google_project_iam_member" "orchestrator-compute-admin" {
+  count   = var.enable_scratch ? 1 : 0
+  project = var.project
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = google_service_account.orchestrator.member
+}
 resource "google_cloud_run_v2_service_iam_member" "agent-calls-agent-api" {
   location = google_cloud_run_v2_service.agent-api.location
   project  = google_cloud_run_v2_service.agent-api.project

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -42,6 +42,47 @@ resource "google_cloudbuild_worker_pool" "jumbo-pool" {
   depends_on = [google_project_service.cloudbuild]
 }
 
+# Instance template for scratch VMs.
+# TODO: Add a startup script that fetches and runs the scratch-worker
+# binary once the worker service lands.
+resource "google_compute_instance_template" "scratch-standard" {
+  count        = var.enable_scratch ? 1 : 0
+  name_prefix  = "${var.host}-scratch-standard-"
+  machine_type = "n2-standard-8"
+  region       = "us-central1"
+
+  service_account {
+    email  = ""
+    scopes = []
+  }
+
+  disk {
+    source_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+    auto_delete  = true
+    boot         = true
+    disk_size_gb = 50
+  }
+  disk {
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    auto_delete  = true
+    interface    = "NVME"
+    disk_size_gb = 375 # local SSD partitions are fixed at 375 GB on n2; add more disk blocks for more capacity.
+  }
+
+  network_interface {
+    network    = google_compute_network.vpc[0].name
+    subnetwork = google_compute_subnetwork.subnet[0].name
+  }
+
+  tags   = ["scratch"]
+  labels = { purpose = "scratch" }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "google_project_service" "run" {
   service = "run.googleapis.com"
 }
@@ -338,6 +379,10 @@ resource "google_cloud_run_v2_service" "agent-api" {
         ], var.enable_private_build_pool ? [
         "--gcb-private-pool-name=${google_cloudbuild_worker_pool.private-pool[0].id}",
         "--gcb-private-pool-region=us-central1",
+        ] : [], var.enable_scratch ? [
+        "--scratch-enabled=true",
+        "--scratch-zone=us-central1-a",
+        "--scratch-instance-standard-template=${google_compute_instance_template.scratch-standard[0].self_link}",
       ] : [])
       resources {
         limits = {

--- a/deployments/variables.tf
+++ b/deployments/variables.tf
@@ -105,6 +105,11 @@ variable "enable_vpc" {
   description = "Whether to create and use VPC infrastructure for private build pools"
   default     = false
 }
+variable "enable_scratch" {
+  type        = bool
+  description = "Whether to deploy scratch VMs for agent-driven iterative builds."
+  default     = false
+}
 variable "build_def_repo" {
   type        = string
   description = "Repository URI containing rebuild build definitions"

--- a/internal/api/agentapiservice/scratch.go
+++ b/internal/api/agentapiservice/scratch.go
@@ -1,0 +1,188 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/api"
+	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+)
+
+// ClassConfig is the per-machine-class GCE shape used by ScratchCreate.
+type ClassConfig struct {
+	// InstanceTemplate is the full Compute Engine resource name of the
+	// instance template to clone from (e.g.
+	// projects/foo/global/instanceTemplates/builder-standard). The template
+	// supplies the boot disk and any local SSD partitions used as scratch.
+	InstanceTemplate string
+}
+
+// selectClass returns the ClassConfig for the given machine class.
+// Jumbo is optional (nil means "jumbo not configured for this
+// deployment"); standard is always required.
+func selectClass(class schema.MachineClass, standard ClassConfig, jumbo *ClassConfig) (ClassConfig, error) {
+	switch class {
+	case schema.MachineClassStandard:
+		return standard, nil
+	case schema.MachineClassJumbo:
+		if jumbo == nil {
+			return ClassConfig{}, errors.Errorf("machine_class %q not configured", class)
+		}
+		return *jumbo, nil
+	default:
+		return ClassConfig{}, errors.Errorf("unknown machine_class %q", class)
+	}
+}
+
+// ScratchCreateDeps wires ScratchCreate.
+type ScratchCreateDeps struct {
+	Scratches db.Scratch
+	GCE       GCE
+	// Standard is the required class config for MachineClassStandard.
+	Standard ClassConfig
+	// Jumbo is the optional class config for MachineClassJumbo. nil
+	// means jumbo isn't available and requsts returns InvalidArgument.
+	Jumbo *ClassConfig
+	Zone  string
+	// IDGen mints scratch IDs. nil falls back to uuid.New().String().
+	IDGen func() string
+}
+
+// ScratchGetDeps wires ScratchGet.
+type ScratchGetDeps struct {
+	Scratches db.Scratch
+}
+
+// ScratchDeleteDeps wires ScratchDelete.
+type ScratchDeleteDeps struct {
+	Scratches db.Scratch
+	GCE       GCE
+}
+
+// ScratchCreate provisions a new build environment synchronously. Steps:
+//
+//	Scratches.Insert(state=Starting) -> InsertInstance -> Update with
+//	InternalIP -> UpdateState(Ready) -> return.
+//
+// Ready currently means "VM exists." The template supplies the boot disk
+// and local SSD partitions; no additional disks are attached.
+// TODO: Poll a worker /healthz before UpdateState(Ready) so Ready means
+// "worker is reachable" once the worker service exists.
+//
+// If any step fails after resources are created, best-effort teardown is
+// run and the record is marked Deleted (records persist for audit).
+func ScratchCreate(ctx context.Context, req schema.ScratchCreateRequest, deps *ScratchCreateDeps) (*schema.Scratch, error) {
+	class, err := selectClass(req.MachineClass, deps.Standard, deps.Jumbo)
+	if err != nil {
+		return nil, api.AsStatus(codes.InvalidArgument, err)
+	}
+
+	scratchID := mintID(deps.IDGen)
+	now := time.Now().UTC()
+	scratch := schema.Scratch{
+		ID:           scratchID,
+		BuildID:      req.BuildID,
+		MachineClass: req.MachineClass,
+		Zone:         deps.Zone,
+		VMName:       "scratch-" + scratchID,
+		State:        schema.ScratchStarting,
+		Created:      now,
+		Updated:      now,
+	}
+	if err := deps.Scratches.Insert(ctx, scratch); err != nil {
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches insert"))
+	}
+
+	// Best-effort cleanup on any failure past this point: attempt deletion of
+	// GCE resources we may have created and mark the record Deleted.
+	ranInsertInstance := false
+	cleanup := func() {
+		bg := context.Background()
+		if ranInsertInstance {
+			if err := deps.GCE.DeleteInstance(bg, scratch.Zone, scratch.VMName); err != nil {
+				log.Printf("teardown DeleteInstance(%s): %v", scratch.VMName, err)
+			}
+		}
+		if err := deps.Scratches.UpdateState(bg, scratchID, schema.ScratchDeleted); err != nil {
+			log.Printf("teardown UpdateState(%s, Deleted): %v", scratchID, err)
+		}
+	}
+
+	ranInsertInstance = true
+	inst, err := deps.GCE.InsertInstanceFromTemplate(ctx, scratch.Zone, scratch.VMName, class.InstanceTemplate, nil)
+	if err != nil {
+		cleanup()
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "insert instance"))
+	}
+
+	scratch.InternalIP = inst.InternalIP
+	scratch.Updated = time.Now().UTC()
+	// Seed LastUsed at provisioning so the reaper's ListIdleSince doesn't
+	// pick up a brand-new scratch whose zero-time LastUsed satisfies the
+	// "last_used < cutoff" filter.
+	scratch.LastUsed = scratch.Updated
+	if err := deps.Scratches.Update(ctx, scratch); err != nil {
+		cleanup()
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update with IP"))
+	}
+
+	if err := deps.Scratches.UpdateState(ctx, scratchID, schema.ScratchReady); err != nil {
+		cleanup()
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update state ready"))
+	}
+	scratch.State = schema.ScratchReady
+	return &scratch, nil
+}
+
+// ScratchGet returns the scratch record by ID.
+func ScratchGet(ctx context.Context, req schema.ScratchGetRequest, deps *ScratchGetDeps) (*schema.Scratch, error) {
+	scratch, err := deps.Scratches.Get(ctx, req.ScratchID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, api.AsStatus(codes.NotFound, errors.Errorf("scratch %q not found", req.ScratchID))
+		}
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches get"))
+	}
+	return &scratch, nil
+}
+
+// ScratchDelete tears down the GCE resources and records the scratch as
+// Deleted. The record itself is preserved for audit (a separate retention
+// sweep can later hard-delete via Scratches.Delete).
+func ScratchDelete(ctx context.Context, req schema.ScratchDeleteRequest, deps *ScratchDeleteDeps) (*schema.ScratchDeleteResponse, error) {
+	scratch, err := deps.Scratches.Get(ctx, req.ScratchID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, api.AsStatus(codes.NotFound, errors.Errorf("scratch %q not found", req.ScratchID))
+		}
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches get"))
+	}
+
+	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleting); err != nil {
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update state deleting"))
+	}
+	if scratch.VMName != "" {
+		if err := deps.GCE.DeleteInstance(ctx, scratch.Zone, scratch.VMName); err != nil {
+			log.Printf("DeleteInstance(%s): %v", scratch.VMName, err)
+		}
+	}
+	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleted); err != nil {
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update state deleted"))
+	}
+	return &schema.ScratchDeleteResponse{ScratchID: scratch.ID, State: schema.ScratchDeleted}, nil
+}
+
+func mintID(gen func() string) string {
+	if gen != nil {
+		return gen()
+	}
+	return uuid.New().String()
+}

--- a/internal/api/agentapiservice/scratch_gce.go
+++ b/internal/api/agentapiservice/scratch_gce.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	compute "google.golang.org/api/compute/v0.beta"
+)
+
+// Instance summarizes the fields the broker reads back from Compute Engine
+// after creating or looking up an instance.
+type Instance struct {
+	Name       string
+	Zone       string
+	InternalIP string
+}
+
+// GCE abstracts the Compute Engine operations the broker uses for env
+// lifecycle. Kept narrow so a memory fake (MemoryGCE) covers the surface
+// for tests, and a real Compute-backed impl can be wired at binary boot
+// without leaking SDK types upward.
+type GCE interface {
+	// InsertInstanceFromTemplate creates a VM with the given labels and
+	// returns its summary (including InternalIP) once it is observable to
+	// the API. labels may be nil for ad-hoc instances; pool replenishment
+	// passes pool labels so ListStoppedInstances can find them later.
+	InsertInstanceFromTemplate(ctx context.Context, zone, name, templateURL string, labels map[string]string) (Instance, error)
+	DeleteInstance(ctx context.Context, zone, name string) error
+	// ListStoppedInstances returns terminated VMs whose labels match every
+	// entry in labels (subset match).
+	ListStoppedInstances(ctx context.Context, zone string, labels map[string]string) ([]Instance, error)
+	// StartInstance brings a terminated VM up and returns its summary
+	// (including the (possibly new) InternalIP).
+	StartInstance(ctx context.Context, zone, name string) (Instance, error)
+	// StopInstance terminates a running VM (used at replenishment to
+	// return a freshly-inserted VM to stopped state).
+	StopInstance(ctx context.Context, zone, name string) error
+}
+
+// computeGCE implements GCE against google.golang.org/api/compute.
+// Each call submits the underlying mutation and blocks polling
+// ZoneOperations.Get until the GCE operation reaches DONE so the broker
+// can treat the call as synchronous.
+type computeGCE struct {
+	svc     *compute.Service
+	project string
+	// OpPollInterval and OpTimeout bound the zone-op polling loop.
+	// Defaults are sensible production values; tests can override.
+	OpPollInterval time.Duration
+	OpTimeout      time.Duration
+}
+
+// NewComputeGCE returns a GCE backed by the Compute v1 REST service for
+// project. Uses Application Default Credentials.
+func NewComputeGCE(ctx context.Context, project string) (GCE, error) {
+	svc, err := compute.NewService(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "compute service")
+	}
+	return &computeGCE{
+		svc:            svc,
+		project:        project,
+		OpPollInterval: 2 * time.Second,
+		OpTimeout:      2 * time.Minute,
+	}, nil
+}
+
+func (g *computeGCE) InsertInstanceFromTemplate(ctx context.Context, zone, name, templateURL string, labels map[string]string) (Instance, error) {
+	op, err := g.svc.Instances.Insert(g.project, zone, &compute.Instance{
+		Name:   name,
+		Labels: labels,
+		Scheduling: &compute.Scheduling{
+			// Cuts the wait on delete by ~90s. Requires v0.beta API.
+			SkipGuestOsShutdown: true,
+		},
+	}).
+		SourceInstanceTemplate(templateURL).
+		Context(ctx).Do()
+	if err != nil {
+		return Instance{}, errors.Wrap(err, "instances.insert")
+	}
+	if err := g.waitZoneOp(ctx, zone, op); err != nil {
+		return Instance{}, err
+	}
+	inst, err := g.svc.Instances.Get(g.project, zone, name).Context(ctx).Do()
+	if err != nil {
+		return Instance{}, errors.Wrap(err, "instances.get")
+	}
+	return Instance{Name: inst.Name, Zone: zone, InternalIP: instanceInternalIP(inst)}, nil
+}
+
+func (g *computeGCE) ListStoppedInstances(ctx context.Context, zone string, labels map[string]string) ([]Instance, error) {
+	var filter strings.Builder
+	filter.WriteString("status = TERMINATED")
+	for k, v := range labels {
+		fmt.Fprintf(&filter, " AND labels.%s = %s", k, v)
+	}
+	call := g.svc.Instances.List(g.project, zone).Filter(filter.String()).Context(ctx)
+	var out []Instance
+	if err := call.Pages(ctx, func(page *compute.InstanceList) error {
+		for _, inst := range page.Items {
+			out = append(out, Instance{
+				Name: inst.Name, Zone: zone, InternalIP: instanceInternalIP(inst),
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "instances.list")
+	}
+	return out, nil
+}
+
+func (g *computeGCE) StartInstance(ctx context.Context, zone, name string) (Instance, error) {
+	op, err := g.svc.Instances.Start(g.project, zone, name).Context(ctx).Do()
+	if err != nil {
+		return Instance{}, errors.Wrap(err, "instances.start")
+	}
+	if err := g.waitZoneOp(ctx, zone, op); err != nil {
+		return Instance{}, err
+	}
+	inst, err := g.svc.Instances.Get(g.project, zone, name).Context(ctx).Do()
+	if err != nil {
+		return Instance{}, errors.Wrap(err, "instances.get")
+	}
+	return Instance{Name: inst.Name, Zone: zone, InternalIP: instanceInternalIP(inst)}, nil
+}
+
+func (g *computeGCE) StopInstance(ctx context.Context, zone, name string) error {
+	op, err := g.svc.Instances.Stop(g.project, zone, name).Context(ctx).Do()
+	if err != nil {
+		return errors.Wrap(err, "instances.stop")
+	}
+	return g.waitZoneOp(ctx, zone, op)
+}
+
+func (g *computeGCE) DeleteInstance(ctx context.Context, zone, name string) error {
+	op, err := g.svc.Instances.Delete(g.project, zone, name).Context(ctx).Do()
+	if err != nil {
+		return errors.Wrap(err, "instances.delete")
+	}
+	return g.waitZoneOp(ctx, zone, op)
+}
+
+func (g *computeGCE) waitZoneOp(ctx context.Context, zone string, op *compute.Operation) error {
+	ctx, cancel := context.WithTimeout(ctx, g.OpTimeout)
+	defer cancel()
+	for {
+		if op.Status == "DONE" {
+			if op.Error != nil && len(op.Error.Errors) > 0 {
+				return errors.Errorf("op %s failed: %s", op.Name, op.Error.Errors[0].Message)
+			}
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(g.OpPollInterval):
+		}
+		next, err := g.svc.ZoneOperations.Get(g.project, zone, op.Name).Context(ctx).Do()
+		if err != nil {
+			return errors.Wrap(err, "polling zone op")
+		}
+		op = next
+	}
+}
+
+func instanceInternalIP(inst *compute.Instance) string {
+	for _, ni := range inst.NetworkInterfaces {
+		if ni.NetworkIP != "" {
+			return ni.NetworkIP
+		}
+	}
+	return ""
+}

--- a/internal/api/agentapiservice/scratch_test.go
+++ b/internal/api/agentapiservice/scratch_test.go
@@ -1,0 +1,381 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func testStandard() ClassConfig {
+	return ClassConfig{
+		InstanceTemplate: "projects/p/global/instanceTemplates/builder-standard",
+	}
+}
+
+func testJumbo() *ClassConfig {
+	return &ClassConfig{
+		InstanceTemplate: "projects/p/global/instanceTemplates/builder-jumbo",
+	}
+}
+
+func newCreateDeps(gce GCE, scratches db.Scratch, idGen func() string) *ScratchCreateDeps {
+	return &ScratchCreateDeps{
+		Scratches: scratches,
+		GCE:       gce,
+		Standard:  testStandard(),
+		Jumbo:     testJumbo(),
+		Zone:      "us-central1-a",
+		IDGen:     idGen,
+	}
+}
+
+func TestScratchCreate_HappyPath(t *testing.T) {
+	gce := NewMemoryGCE()
+	gce.SetNextIP("10.0.0.42")
+	scratches := db.NewMemoryScratch()
+	deps := newCreateDeps(gce, scratches, func() string { return "sA" })
+
+	got, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
+		BuildID: "build-1", MachineClass: schema.MachineClassStandard,
+	}, deps)
+	if err != nil {
+		t.Fatalf("ScratchCreate: %v", err)
+	}
+	if got.State != schema.ScratchReady {
+		t.Errorf("State = %q; want ready", got.State)
+	}
+	if got.InternalIP != "10.0.0.42" {
+		t.Errorf("InternalIP = %q; want 10.0.0.42", got.InternalIP)
+	}
+	if got.VMName != "scratch-sA" {
+		t.Errorf("VMName = %q; want scratch-sA", got.VMName)
+	}
+	if got.MachineClass != schema.MachineClassStandard || got.BuildID != "build-1" {
+		t.Errorf("class/build = (%q, %q)", got.MachineClass, got.BuildID)
+	}
+
+	gotLog := gce.Log()
+	if len(gotLog) < 1 || !strings.HasPrefix(gotLog[0], "InsertInstanceFromTemplate(") {
+		t.Errorf("log[0] = %q; want InsertInstanceFromTemplate(...", gotLog)
+	}
+
+	rec, _ := scratches.Get(context.Background(), "sA")
+	if rec.State != schema.ScratchReady {
+		t.Errorf("stored State = %q; want ready", rec.State)
+	}
+}
+
+func TestScratchCreate_JumboUsesJumboTemplate(t *testing.T) {
+	gce := NewMemoryGCE()
+	deps := newCreateDeps(gce, db.NewMemoryScratch(), func() string { return "sJ" })
+
+	if _, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
+		BuildID: "b", MachineClass: schema.MachineClassJumbo,
+	}, deps); err != nil {
+		t.Fatalf("ScratchCreate: %v", err)
+	}
+	if !strings.Contains(gce.Log()[0], "builder-jumbo") {
+		t.Errorf("InsertInstanceFromTemplate log = %q; want builder-jumbo template", gce.Log()[0])
+	}
+}
+
+func TestScratchCreate_UnknownMachineClass(t *testing.T) {
+	deps := newCreateDeps(NewMemoryGCE(), db.NewMemoryScratch(), nil)
+	_, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
+		BuildID: "b", MachineClass: "exotic",
+	}, deps)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("code = %s; want InvalidArgument. err=%v", status.Code(err), err)
+	}
+}
+
+func TestScratchCreate_InstanceInsertFails(t *testing.T) {
+	gce := NewMemoryGCE()
+	gce.FailNext("InsertInstanceFromTemplate", errors.New("region full"))
+	scratches := db.NewMemoryScratch()
+	deps := newCreateDeps(gce, scratches, func() string { return "sI" })
+
+	_, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
+		BuildID: "b", MachineClass: schema.MachineClassStandard,
+	}, deps)
+	if err == nil {
+		t.Fatalf("ScratchCreate succeeded; want failure")
+	}
+	if gce.InstanceExists("us-central1-a", "scratch-sI") {
+		t.Errorf("instance still exists after teardown")
+	}
+	rec, err := scratches.Get(context.Background(), "sI")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec.State != schema.ScratchDeleted {
+		t.Errorf("State = %q; want deleted", rec.State)
+	}
+}
+
+func TestScratchGet_HappyAndMissing(t *testing.T) {
+	scratches := db.NewMemoryScratch()
+	want := schema.Scratch{ID: "s1", State: schema.ScratchReady, InternalIP: "10.0.0.7"}
+	if err := scratches.Insert(context.Background(), want); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	deps := &ScratchGetDeps{Scratches: scratches}
+
+	got, err := ScratchGet(context.Background(), schema.ScratchGetRequest{ScratchID: "s1"}, deps)
+	if err != nil {
+		t.Fatalf("ScratchGet: %v", err)
+	}
+	if got.ID != "s1" || got.InternalIP != "10.0.0.7" {
+		t.Errorf("got = %+v; want s1 / 10.0.0.7", got)
+	}
+
+	_, err = ScratchGet(context.Background(), schema.ScratchGetRequest{ScratchID: "missing"}, deps)
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %s; want NotFound. err=%v", status.Code(err), err)
+	}
+}
+
+func TestScratchDelete_HappyPath(t *testing.T) {
+	gce := NewMemoryGCE()
+	scratches := db.NewMemoryScratch()
+	zone := "us-central1-a"
+	_, _ = gce.InsertInstanceFromTemplate(context.Background(), zone, "scratch-s1", "tmpl", nil)
+	if err := scratches.Insert(context.Background(), schema.Scratch{
+		ID: "s1", State: schema.ScratchReady, Zone: zone, VMName: "scratch-s1",
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+
+	resp, err := ScratchDelete(context.Background(), schema.ScratchDeleteRequest{ScratchID: "s1"},
+		&ScratchDeleteDeps{Scratches: scratches, GCE: gce})
+	if err != nil {
+		t.Fatalf("ScratchDelete: %v", err)
+	}
+	if resp.ScratchID != "s1" || resp.State != schema.ScratchDeleted {
+		t.Errorf("resp = %+v; want s1/deleted", resp)
+	}
+	if gce.InstanceExists(zone, "scratch-s1") {
+		t.Errorf("instance still exists after delete")
+	}
+	rec, _ := scratches.Get(context.Background(), "s1")
+	if rec.State != schema.ScratchDeleted {
+		t.Errorf("State = %q; want deleted", rec.State)
+	}
+}
+
+func TestScratchDelete_NotFound(t *testing.T) {
+	_, err := ScratchDelete(context.Background(), schema.ScratchDeleteRequest{ScratchID: "missing"},
+		&ScratchDeleteDeps{Scratches: db.NewMemoryScratch(), GCE: NewMemoryGCE()})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %s; want NotFound. err=%v", status.Code(err), err)
+	}
+}
+
+// MemoryGCE is an in-memory fake of GCE for tests. It records the operation
+// sequence and supports targeted failure injection.
+type MemoryGCE struct {
+	mu        sync.Mutex
+	log       []string // human-readable: "InsertInstanceFromTemplate(zone,name,...)" etc.
+	instances map[string]Instance
+	labels    map[string]map[string]string // instance key -> labels
+	stopped   map[string]bool              // instance key -> stopped (true means terminated, missing/false means running)
+	// failOnce[op]=err returns err once when op is invoked, then clears.
+	// op keys mirror the log prefixes: "InsertInstanceFromTemplate", "DeleteInstance", ...
+	failOnce map[string]error
+	// nextIP supplies the InternalIP for the next InsertInstance call. If
+	// empty, a deterministic "10.0.0.N" address is assigned.
+	nextIP string
+	ipSeq  int
+}
+
+// NewMemoryGCE returns an empty fake.
+func NewMemoryGCE() *MemoryGCE {
+	return &MemoryGCE{
+		instances: map[string]Instance{},
+		labels:    map[string]map[string]string{},
+		stopped:   map[string]bool{},
+		failOnce:  map[string]error{},
+	}
+}
+
+// SeedStopped pre-creates a stopped instance with the given labels. Used by
+// tests to populate the warm pool without going through Insert+Stop.
+func (m *MemoryGCE) SeedStopped(zone, name string, labels map[string]string, internalIP string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := zone + "/" + name
+	m.instances[key] = Instance{Name: name, Zone: zone, InternalIP: internalIP}
+	m.labels[key] = copyLabels(labels)
+	m.stopped[key] = true
+}
+
+func copyLabels(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	maps.Copy(out, in)
+	return out
+}
+
+func labelsMatch(have, want map[string]string) bool {
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// FailNext registers an error to be returned the next time op runs.
+func (m *MemoryGCE) FailNext(op string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failOnce[op] = err
+}
+
+// SetNextIP fixes the InternalIP for the next InsertInstanceFromTemplate.
+func (m *MemoryGCE) SetNextIP(ip string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextIP = ip
+}
+
+// Log returns the sequence of operations performed so far.
+func (m *MemoryGCE) Log() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.log))
+	copy(out, m.log)
+	return out
+}
+
+// InstanceExists reports whether name exists in zone.
+func (m *MemoryGCE) InstanceExists(zone, name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.instances[zone+"/"+name]
+	return ok
+}
+
+func (m *MemoryGCE) checkFail(op string) error {
+	if err, ok := m.failOnce[op]; ok {
+		delete(m.failOnce, op)
+		return err
+	}
+	return nil
+}
+
+func (m *MemoryGCE) record(format string, args ...any) {
+	m.log = append(m.log, fmt.Sprintf(format, args...))
+}
+
+func (m *MemoryGCE) InsertInstanceFromTemplate(_ context.Context, zone, name, templateURL string, labels map[string]string) (Instance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.record("InsertInstanceFromTemplate(%s,%s,%s)", zone, name, templateURL)
+	if err := m.checkFail("InsertInstanceFromTemplate"); err != nil {
+		return Instance{}, err
+	}
+	key := zone + "/" + name
+	if _, exists := m.instances[key]; exists {
+		return Instance{}, errors.New("instance already exists")
+	}
+	ip := m.nextIP
+	if ip == "" {
+		m.ipSeq++
+		ip = fmt.Sprintf("10.0.0.%d", m.ipSeq)
+	}
+	m.nextIP = ""
+	inst := Instance{Name: name, Zone: zone, InternalIP: ip}
+	m.instances[key] = inst
+	m.labels[key] = copyLabels(labels)
+	// Newly-inserted instances are running.
+	return inst, nil
+}
+
+func (m *MemoryGCE) ListStoppedInstances(_ context.Context, zone string, labels map[string]string) ([]Instance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.record("ListStoppedInstances(%s,%v)", zone, labels)
+	if err := m.checkFail("ListStoppedInstances"); err != nil {
+		return nil, err
+	}
+	var out []Instance
+	for key, inst := range m.instances {
+		if inst.Zone != zone {
+			continue
+		}
+		if !m.stopped[key] {
+			continue
+		}
+		if !labelsMatch(m.labels[key], labels) {
+			continue
+		}
+		out = append(out, inst)
+	}
+	return out, nil
+}
+
+func (m *MemoryGCE) StartInstance(_ context.Context, zone, name string) (Instance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.record("StartInstance(%s,%s)", zone, name)
+	if err := m.checkFail("StartInstance"); err != nil {
+		return Instance{}, err
+	}
+	key := zone + "/" + name
+	inst, ok := m.instances[key]
+	if !ok {
+		return Instance{}, errors.New("instance not found")
+	}
+	delete(m.stopped, key)
+	// Real Compute can change the InternalIP on start; mint a fresh one
+	// so callers must use the returned value rather than the seeded one.
+	m.ipSeq++
+	inst.InternalIP = fmt.Sprintf("10.0.0.%d", m.ipSeq)
+	m.instances[key] = inst
+	return inst, nil
+}
+
+func (m *MemoryGCE) StopInstance(_ context.Context, zone, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.record("StopInstance(%s,%s)", zone, name)
+	if err := m.checkFail("StopInstance"); err != nil {
+		return err
+	}
+	key := zone + "/" + name
+	if _, ok := m.instances[key]; !ok {
+		return errors.New("instance not found")
+	}
+	m.stopped[key] = true
+	return nil
+}
+
+func (m *MemoryGCE) DeleteInstance(_ context.Context, zone, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.record("DeleteInstance(%s,%s)", zone, name)
+	if err := m.checkFail("DeleteInstance"); err != nil {
+		return err
+	}
+	key := zone + "/" + name
+	if _, ok := m.instances[key]; !ok {
+		return errors.New("instance not found")
+	}
+	delete(m.instances, key)
+	return nil
+}

--- a/internal/db/scratch.go
+++ b/internal/db/scratch.go
@@ -1,0 +1,186 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Scratch persists scratch lifecycle records. Extends the generic Resource
+// CRUD with field-level mutators and lifecycle-specific queries.
+//
+// UpdateState and UpdateLastUsed are not just convenience over Update; they
+// write a single Firestore field each, which gives field-level atomicity
+// against concurrent writers. A full-record Update from the reaper and a
+// concurrent UpdateLastUsed from an in-flight exec would race; whichever
+// landed last would clobber the other's field. With field-level updates the
+// two writes commute.
+type Scratch interface {
+	Resource[schema.Scratch, string]
+	// UpdateState sets the state field (and bumps `updated`).
+	UpdateState(ctx context.Context, scratchID string, s schema.ScratchState) error
+	// UpdateLastUsed sets the last_used field (and bumps `updated`).
+	UpdateLastUsed(ctx context.Context, scratchID string, t time.Time) error
+	// ListIdleSince returns scratches in state Ready whose LastUsed is
+	// strictly before t. Backed by a (state, last_used) composite index in
+	// Firestore.
+	ListIdleSince(ctx context.Context, t time.Time) ([]schema.Scratch, error)
+	Delete(ctx context.Context, scratchID string) error
+}
+
+const scratchCollection = "scratch"
+
+func scratchPath(s schema.Scratch) []string { return []string{scratchCollection, s.ID} }
+func scratchKey(id string) []string         { return []string{scratchCollection, id} }
+
+type firestoreScratch struct {
+	*firestoreResource[schema.Scratch, string]
+	client *firestore.Client
+}
+
+func NewFirestoreScratch(c *firestore.Client) Scratch {
+	return &firestoreScratch{
+		firestoreResource: &firestoreResource[schema.Scratch, string]{
+			client: c, pathFor: scratchPath, pathForKey: scratchKey,
+		},
+		client: c,
+	}
+}
+
+func (f *firestoreScratch) doc(id string) *firestore.DocumentRef {
+	return f.client.Collection(scratchCollection).Doc(id)
+}
+
+func (f *firestoreScratch) UpdateState(ctx context.Context, scratchID string, s schema.ScratchState) error {
+	_, err := f.doc(scratchID).Update(ctx, []firestore.Update{
+		{Path: "state", Value: s},
+		{Path: "updated", Value: time.Now().UTC()},
+	})
+	if status.Code(err) == codes.NotFound {
+		return ErrNotFound
+	}
+	return err
+}
+
+func (f *firestoreScratch) UpdateLastUsed(ctx context.Context, scratchID string, t time.Time) error {
+	_, err := f.doc(scratchID).Update(ctx, []firestore.Update{
+		{Path: "last_used", Value: t.UTC()},
+		{Path: "updated", Value: time.Now().UTC()},
+	})
+	if status.Code(err) == codes.NotFound {
+		return ErrNotFound
+	}
+	return err
+}
+
+func (f *firestoreScratch) ListIdleSince(ctx context.Context, t time.Time) ([]schema.Scratch, error) {
+	q := f.client.Collection(scratchCollection).
+		Where("state", "==", string(schema.ScratchReady)).
+		Where("last_used", "<", t.UTC())
+	iter := q.Documents(ctx)
+	defer iter.Stop()
+	var out []schema.Scratch
+	for {
+		snap, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var e schema.Scratch
+		if err := snap.DataTo(&e); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func (f *firestoreScratch) Delete(ctx context.Context, scratchID string) error {
+	// Firestore Delete on a missing doc is a no-op; wrap in a tx so we can
+	// surface ErrNotFound.
+	err := f.client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		ref := f.doc(scratchID)
+		if _, err := tx.Get(ref); err != nil {
+			return err
+		}
+		return tx.Delete(ref)
+	})
+	if status.Code(err) == codes.NotFound {
+		return ErrNotFound
+	}
+	return err
+}
+
+type memoryScratch struct {
+	*memoryResource[schema.Scratch, string]
+}
+
+// NewMemoryScratch returns an in-memory Scratch for tests.
+func NewMemoryScratch() Scratch {
+	return &memoryScratch{
+		memoryResource: &memoryResource[schema.Scratch, string]{
+			data: map[string]schema.Scratch{}, pathFor: scratchPath, pathForKey: scratchKey,
+		},
+	}
+}
+
+func (m *memoryScratch) UpdateState(ctx context.Context, scratchID string, s schema.ScratchState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := scratchCollection + "/" + scratchID
+	e, ok := m.data[key]
+	if !ok {
+		return ErrNotFound
+	}
+	e.State = s
+	e.Updated = time.Now().UTC()
+	m.data[key] = e
+	return nil
+}
+
+func (m *memoryScratch) UpdateLastUsed(ctx context.Context, scratchID string, t time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := scratchCollection + "/" + scratchID
+	e, ok := m.data[key]
+	if !ok {
+		return ErrNotFound
+	}
+	e.LastUsed = t.UTC()
+	e.Updated = time.Now().UTC()
+	m.data[key] = e
+	return nil
+}
+
+func (m *memoryScratch) ListIdleSince(ctx context.Context, t time.Time) ([]schema.Scratch, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []schema.Scratch
+	for _, e := range m.data {
+		if e.State == schema.ScratchReady && e.LastUsed.Before(t) {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+func (m *memoryScratch) Delete(ctx context.Context, scratchID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := scratchCollection + "/" + scratchID
+	if _, ok := m.data[key]; !ok {
+		return ErrNotFound
+	}
+	delete(m.data, key)
+	return nil
+}

--- a/internal/db/scratch_test.go
+++ b/internal/db/scratch_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+// Tests here cover only the methods Scratch adds on top of Resource. The
+// generic CRUD (Insert/Get/Update/Upsert) is exercised by the generic
+// memoryResource through any of its instantiations.
+
+func sampleScratch(id string, state schema.ScratchState, lastUsed time.Time) schema.Scratch {
+	return schema.Scratch{
+		ID:           id,
+		BuildID:      "build-" + id,
+		MachineClass: schema.MachineClassStandard,
+		VMName:       "vm-" + id,
+		InternalIP:   "10.0.0.1",
+		Zone:         "us-central1-a",
+		State:        state,
+		LastUsed:     lastUsed,
+	}
+}
+
+func TestMemoryScratch_BespokeNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryScratch()
+	if err := s.UpdateState(ctx, "missing", schema.ScratchReady); !errors.Is(err, ErrNotFound) {
+		t.Errorf("UpdateState(missing) = %v; want ErrNotFound", err)
+	}
+	if err := s.UpdateLastUsed(ctx, "missing", time.Now()); !errors.Is(err, ErrNotFound) {
+		t.Errorf("UpdateLastUsed(missing) = %v; want ErrNotFound", err)
+	}
+	if err := s.Delete(ctx, "missing"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Delete(missing) = %v; want ErrNotFound", err)
+	}
+}
+
+func TestMemoryScratch_UpdateState(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryScratch()
+	if err := s.Insert(ctx, sampleScratch("e1", schema.ScratchStarting, time.Time{})); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	before := time.Now().UTC()
+	if err := s.UpdateState(ctx, "e1", schema.ScratchReady); err != nil {
+		t.Fatalf("UpdateState: %v", err)
+	}
+	got, _ := s.Get(ctx, "e1")
+	if got.State != schema.ScratchReady {
+		t.Errorf("State = %q; want %q", got.State, schema.ScratchReady)
+	}
+	if got.Updated.Before(before) {
+		t.Errorf("Updated = %v; want >= %v", got.Updated, before)
+	}
+}
+
+func TestMemoryScratch_UpdateLastUsed(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryScratch()
+	if err := s.Insert(ctx, sampleScratch("e1", schema.ScratchReady, time.Time{})); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	before := time.Now().UTC()
+	want := time.Unix(1700000000, 0).UTC()
+	if err := s.UpdateLastUsed(ctx, "e1", want); err != nil {
+		t.Fatalf("UpdateLastUsed: %v", err)
+	}
+	got, _ := s.Get(ctx, "e1")
+	if !got.LastUsed.Equal(want) {
+		t.Errorf("LastUsed = %v; want %v", got.LastUsed, want)
+	}
+	if got.Updated.Before(before) {
+		t.Errorf("Updated = %v; want >= %v", got.Updated, before)
+	}
+}
+
+func TestMemoryScratch_ListIdleSince(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryScratch()
+	cutoff := time.Unix(1700001000, 0).UTC()
+	old := cutoff.Add(-time.Hour)
+	fresh := cutoff.Add(time.Hour)
+
+	for _, e := range []schema.Scratch{
+		sampleScratch("ready-old", schema.ScratchReady, old),                   // ✓ included
+		sampleScratch("ready-fresh", schema.ScratchReady, fresh),               // ✗ too fresh
+		sampleScratch("starting-old", schema.ScratchStarting, old),             // ✗ wrong state
+		sampleScratch("deleting-old", schema.ScratchDeleting, old),             // ✗ wrong state
+		sampleScratch("deleted-old", schema.ScratchDeleted, old),               // ✗ wrong state
+		sampleScratch("ready-old-2", schema.ScratchReady, old.Add(-time.Hour)), // ✓ included
+	} {
+		if err := s.Insert(ctx, e); err != nil {
+			t.Fatalf("Insert(%s): %v", e.ID, err)
+		}
+	}
+
+	got, err := s.ListIdleSince(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("ListIdleSince: %v", err)
+	}
+	var ids []string
+	for _, e := range got {
+		ids = append(ids, e.ID)
+	}
+	sort.Strings(ids)
+	want := []string{"ready-old", "ready-old-2"}
+	if diff := cmp.Diff(want, ids); diff != "" {
+		t.Errorf("ListIdleSince ids mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMemoryScratch_Delete(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryScratch()
+	if err := s.Insert(ctx, sampleScratch("e1", schema.ScratchReady, time.Time{})); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := s.Delete(ctx, "e1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.Get(ctx, "e1"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after Delete = %v; want ErrNotFound", err)
+	}
+}

--- a/pkg/rebuild/schema/scratch.go
+++ b/pkg/rebuild/schema/scratch.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import (
+	"errors"
+	"time"
+)
+
+// ScratchState is the lifecycle state of a scratch build environment.
+type ScratchState string
+
+const (
+	ScratchStarting ScratchState = "starting"
+	ScratchReady    ScratchState = "ready"
+	ScratchDeleting ScratchState = "deleting"
+	ScratchDeleted  ScratchState = "deleted"
+)
+
+// MachineClass selects the VM size for a scratch.
+type MachineClass string
+
+const (
+	MachineClassStandard MachineClass = "standard"
+	MachineClassJumbo    MachineClass = "jumbo"
+)
+
+// Scratch is a per-build agent scratch environment. It binds a VM to an
+// agent for maintaining build-local state (Docker daemon storage, working
+// directory, build caches) on the VM's local SSD.
+type Scratch struct {
+	ID           string       `json:"id,omitempty" firestore:"id,omitempty"`
+	BuildID      string       `json:"build_id,omitempty" firestore:"build_id,omitempty"`
+	MachineClass MachineClass `json:"machine_class,omitempty" firestore:"machine_class,omitempty"`
+	VMName       string       `json:"vm_name,omitempty" firestore:"vm_name,omitempty"`
+	InternalIP   string       `json:"internal_ip,omitempty" firestore:"internal_ip,omitempty"`
+	Zone         string       `json:"zone,omitempty" firestore:"zone,omitempty"`
+	State        ScratchState `json:"state,omitempty" firestore:"state,omitempty"`
+	Created      time.Time    `json:"created,omitzero" firestore:"created,omitempty"`
+	Updated      time.Time    `json:"updated,omitzero" firestore:"updated,omitempty"`
+	LastUsed     time.Time    `json:"last_used,omitzero" firestore:"last_used,omitempty"`
+}
+
+// ScratchCreateRequest is the input to /scratch/create.
+type ScratchCreateRequest struct {
+	BuildID      string       `form:"build_id,required"`
+	MachineClass MachineClass `form:"machine_class,required"`
+}
+
+// Validate implements act.Input.
+func (r ScratchCreateRequest) Validate() error {
+	if r.BuildID == "" {
+		return errors.New("build_id is required")
+	}
+	if r.MachineClass == "" {
+		return errors.New("machine_class is required")
+	}
+	return nil
+}
+
+// ScratchGetRequest is the input to /scratch/get.
+type ScratchGetRequest struct {
+	ScratchID string `form:"scratch_id,required"`
+}
+
+// Validate implements act.Input.
+func (r ScratchGetRequest) Validate() error {
+	if r.ScratchID == "" {
+		return errors.New("scratch_id is required")
+	}
+	return nil
+}
+
+// ScratchDeleteRequest is the input to /scratch/delete.
+type ScratchDeleteRequest struct {
+	ScratchID string `form:"scratch_id,required"`
+}
+
+// Validate implements act.Input.
+func (r ScratchDeleteRequest) Validate() error {
+	if r.ScratchID == "" {
+		return errors.New("scratch_id is required")
+	}
+	return nil
+}
+
+// ScratchDeleteResponse is returned by /scratch/delete.
+type ScratchDeleteResponse struct {
+	ScratchID string       `json:"scratch_id"`
+	State     ScratchState `json:"state"`
+}


### PR DESCRIPTION
This is *incomplete* but demonstrates the ability to create and teardown
VMs and exercises our state bookkeeping. Subsquent changes actually
enable us to make use of these constructs for remote execution and state
management.