### PR TITLE
Add initial scratch worker

### DIFF
--- a/build/package/Dockerfile.scratch-worker
+++ b/build/package/Dockerfile.scratch-worker
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS binary
+ARG DEBUG=false
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build \
+    -ldflags="$([ ${DEBUG} = "true" ] || printf '-s -w')" \
+    -gcflags="-l=4" \
+    -o scratch-worker \
+    ./cmd/scratch-worker
+FROM scratch
+COPY --from=binary /src/scratch-worker /
+ENTRYPOINT ["/scratch-worker"]

--- a/cmd/agent-api/main.go
+++ b/cmd/agent-api/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"cloud.google.com/go/storage"
@@ -38,6 +39,7 @@ var (
 	// Scratch flags. Gated by --scratch-enabled.
 	scratchEnabled      = flag.Bool("scratch-enabled", false, "register the scratch routes")
 	scratchZone         = flag.String("scratch-zone", "", "GCE zone for scratch VMs (required when scratch enabled)")
+	scratchWorkerPort   = flag.Int("scratch-worker-port", 8080, "port the worker listens on")
 	scratchStandardTmpl = flag.String("scratch-instance-standard-template", "", "GCE instance template URL for the standard machine class (required when scratch enabled)")
 	scratchJumboTmpl    = flag.String("scratch-instance-jumbo-template", "", "GCE instance template URL for the jumbo machine class (optional)")
 )
@@ -123,6 +125,28 @@ func AgentCompleteInit(ctx context.Context) (*agentapiservice.AgentCompleteDeps,
 	return &d, nil
 }
 
+// scratchHealthProbe pings http://<ip>:<workerPort>/healthz. Worker
+// /healthz is unauthenticated by design.
+func scratchHealthProbe(workerPort int) agentapiservice.HealthProbe {
+	client := &http.Client{Timeout: 2 * time.Second}
+	return func(ctx context.Context, ip string) error {
+		u := fmt.Sprintf("http://%s:%d/healthz", ip, workerPort)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return errors.Errorf("healthz status %d", resp.StatusCode)
+		}
+		return nil
+	}
+}
+
 func ScratchCreateInit(ctx context.Context) (*agentapiservice.ScratchCreateDeps, error) {
 	fs, err := firestore.NewClient(ctx, *project)
 	if err != nil {
@@ -146,7 +170,8 @@ func ScratchCreateInit(ctx context.Context) (*agentapiservice.ScratchCreateDeps,
 				InstanceTemplate: *scratchJumboTmpl,
 			}
 		}(),
-		Zone: *scratchZone,
+		Zone:        *scratchZone,
+		HealthProbe: scratchHealthProbe(*scratchWorkerPort),
 	}, nil
 }
 

--- a/cmd/scratch-worker/main.go
+++ b/cmd/scratch-worker/main.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Command scratch-worker is the per-VM scratch worker. It serves
+// /healthz and /stat over HTTP. The worker has no GCP credentials of
+// its own; the VM template should set service_account = null.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/google/oss-rebuild/internal/api"
+	"github.com/google/oss-rebuild/internal/api/scratchworkerservice"
+	"github.com/google/oss-rebuild/internal/api/scratchworkerservice/idauth"
+)
+
+var (
+	callerSA         = flag.String("caller-sa", "", "caller service account email (sender of incoming requests)")
+	audience         = flag.String("audience", "", "expected ID-token audience (e.g. https://builder/<vm-name>)")
+	dockerSocketPath = flag.String("docker-socket", "/var/run/docker.sock", "path probed by /stat for Docker daemon presence")
+	diskPaths        = flag.String("disk-paths", "", "comma-separated mount paths reported by /stat")
+	listen           = flag.String("listen", ":8080", "listen address")
+)
+
+// statDeps holds the singleton built once at startup.
+var statDeps *scratchworkerservice.StatDeps
+
+func statInit(_ context.Context) (*scratchworkerservice.StatDeps, error) { return statDeps, nil }
+
+func main() {
+	flag.Parse()
+	if *callerSA == "" {
+		log.Fatalf("--caller-sa is required")
+	}
+	if *audience == "" {
+		log.Fatalf("--audience is required")
+	}
+
+	statDeps = &scratchworkerservice.StatDeps{
+		DockerSocketPath: *dockerSocketPath,
+		DiskPaths:        splitCSV(*diskPaths),
+	}
+
+	mw := idauth.Middleware(idauth.NewGoogleValidator(*callerSA, *audience))
+
+	mux := http.NewServeMux()
+	mux.Handle("/stat", mw(api.Handler(statInit, scratchworkerservice.Stat)))
+	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, _ *http.Request) { rw.WriteHeader(http.StatusOK) })
+
+	log.Printf("scratch-worker listening on %s", *listen)
+	if err := http.ListenAndServe(*listen, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/deployments/containers.tf
+++ b/deployments/containers.tf
@@ -98,7 +98,7 @@ locals {
       build_args = ["DEBUG=${terraform_data.debug.output}"]
     }
   } : {})
-  prebuild_images = {
+  prebuild_images = merge({
     gsutil_writeonly = {
       dockerfile = "build/package/Dockerfile.gsutil_writeonly"
       build_args = ["DEBUG=${terraform_data.debug.output}"]
@@ -115,7 +115,15 @@ locals {
       dockerfile = "build/package/Dockerfile.tetragon_sysgraph"
       build_args = ["DEBUG=${terraform_data.debug.output}"]
     }
-  }
+    }, var.enable_scratch ? {
+    # scratch-worker is downloaded onto scratch VMs at startup via the
+    # cloud-init script in services.tf. Treated as a bootstrap binary
+    # like gsutil_writeonly et al.
+    scratch-worker = {
+      dockerfile = "build/package/Dockerfile.scratch-worker"
+      build_args = ["DEBUG=${terraform_data.debug.output}"]
+    }
+  } : {})
 }
 
 module "service_images" {

--- a/deployments/platform.tf
+++ b/deployments/platform.tf
@@ -313,3 +313,17 @@ resource "google_compute_firewall" "allow_outbound" {
   }
   destination_ranges = ["0.0.0.0/0"]
 }
+
+# Scratch workers: reachable on port 8080 only from agent-api's
+# Direct VPC egress range. Workers have no external IPs.
+resource "google_compute_firewall" "scratch-worker-ingress" {
+  count   = var.enable_scratch ? 1 : 0
+  name    = "${var.host}-scratch-worker-ingress"
+  network = google_compute_network.vpc[0].name
+  allow {
+    protocol = "tcp"
+    ports    = ["8080"]
+  }
+  source_ranges = [google_compute_subnetwork.subnet[0].ip_cidr_range]
+  target_tags   = ["scratch"]
+}

--- a/deployments/scratch_startup.sh
+++ b/deployments/scratch_startup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Worker VM startup script.
+#
+# The worker VM has NO attached service account — it holds zero GCP
+# credentials. This script can still fetch the scratch-worker binary
+# from GCS because the bootstrap-tools bucket is public-readable on
+# public deployments; the binary itself doesn't contain anything
+# sensitive.
+# TODO: For private deployments, attach a narrowly-scoped SA with
+# storage.objects.get on the bootstrap-tools bucket, or expose the
+# binary via a signed URL in instance metadata.
+#
+# Templated by Terraform with:
+#   worker_binary_uri - gs://... full URI to the scratch-worker binary
+#   caller_sa         - email of the SA that calls the worker (agent-api's)
+#   audience          - expected ID-token audience for inbound requests
+
+set -euxo pipefail
+
+DEBIAN_FRONTEND=noninteractive apt-get update -y
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    docker.io \
+    curl \
+    ca-certificates
+systemctl enable --now docker
+
+# Mount the local SSD at /var/lib/docker for IOPS.
+if [ -e /dev/nvme0n1 ]; then
+    mkfs.ext4 -F /dev/nvme0n1
+    mkdir -p /var/lib/docker
+    mount /dev/nvme0n1 /var/lib/docker
+    systemctl restart docker
+fi
+
+useradd --create-home --home-dir /home/builder --shell /bin/bash builder || true
+mkdir -p /opt/builder
+chown -R builder:builder /opt/builder /home/builder
+
+# TODO: Support non-public bootstrap tools.
+WORKER_BINARY_URI='${worker_binary_uri}'
+curl -fsSL -o /opt/builder/scratch-worker \
+    "https://storage.googleapis.com/$${WORKER_BINARY_URI#gs://}"
+chmod +x /opt/builder/scratch-worker
+
+cat >/etc/systemd/system/scratch-worker.service <<EOF
+[Unit]
+Description=Scratch worker
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=builder
+WorkingDirectory=/home/builder
+ExecStart=/opt/builder/scratch-worker \\
+    --caller-sa=${caller_sa} \\
+    --audience=${audience} \\
+    --docker-socket=/var/run/docker.sock \\
+    --disk-paths=/var/lib/docker,/home/builder \\
+    --listen=:8080
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now scratch-worker.service

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -42,9 +42,9 @@ resource "google_cloudbuild_worker_pool" "jumbo-pool" {
   depends_on = [google_project_service.cloudbuild]
 }
 
-# Instance template for scratch VMs.
-# TODO: Add a startup script that fetches and runs the scratch-worker
-# binary once the worker service lands.
+# Instance template for scratch VMs. The startup script fetches and
+# runs the scratch-worker binary; the VM has no attached service account
+# so agent-api drives the worker over private-IP HTTP with an ID token.
 resource "google_compute_instance_template" "scratch-standard" {
   count        = var.enable_scratch ? 1 : 0
   name_prefix  = "${var.host}-scratch-standard-"
@@ -77,6 +77,14 @@ resource "google_compute_instance_template" "scratch-standard" {
 
   tags   = ["scratch"]
   labels = { purpose = "scratch" }
+
+  metadata = {
+    startup-script = templatefile("${path.module}/scratch_startup.sh", {
+      worker_binary_uri = "gs://${google_storage_bucket.bootstrap-tools.name}/${module.prebuild_images["scratch-worker"].image_version}/scratch-worker"
+      caller_sa         = google_service_account.orchestrator.email
+      audience          = "https://builder/$${HOSTNAME}"
+    })
+  }
 
   lifecycle {
     create_before_destroy = true
@@ -382,6 +390,7 @@ resource "google_cloud_run_v2_service" "agent-api" {
         ] : [], var.enable_scratch ? [
         "--scratch-enabled=true",
         "--scratch-zone=us-central1-a",
+        "--scratch-worker-port=8080",
         "--scratch-instance-standard-template=${google_compute_instance_template.scratch-standard[0].self_link}",
       ] : [])
       resources {
@@ -389,6 +398,18 @@ resource "google_cloud_run_v2_service" "agent-api" {
           cpu    = "1000m"
           memory = "1G"
         }
+      }
+    }
+    # When scratch is enabled, agent-api reaches worker VMs on private
+    # IPs via Direct VPC egress.
+    dynamic "vpc_access" {
+      for_each = var.enable_scratch ? [1] : []
+      content {
+        network_interfaces {
+          network    = google_compute_network.vpc[0].name
+          subnetwork = google_compute_subnetwork.subnet[0].name
+        }
+        egress = "ALL_TRAFFIC"
       }
     }
     scaling { max_instance_count = 10 }

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 	google.golang.org/api v0.242.0
 	google.golang.org/genai v1.24.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250804133106-a7a43d27e69b
@@ -110,7 +111,6 @@ require (
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/internal/api/agentapiservice/scratch.go
+++ b/internal/api/agentapiservice/scratch.go
@@ -42,6 +42,15 @@ func selectClass(class schema.MachineClass, standard ClassConfig, jumbo *ClassCo
 	}
 }
 
+// HealthProbe pings the worker at ip and returns nil when /healthz responds.
+// Injected so tests can drive the polling deterministically.
+//
+// /healthz is a plain unauthenticated GET (outside the act framework) so the
+// broker can probe before any caller context exists and so external health
+// checkers (LB, MIG) can hit it without minting tokens. Could be folded into
+// act if those constraints stop mattering.
+type HealthProbe func(ctx context.Context, internalIP string) error
+
 // ScratchCreateDeps wires ScratchCreate.
 type ScratchCreateDeps struct {
 	Scratches db.Scratch
@@ -52,6 +61,12 @@ type ScratchCreateDeps struct {
 	// means jumbo isn't available and requsts returns InvalidArgument.
 	Jumbo *ClassConfig
 	Zone  string
+	// HealthProbe is called until it returns nil or HealthTimeout elapses.
+	HealthProbe HealthProbe
+	// HealthTimeout bounds the polling loop. Zero means 90 seconds.
+	HealthTimeout time.Duration
+	// HealthInterval is the gap between probe attempts. Zero means 500ms.
+	HealthInterval time.Duration
 	// IDGen mints scratch IDs. nil falls back to uuid.New().String().
 	IDGen func() string
 }
@@ -70,12 +85,7 @@ type ScratchDeleteDeps struct {
 // ScratchCreate provisions a new build environment synchronously. Steps:
 //
 //	Scratches.Insert(state=Starting) -> InsertInstance -> Update with
-//	InternalIP -> UpdateState(Ready) -> return.
-//
-// Ready currently means "VM exists." The template supplies the boot disk
-// and local SSD partitions; no additional disks are attached.
-// TODO: Poll a worker /healthz before UpdateState(Ready) so Ready means
-// "worker is reachable" once the worker service exists.
+//	InternalIP -> poll HealthProbe -> UpdateState(Ready) -> return.
 //
 // If any step fails after resources are created, best-effort teardown is
 // run and the record is marked Deleted (records persist for audit).
@@ -134,6 +144,11 @@ func ScratchCreate(ctx context.Context, req schema.ScratchCreateRequest, deps *S
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update with IP"))
 	}
 
+	if err := waitHealthy(ctx, deps, scratch.InternalIP); err != nil {
+		cleanup()
+		return nil, api.AsStatus(codes.DeadlineExceeded, errors.Wrap(err, "worker healthz"))
+	}
+
 	if err := deps.Scratches.UpdateState(ctx, scratchID, schema.ScratchReady); err != nil {
 		cleanup()
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update state ready"))
@@ -178,6 +193,34 @@ func ScratchDelete(ctx context.Context, req schema.ScratchDeleteRequest, deps *S
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update state deleted"))
 	}
 	return &schema.ScratchDeleteResponse{ScratchID: scratch.ID, State: schema.ScratchDeleted}, nil
+}
+
+func waitHealthy(ctx context.Context, deps *ScratchCreateDeps, ip string) error {
+	timeout := deps.HealthTimeout
+	if timeout <= 0 {
+		timeout = 90 * time.Second
+	}
+	interval := deps.HealthInterval
+	if interval <= 0 {
+		interval = 500 * time.Millisecond
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := deps.HealthProbe(probeCtx, ip); err == nil {
+		return nil
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-probeCtx.Done():
+			return probeCtx.Err()
+		case <-t.C:
+			if err := deps.HealthProbe(probeCtx, ip); err == nil {
+				return nil
+			}
+		}
+	}
 }
 
 func mintID(gen func() string) string {

--- a/internal/api/agentapiservice/scratch_test.go
+++ b/internal/api/agentapiservice/scratch_test.go
@@ -10,7 +10,9 @@ import (
 	"maps"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/oss-rebuild/internal/db"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
@@ -30,14 +32,40 @@ func testJumbo() *ClassConfig {
 	}
 }
 
-func newCreateDeps(gce GCE, scratches db.Scratch, idGen func() string) *ScratchCreateDeps {
+func newCreateDeps(gce GCE, scratches db.Scratch, probe HealthProbe, idGen func() string) *ScratchCreateDeps {
 	return &ScratchCreateDeps{
-		Scratches: scratches,
-		GCE:       gce,
-		Standard:  testStandard(),
-		Jumbo:     testJumbo(),
-		Zone:      "us-central1-a",
-		IDGen:     idGen,
+		Scratches:      scratches,
+		GCE:            gce,
+		Standard:       testStandard(),
+		Jumbo:          testJumbo(),
+		Zone:           "us-central1-a",
+		HealthProbe:    probe,
+		HealthTimeout:  500 * time.Millisecond,
+		HealthInterval: 10 * time.Millisecond,
+		IDGen:          idGen,
+	}
+}
+
+// okProbe is a HealthProbe that always succeeds, for tests that don't
+// care about the probe behavior.
+func okProbe(_ context.Context, _ string) error { return nil }
+
+// healthyAfter returns a HealthProbe that fails the first n-1 calls and
+// succeeds afterwards. counter is updated atomically with each invocation.
+func healthyAfter(counter *int32, n int32) HealthProbe {
+	return func(_ context.Context, _ string) error {
+		c := atomic.AddInt32(counter, 1)
+		if c < n {
+			return errors.New("not yet")
+		}
+		return nil
+	}
+}
+
+func alwaysUnhealthy(counter *int32) HealthProbe {
+	return func(_ context.Context, _ string) error {
+		atomic.AddInt32(counter, 1)
+		return errors.New("nope")
 	}
 }
 
@@ -45,7 +73,7 @@ func TestScratchCreate_HappyPath(t *testing.T) {
 	gce := NewMemoryGCE()
 	gce.SetNextIP("10.0.0.42")
 	scratches := db.NewMemoryScratch()
-	deps := newCreateDeps(gce, scratches, func() string { return "sA" })
+	deps := newCreateDeps(gce, scratches, okProbe, func() string { return "sA" })
 
 	got, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
 		BuildID: "build-1", MachineClass: schema.MachineClassStandard,
@@ -79,7 +107,7 @@ func TestScratchCreate_HappyPath(t *testing.T) {
 
 func TestScratchCreate_JumboUsesJumboTemplate(t *testing.T) {
 	gce := NewMemoryGCE()
-	deps := newCreateDeps(gce, db.NewMemoryScratch(), func() string { return "sJ" })
+	deps := newCreateDeps(gce, db.NewMemoryScratch(), okProbe, func() string { return "sJ" })
 
 	if _, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
 		BuildID: "b", MachineClass: schema.MachineClassJumbo,
@@ -92,7 +120,7 @@ func TestScratchCreate_JumboUsesJumboTemplate(t *testing.T) {
 }
 
 func TestScratchCreate_UnknownMachineClass(t *testing.T) {
-	deps := newCreateDeps(NewMemoryGCE(), db.NewMemoryScratch(), nil)
+	deps := newCreateDeps(NewMemoryGCE(), db.NewMemoryScratch(), okProbe, nil)
 	_, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
 		BuildID: "b", MachineClass: "exotic",
 	}, deps)
@@ -105,7 +133,7 @@ func TestScratchCreate_InstanceInsertFails(t *testing.T) {
 	gce := NewMemoryGCE()
 	gce.FailNext("InsertInstanceFromTemplate", errors.New("region full"))
 	scratches := db.NewMemoryScratch()
-	deps := newCreateDeps(gce, scratches, func() string { return "sI" })
+	deps := newCreateDeps(gce, scratches, okProbe, func() string { return "sI" })
 
 	_, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
 		BuildID: "b", MachineClass: schema.MachineClassStandard,
@@ -119,6 +147,49 @@ func TestScratchCreate_InstanceInsertFails(t *testing.T) {
 	rec, err := scratches.Get(context.Background(), "sI")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
+	}
+	if rec.State != schema.ScratchDeleted {
+		t.Errorf("State = %q; want deleted", rec.State)
+	}
+}
+
+func TestScratchCreate_HealthzPollsUntilSuccess(t *testing.T) {
+	gce := NewMemoryGCE()
+	var probeCount int32
+	const wantCalls = int32(3)
+	deps := newCreateDeps(gce, db.NewMemoryScratch(), healthyAfter(&probeCount, wantCalls), func() string { return "sP" })
+
+	if _, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
+		BuildID: "b", MachineClass: schema.MachineClassStandard,
+	}, deps); err != nil {
+		t.Fatalf("ScratchCreate: %v", err)
+	}
+	if got := atomic.LoadInt32(&probeCount); got != wantCalls {
+		t.Errorf("probe calls = %d; want %d", got, wantCalls)
+	}
+}
+
+func TestScratchCreate_HealthzTimeoutTriggersTeardown(t *testing.T) {
+	gce := NewMemoryGCE()
+	scratches := db.NewMemoryScratch()
+	var probeCount int32
+	deps := newCreateDeps(gce, scratches, alwaysUnhealthy(&probeCount), func() string { return "sT" })
+
+	_, err := ScratchCreate(context.Background(), schema.ScratchCreateRequest{
+		BuildID: "b", MachineClass: schema.MachineClassStandard,
+	}, deps)
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Errorf("code = %s; want DeadlineExceeded. err=%v", status.Code(err), err)
+	}
+	if atomic.LoadInt32(&probeCount) < 2 {
+		t.Errorf("probe calls = %d; want >= 2 (polling loop)", probeCount)
+	}
+	if gce.InstanceExists("us-central1-a", "scratch-sT") {
+		t.Errorf("instance still exists after teardown")
+	}
+	rec, err := scratches.Get(context.Background(), "sT")
+	if err != nil {
+		t.Fatalf("Get after teardown: %v", err)
 	}
 	if rec.State != schema.ScratchDeleted {
 		t.Errorf("State = %q; want deleted", rec.State)

--- a/internal/api/scratchworkerservice/idauth/idauth.go
+++ b/internal/api/scratchworkerservice/idauth/idauth.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package idauth provides HTTP middleware that requires a Google-signed
+// ID token on inbound requests. Used on the scratch worker to
+// gate /exec/start and /stat to the broker's service account.
+package idauth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/api/idtoken"
+)
+
+// Validator verifies an inbound bearer token. Implementations return the
+// caller's email on success.
+type Validator interface {
+	Validate(ctx context.Context, token string) (email string, err error)
+}
+
+// googleValidator verifies a Google-signed ID token against an expected
+// audience and asserts the email claim matches the configured caller SA.
+type googleValidator struct {
+	audience      string
+	expectedEmail string
+}
+
+// NewGoogleValidator returns a Validator that requires the token to be
+// signed by Google, have audience equal to audience, and carry an email
+// claim equal to expectedEmail.
+func NewGoogleValidator(expectedEmail, audience string) Validator {
+	return &googleValidator{expectedEmail: expectedEmail, audience: audience}
+}
+
+func (g *googleValidator) Validate(ctx context.Context, token string) (string, error) {
+	payload, err := idtoken.Validate(ctx, token, g.audience)
+	if err != nil {
+		return "", errors.Wrap(err, "idtoken validate")
+	}
+	email, _ := payload.Claims["email"].(string)
+	if email != g.expectedEmail {
+		return email, errors.Errorf("email %q does not match expected %q", email, g.expectedEmail)
+	}
+	return email, nil
+}
+
+// Middleware returns an HTTP middleware that gates next behind a valid
+// bearer token. Failures emit 401 with a short text body.
+func Middleware(v Validator) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			tok := bearer(r)
+			if tok == "" {
+				http.Error(rw, "missing bearer token", http.StatusUnauthorized)
+				return
+			}
+			if _, err := v.Validate(r.Context(), tok); err != nil {
+				http.Error(rw, "invalid token", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(rw, r)
+		})
+	}
+}
+
+func bearer(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(h, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(h, prefix))
+}

--- a/internal/api/scratchworkerservice/idauth/idauth_test.go
+++ b/internal/api/scratchworkerservice/idauth/idauth_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package idauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+type fakeValidator struct {
+	accept string // the one token value that passes
+	email  string
+}
+
+func (f fakeValidator) Validate(_ context.Context, token string) (string, error) {
+	if token == f.accept {
+		return f.email, nil
+	}
+	return "", errors.New("not authorized")
+}
+
+func wrap(t *testing.T, v Validator) *httptest.Server {
+	t.Helper()
+	mw := Middleware(v)
+	h := mw(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusNoContent) // distinct success signal
+	}))
+	return httptest.NewServer(h)
+}
+
+func TestMiddleware_MissingHeader(t *testing.T) {
+	srv := wrap(t, fakeValidator{accept: "good", email: "broker@example.com"})
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", resp.StatusCode)
+	}
+}
+
+func TestMiddleware_NonBearer(t *testing.T) {
+	srv := wrap(t, fakeValidator{accept: "good"})
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Basic Z29vZA==")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", resp.StatusCode)
+	}
+}
+
+func TestMiddleware_BadToken(t *testing.T) {
+	srv := wrap(t, fakeValidator{accept: "good"})
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer not-the-good-one")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", resp.StatusCode)
+	}
+}
+
+func TestMiddleware_GoodToken(t *testing.T) {
+	srv := wrap(t, fakeValidator{accept: "good", email: "broker@example.com"})
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer good")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d; want 204 (handler reached)", resp.StatusCode)
+	}
+}
+
+func TestBearer_WhitespaceAndCase(t *testing.T) {
+	cases := map[string]string{
+		"Bearer abc":    "abc",
+		"Bearer  abc":   "abc",
+		"Bearer abc ":   "abc",
+		"":              "",
+		"bearer abc":    "", // case-sensitive on purpose
+		"Bearer":        "",
+		"NotBearer abc": "",
+	}
+	for header, want := range cases {
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
+		if header != "" {
+			req.Header.Set("Authorization", header)
+		}
+		if got := bearer(req); got != want {
+			t.Errorf("bearer(%q) = %q; want %q", header, got, want)
+		}
+	}
+}

--- a/internal/api/scratchworkerservice/stat.go
+++ b/internal/api/scratchworkerservice/stat.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scratchworkerservice
+
+import (
+	"context"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// StatRequest is the empty input for the worker's /stat endpoint.
+type StatRequest struct{}
+
+// Validate implements act.Input.
+func (StatRequest) Validate() error { return nil }
+
+// DiskUsage reports total/free byte counts for a mounted filesystem.
+type DiskUsage struct {
+	Path  string `json:"path"`
+	Total uint64 `json:"total"`
+	Free  uint64 `json:"free"`
+}
+
+// StatResult is the worker self-report returned by /stat.
+type StatResult struct {
+	DockerSocketPresent bool        `json:"docker_socket_present"`
+	DockerSocketPath    string      `json:"docker_socket_path,omitempty"`
+	Disks               []DiskUsage `json:"disks,omitempty"`
+}
+
+// StatDeps are the inputs the Stat handler needs.
+// Configured at worker startup, the same values are used on every request.
+type StatDeps struct {
+	// DockerSocketPath is the path probed for daemon presence.
+	// Default at construction time, typically "/var/run/docker.sock".
+	DockerSocketPath string
+	// DiskPaths are the filesystem mounts to report usage for.
+	// Typically Workdir + the Docker root.
+	DiskPaths []string
+}
+
+// Stat returns a snapshot of the worker's relevant local state.
+func Stat(_ context.Context, _ StatRequest, deps *StatDeps) (*StatResult, error) {
+	out := &StatResult{}
+	if deps.DockerSocketPath != "" {
+		out.DockerSocketPath = deps.DockerSocketPath
+		if _, err := os.Stat(deps.DockerSocketPath); err == nil {
+			out.DockerSocketPresent = true
+		}
+	}
+	for _, p := range deps.DiskPaths {
+		if du, err := diskUsage(p); err == nil {
+			out.Disks = append(out.Disks, du)
+		}
+	}
+	return out, nil
+}
+
+func diskUsage(path string) (DiskUsage, error) {
+	var s unix.Statfs_t
+	if err := unix.Statfs(path, &s); err != nil {
+		return DiskUsage{}, err
+	}
+	bsize := uint64(s.Bsize)
+	return DiskUsage{
+		Path:  path,
+		Total: bsize * uint64(s.Blocks),
+		Free:  bsize * uint64(s.Bavail),
+	}, nil
+}

--- a/internal/api/scratchworkerservice/stat_test.go
+++ b/internal/api/scratchworkerservice/stat_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scratchworkerservice
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestStat_FieldsAndDiskUsage(t *testing.T) {
+	dir := t.TempDir()
+	// Point socket probe at something that doesn't exist so we deterministically
+	// see DockerSocketPresent = false.
+	deps := &StatDeps{
+		DockerSocketPath: "/tmp/this-socket-does-not-exist",
+		DiskPaths:        []string{dir},
+	}
+	got, err := Stat(context.Background(), StatRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got.DockerSocketPresent {
+		t.Errorf("DockerSocketPresent = true; want false (path absent)")
+	}
+	if got.DockerSocketPath != "/tmp/this-socket-does-not-exist" {
+		t.Errorf("DockerSocketPath = %q; want %q", got.DockerSocketPath, "/tmp/this-socket-does-not-exist")
+	}
+	if len(got.Disks) != 1 {
+		t.Fatalf("Disks len = %d; want 1", len(got.Disks))
+	}
+	if got.Disks[0].Path != dir || got.Disks[0].Total == 0 || got.Disks[0].Free == 0 {
+		t.Errorf("Disks[0] = %+v; want non-zero Total/Free for %q", got.Disks[0], dir)
+	}
+}
+
+func TestStat_DockerSocketPresent(t *testing.T) {
+	// Create a UNIX-domain socket file (any file will do for os.Stat check).
+	sock, err := os.CreateTemp(t.TempDir(), "fake-docker.sock")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	sock.Close()
+	deps := &StatDeps{DockerSocketPath: sock.Name()}
+	got, err := Stat(context.Background(), StatRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !got.DockerSocketPresent {
+		t.Errorf("DockerSocketPresent = false; want true (path exists)")
+	}
+}


### PR DESCRIPTION
This sidecar runs alongside any activity in the scratch environment and
mediates communication with the agent API. Notably, the worker has no
IAM access itself so the only way we get data back to durable storage
is pull-through via the agent API. We authenticate by pre-configuring
the sidecar to expect the agent API credentials and validating a signed
JWT sent alongside each request.