### PR TITLE
Add execution support to scratch

### DIFF
--- a/cmd/agent-api/main.go
+++ b/cmd/agent-api/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -17,11 +18,14 @@ import (
 	"github.com/google/oss-rebuild/internal/api"
 	"github.com/google/oss-rebuild/internal/api/agentapiservice"
 	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/internal/httpx"
 	"github.com/google/oss-rebuild/internal/serviceid"
 	buildgcb "github.com/google/oss-rebuild/pkg/build/gcb"
 	"github.com/google/oss-rebuild/pkg/gcb"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/pkg/errors"
 	"google.golang.org/api/cloudbuild/v1"
+	"google.golang.org/api/idtoken"
 )
 
 var (
@@ -42,6 +46,7 @@ var (
 	scratchWorkerPort   = flag.Int("scratch-worker-port", 8080, "port the worker listens on")
 	scratchStandardTmpl = flag.String("scratch-instance-standard-template", "", "GCE instance template URL for the standard machine class (required when scratch enabled)")
 	scratchJumboTmpl    = flag.String("scratch-instance-jumbo-template", "", "GCE instance template URL for the jumbo machine class (optional)")
+	scratchOutputBucket = flag.String("scratch-output-bucket", "", "GCS bucket the broker writes exec output into (required when --scratch-enabled)")
 )
 
 // Link-time configured service identity
@@ -125,6 +130,24 @@ func AgentCompleteInit(ctx context.Context) (*agentapiservice.AgentCompleteDeps,
 	return &d, nil
 }
 
+// scratchWorkerDialer mints an ID-token-bearing HTTP client per
+// scratch with audience "https://builder/<vm-name>", the audience each
+// worker is configured to verify.
+func scratchWorkerDialer(ctx context.Context, workerPort int) agentapiservice.WorkerDialer {
+	return func(s schema.Scratch) (httpx.BasicClient, *url.URL, error) {
+		audience := fmt.Sprintf("https://builder/%s", s.VMName)
+		c, err := idtoken.NewClient(ctx, audience)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "idtoken client")
+		}
+		u, err := url.Parse(fmt.Sprintf("http://%s:%d", s.InternalIP, workerPort))
+		if err != nil {
+			return nil, nil, err
+		}
+		return c, u, nil
+	}
+}
+
 // scratchHealthProbe pings http://<ip>:<workerPort>/healthz. Worker
 // /healthz is unauthenticated by design.
 func scratchHealthProbe(workerPort int) agentapiservice.HealthProbe {
@@ -195,6 +218,37 @@ func ScratchDeleteInit(ctx context.Context) (*agentapiservice.ScratchDeleteDeps,
 	return &agentapiservice.ScratchDeleteDeps{Scratches: db.NewFirestoreScratch(fs), GCE: gce}, nil
 }
 
+func ScratchExecCreateInit(ctx context.Context) (*agentapiservice.ScratchExecCreateDeps, error) {
+	fs, err := firestore.NewClient(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "firestore client")
+	}
+	return &agentapiservice.ScratchExecCreateDeps{
+		Scratches:    db.NewFirestoreScratch(fs),
+		Execs:        db.NewFirestoreScratchExecs(fs),
+		WorkerDialer: scratchWorkerDialer(ctx, *scratchWorkerPort),
+		OutputBucket: *scratchOutputBucket,
+	}, nil
+}
+
+func ScratchExecGetInit(ctx context.Context) (*agentapiservice.ScratchExecGetDeps, error) {
+	fs, err := firestore.NewClient(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "firestore client")
+	}
+	gcs, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "storage client")
+	}
+	return &agentapiservice.ScratchExecGetDeps{
+		Scratches:    db.NewFirestoreScratch(fs),
+		Execs:        db.NewFirestoreScratchExecs(fs),
+		WorkerDialer: scratchWorkerDialer(ctx, *scratchWorkerPort),
+		GCS:          gcs,
+		OutputBucket: *scratchOutputBucket,
+	}, nil
+}
+
 func main() {
 	flag.Parse()
 	mux := http.NewServeMux()
@@ -205,6 +259,8 @@ func main() {
 		mux.HandleFunc("/scratch/create", api.Handler(ScratchCreateInit, agentapiservice.ScratchCreate))
 		mux.HandleFunc("/scratch/get", api.Handler(ScratchGetInit, agentapiservice.ScratchGet))
 		mux.HandleFunc("/scratch/delete", api.Handler(ScratchDeleteInit, agentapiservice.ScratchDelete))
+		mux.HandleFunc("/scratch/exec/op/create", api.Handler(ScratchExecCreateInit, agentapiservice.ScratchExecCreate))
+		mux.HandleFunc("/scratch/exec/op/get", api.Handler(ScratchExecGetInit, agentapiservice.ScratchExecGet))
 	}
 
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), mux); err != nil {

--- a/cmd/scratch-worker/main.go
+++ b/cmd/scratch-worker/main.go
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Command scratch-worker is the per-VM scratch worker. It serves
-// /healthz and /stat over HTTP. The worker process makes no GCP API
-// calls of its own: on public deployments the VM has no attached SA,
-// and on private deployments the VM's SA is scoped narrowly to GCS
-// read for bootstrap fetching of this binary.
+// /exec/start, /exec/op/status, /exec/op/output, /healthz, and /stat over
+// HTTP. The worker process makes no GCP API calls of its own: on public
+// deployments the VM has no attached SA, and on private deployments the VM's
+// SA is scoped narrowly to GCS read for bootstrap fetching of this binary.
 package main
 
 import (
@@ -23,15 +23,26 @@ import (
 var (
 	callerSA         = flag.String("caller-sa", "", "caller service account email (sender of incoming requests)")
 	audience         = flag.String("audience", "", "expected ID-token audience (e.g. https://builder/<vm-name>)")
+	workdir          = flag.String("workdir", "/home/builder", "default cwd for execs")
+	tempDir          = flag.String("temp-dir", "", "temp directory for exec stdout/stderr capture; empty = OS default")
 	dockerSocketPath = flag.String("docker-socket", "/var/run/docker.sock", "path probed by /stat for Docker daemon presence")
 	diskPaths        = flag.String("disk-paths", "", "comma-separated mount paths reported by /stat")
 	listen           = flag.String("listen", ":8080", "listen address")
 )
 
-// statDeps holds the singleton built once at startup.
-var statDeps *scratchworkerservice.StatDeps
+// Process-wide deps, built once at startup.
+var (
+	execDeps   *scratchworkerservice.ExecDeps
+	statusDeps *scratchworkerservice.StatusDeps
+	outputDeps *scratchworkerservice.OutputDeps
+	statDeps   *scratchworkerservice.StatDeps
+	store      *scratchworkerservice.ExecStore
+)
 
-func statInit(_ context.Context) (*scratchworkerservice.StatDeps, error) { return statDeps, nil }
+func execInit(_ context.Context) (*scratchworkerservice.ExecDeps, error)     { return execDeps, nil }
+func statusInit(_ context.Context) (*scratchworkerservice.StatusDeps, error) { return statusDeps, nil }
+func outputInit(_ context.Context) (*scratchworkerservice.OutputDeps, error) { return outputDeps, nil }
+func statInit(_ context.Context) (*scratchworkerservice.StatDeps, error)     { return statDeps, nil }
 
 func main() {
 	flag.Parse()
@@ -42,6 +53,14 @@ func main() {
 		log.Fatalf("--audience is required")
 	}
 
+	store = scratchworkerservice.NewExecStore()
+	execDeps = &scratchworkerservice.ExecDeps{
+		Store:   store,
+		TempDir: *tempDir,
+		Workdir: *workdir,
+	}
+	statusDeps = &scratchworkerservice.StatusDeps{Store: store}
+	outputDeps = &scratchworkerservice.OutputDeps{Store: store}
 	statDeps = &scratchworkerservice.StatDeps{
 		DockerSocketPath: *dockerSocketPath,
 		DiskPaths:        splitCSV(*diskPaths),
@@ -50,6 +69,10 @@ func main() {
 	mw := idauth.Middleware(idauth.NewGoogleValidator(*callerSA, *audience))
 
 	mux := http.NewServeMux()
+	mux.Handle("/exec/start", mw(api.Handler(execInit, scratchworkerservice.ExecStart)))
+	mux.Handle("/exec/op/status", mw(api.Handler(statusInit, scratchworkerservice.Status)))
+	mux.Handle("/exec/op/output", mw(api.Handler(outputInit, scratchworkerservice.Output)))
+	// TODO: Add /exec/op/kill
 	mux.Handle("/stat", mw(api.Handler(statInit, scratchworkerservice.Stat)))
 	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, _ *http.Request) { rw.WriteHeader(http.StatusOK) })
 

--- a/deployments/iam.tf
+++ b/deployments/iam.tf
@@ -397,6 +397,12 @@ resource "google_project_iam_member" "orchestrator-compute-admin" {
   role    = "roles/compute.instanceAdmin.v1"
   member  = google_service_account.orchestrator.member
 }
+resource "google_storage_bucket_iam_member" "orchestrator-rw-scratch-output" {
+  count  = var.enable_scratch ? 1 : 0
+  bucket = google_storage_bucket.scratch-output[0].name
+  role   = "roles/storage.objectAdmin"
+  member = google_service_account.orchestrator.member
+}
 resource "google_cloud_run_v2_service_iam_member" "agent-calls-agent-api" {
   location = google_cloud_run_v2_service.agent-api.location
   project  = google_cloud_run_v2_service.agent-api.project

--- a/deployments/platform.tf
+++ b/deployments/platform.tf
@@ -134,6 +134,16 @@ resource "google_storage_bucket" "agent-metadata" {
   depends_on                  = [google_project_service.storage]
 }
 
+resource "google_storage_bucket" "scratch-output" {
+  count                       = var.enable_scratch ? 1 : 0
+  name                        = "${var.host}-scratch-exec-output"
+  location                    = "us-central1"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  depends_on                  = [google_project_service.storage]
+  # TODO: Consider an age-based lifecycle rule once we have a feel for realistic retention needs.
+}
+
 ## Firestore
 
 resource "google_project_service" "compute" {

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -393,6 +393,7 @@ resource "google_cloud_run_v2_service" "agent-api" {
         "--scratch-zone=us-central1-a",
         "--scratch-worker-port=8080",
         "--scratch-instance-standard-template=${google_compute_instance_template.scratch-standard[0].self_link}",
+        "--scratch-output-bucket=${google_storage_bucket.scratch-output[0].name}",
       ] : [])
       resources {
         limits = {

--- a/internal/api/agentapiservice/scratch.go
+++ b/internal/api/agentapiservice/scratch.go
@@ -96,10 +96,12 @@ func ScratchCreate(ctx context.Context, req schema.ScratchCreateRequest, deps *S
 	}
 
 	scratchID := mintID(deps.IDGen)
+	obliviousID := uuid.New().String() // Used in GCS object paths
 	now := time.Now().UTC()
 	scratch := schema.Scratch{
 		ID:           scratchID,
 		BuildID:      req.BuildID,
+		ObliviousID:  obliviousID,
 		MachineClass: req.MachineClass,
 		Zone:         deps.Zone,
 		VMName:       "scratch-" + scratchID,

--- a/internal/api/agentapiservice/scratch_exec.go
+++ b/internal/api/agentapiservice/scratch_exec.go
@@ -1,0 +1,328 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"net/url"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/api"
+	"github.com/google/oss-rebuild/internal/api/scratchworkerservice"
+	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/internal/httpx"
+	"github.com/google/oss-rebuild/pkg/act"
+	"github.com/google/oss-rebuild/pkg/longrunning"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+)
+
+// WorkerDialer returns the HTTP client and base URL for the worker on a
+// given scratch. Constructed once per request so the broker can mint
+// an ID-token client scoped to the per-VM audience.
+type WorkerDialer func(scratch schema.Scratch) (httpx.BasicClient, *url.URL, error)
+
+// ScratchExecCreateDeps wires ScratchExecCreate.
+type ScratchExecCreateDeps struct {
+	Scratches    db.Scratch
+	Execs        db.ScratchExecs
+	WorkerDialer WorkerDialer
+	OutputBucket string
+	IDGen        func() string // For op IDs. If nil, defaults to uuid.New()
+}
+
+// ScratchExecGetDeps wires ScratchExecGet.
+//
+// TODO(streaming-sync): ScratchExecGet today only fetches the worker
+// output on the Done transition (one-shot sync). A follow-up PR
+// introduces a Syncer interface for per-poll partial syncs (live tail).
+type ScratchExecGetDeps struct {
+	Scratches    db.Scratch
+	Execs        db.ScratchExecs
+	WorkerDialer WorkerDialer
+	GCS          *storage.Client // to write the op output. Disabled on nil
+	OutputBucket string
+}
+
+// ProjectScratchExec adapts the stored exec record to its long-running-operation
+// view. Result is always populated as a snapshot of observable state (OutURI may
+// be partial in Pending and Failed). Error is populated additionally when the exec
+// has terminally failed; the two coexist intentionally so callers can read partial
+// output captured before the failure.
+func ProjectScratchExec(e schema.ScratchExec) longrunning.Operation[schema.ScratchExecResult] {
+	op := longrunning.Operation[schema.ScratchExecResult]{
+		ID:   e.ID,
+		Done: e.State != schema.ScratchExecPending,
+		Result: &schema.ScratchExecResult{
+			ScratchID:  e.ScratchID,
+			ExitCode:   e.ExitCode,
+			OutURI:     e.OutURI,
+			StartedAt:  e.StartedAt,
+			FinishedAt: e.FinishedAt,
+		},
+	}
+	if e.Error != nil {
+		op.Error = &longrunning.OperationError{
+			Code:    e.Error.Code,
+			Message: e.Error.Message,
+		}
+	}
+	return op
+}
+
+// ScratchExecCreate starts an exec on the requested scratch. It mints an opaque
+// opID, persists a Pending ScratchExec pre-populated with the immutable parts of
+// the eventual Result, dispatches the work to the worker, and returns the projected
+// operation.
+//
+// API-error vs Operation-error contract: failures that happen before the exec
+// record is durably inserted surface as API status errors (the operation has no
+// identity yet). Failures after Insert succeeds become part of the operation's
+// state: the exec is finalized as Failed and returned as a successful response
+// whose Operation.Error carries the reason. This matches the longrunning idiom
+// and matches what Get would return for the same op id.
+func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps *ScratchExecCreateDeps) (*longrunning.Operation[schema.ScratchExecResult], error) {
+	scratch, err := deps.Scratches.Get(ctx, req.ScratchID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, api.AsStatus(codes.NotFound, errors.Errorf("scratch %q not found", req.ScratchID))
+		}
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches get"))
+	}
+	if scratch.State != schema.ScratchReady {
+		return nil, api.AsStatus(codes.FailedPrecondition, errors.Errorf("scratch %q not ready (state=%s)", req.ScratchID, scratch.State))
+	}
+	if scratch.ObliviousID == "" {
+		return nil, api.AsStatus(codes.Internal, errors.Errorf("scratch %q missing ObliviousID", req.ScratchID))
+	}
+
+	// Prepare the worker client before Insert so a dialer failure (auth setup,
+	// URL parse) is a request-time error rather than a dangling Pending record.
+	client, baseURL, err := deps.WorkerDialer(scratch)
+	if err != nil {
+		return nil, api.AsStatus(codes.Unavailable, errors.Wrap(err, "worker dialer"))
+	}
+
+	opID := mintID(deps.IDGen)
+	startedAt := time.Now().UTC()
+	exec := schema.ScratchExec{
+		ID:        opID,
+		ScratchID: req.ScratchID,
+		Cmd:       req.Cmd,
+		Cwd:       req.Cwd,
+		State:     schema.ScratchExecPending,
+		OutURI:    outURIFor(deps.OutputBucket, scratch.ObliviousID, opID),
+		StartedAt: startedAt,
+	}
+	if err := deps.Execs.Insert(ctx, exec); err != nil {
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "execs insert"))
+	}
+
+	// Past this point the operation has identity. Any failure becomes terminal
+	// Operation state, not an API error.
+
+	startStub := api.Stub[scratchworkerservice.StartRequest, act.NoOutput](client, baseURL.JoinPath("exec/start"))
+	if _, err := startStub(ctx, scratchworkerservice.StartRequest{
+		OpID:           opID,
+		ScratchID:      req.ScratchID,
+		Cmd:            req.Cmd,
+		Cwd:            req.Cwd,
+		Env:            req.Env,
+		StdinB64:       req.StdinB64,
+		TimeoutSeconds: req.TimeoutSeconds,
+	}); err != nil {
+		log.Printf("scratch %q exec %q: worker dispatch: %v", req.ScratchID, opID, err)
+		exec, ferr := finalize(ctx, deps.Execs, exec, &schema.Status{
+			Code:    int(codes.Unavailable),
+			Message: errors.Wrap(err, "worker dispatch").Error(),
+		})
+		if ferr != nil {
+			return nil, api.AsStatus(codes.Internal, errors.Wrapf(ferr, "scratch %q exec %q", req.ScratchID, opID))
+		}
+		op := ProjectScratchExec(exec)
+		return &op, nil
+	}
+
+	// Bump LastUsed so a future reaper doesn't pick up a freshly-dispatched
+	// scratch. Best effort: a transient failure here doesn't block the op.
+	if err := deps.Scratches.UpdateLastUsed(ctx, req.ScratchID, time.Now().UTC()); err != nil {
+		log.Printf("scratch %q exec %q: update last_used: %v", req.ScratchID, opID, err)
+	}
+
+	op := ProjectScratchExec(exec)
+	return &op, nil
+}
+
+// ScratchExecGet returns the current state of an exec op. If the op is pending
+// and a GCS client is configured, ScratchExecGet polls the worker for status;
+// on the Done transition it fetches the full output buffer, writes it to GCS
+// once, and finalizes the Firestore record.
+//
+// Sync errors follow the last-error-is-final policy: any failure to reach the
+// worker, read its state, or persist the output transitions the exec to Failed
+// immediately. We deliberately do not retry transient errors. For in-VPC
+// broker→worker traffic the blip rate is low enough that an occasional false
+// Failed is the right cost vs. an exec that lingers in Pending indefinitely.
+//
+// TODO(streaming-sync): replace the on-Done one-shot below with a Syncer-based
+// per-poll sync so agents get live tail behavior.
+func ScratchExecGet(ctx context.Context, req schema.GetOperationRequest, deps *ScratchExecGetDeps) (*longrunning.Operation[schema.ScratchExecResult], error) {
+	exec, err := deps.Execs.Get(ctx, req.ID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, api.AsStatus(codes.NotFound, errors.Errorf("op %q not found", req.ID))
+		}
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "execs get"))
+	}
+	if exec.State != schema.ScratchExecPending || deps.GCS == nil || exec.ScratchID == "" {
+		op := ProjectScratchExec(exec)
+		return &op, nil
+	}
+
+	scratch, err := deps.Scratches.Get(ctx, exec.ScratchID)
+	if err != nil {
+		log.Printf("exec %q: scratch %q lookup: %v", exec.ID, exec.ScratchID, err)
+		exec, ferr := finalize(ctx, deps.Execs, exec, &schema.Status{
+			Code:    int(codes.Unavailable),
+			Message: errors.Wrap(err, "scratch lookup").Error(),
+		})
+		if ferr != nil {
+			return nil, api.AsStatus(codes.Internal, errors.Wrapf(ferr, "exec %q", exec.ID))
+		}
+		op := ProjectScratchExec(exec)
+		return &op, nil
+	}
+	if scratch.State != schema.ScratchReady {
+		log.Printf("exec %q: scratch %q not ready (state=%s)", exec.ID, exec.ScratchID, scratch.State)
+		exec, ferr := finalize(ctx, deps.Execs, exec, &schema.Status{
+			Code:    int(codes.Unavailable),
+			Message: errors.Errorf("scratch not ready (state=%s)", scratch.State).Error(),
+		})
+		if ferr != nil {
+			return nil, api.AsStatus(codes.Internal, errors.Wrapf(ferr, "exec %q", exec.ID))
+		}
+		op := ProjectScratchExec(exec)
+		return &op, nil
+	}
+
+	synced, err := syncOnDone(ctx, deps, exec, scratch)
+	if err != nil {
+		log.Printf("exec %q: sync: %v", exec.ID, err)
+		exec, ferr := finalize(ctx, deps.Execs, exec, &schema.Status{
+			Code:    int(codes.Unavailable),
+			Message: err.Error(),
+		})
+		if ferr != nil {
+			return nil, api.AsStatus(codes.Internal, errors.Wrapf(ferr, "exec %q", exec.ID))
+		}
+		op := ProjectScratchExec(exec)
+		return &op, nil
+	}
+	op := ProjectScratchExec(synced)
+	return &op, nil
+}
+
+// syncOnDone polls the worker for status. If Done, it fetches the full output
+// buffer, writes it to GCS, and finalizes the Firestore record. Returns the
+// (possibly updated) exec on success; on any error the exec is unchanged and
+// the caller decides whether to finalize.
+func syncOnDone(ctx context.Context, deps *ScratchExecGetDeps, exec schema.ScratchExec, scratch schema.Scratch) (schema.ScratchExec, error) {
+	client, baseURL, err := deps.WorkerDialer(scratch)
+	if err != nil {
+		return exec, errors.Wrap(err, "worker client")
+	}
+	statusStub := api.Stub[scratchworkerservice.StatusRequest, scratchworkerservice.ExecStatus](client, baseURL.JoinPath("exec/op/status"))
+	status, err := statusStub(ctx, scratchworkerservice.StatusRequest{ID: exec.ID})
+	if err != nil {
+		return exec, errors.Wrap(err, "worker status")
+	}
+	if !status.Done {
+		return exec, nil
+	}
+
+	outputStub := api.Stub[scratchworkerservice.OutputRequest, scratchworkerservice.OutputResponse](client, baseURL.JoinPath("exec/op/output"))
+	body, err := outputStub(ctx, scratchworkerservice.OutputRequest{ID: exec.ID})
+	if err != nil {
+		return exec, errors.Wrap(err, "worker output")
+	}
+	if err := writeOut(ctx, deps.GCS, deps.OutputBucket, scratch.ObliviousID, exec.ID, body.Bytes); err != nil {
+		return exec, errors.Wrap(err, "write out")
+	}
+
+	final := exec
+	final.ExitCode = status.ExitCode
+	if !status.FinishedAt.IsZero() {
+		final.FinishedAt = status.FinishedAt
+	} else {
+		final.FinishedAt = time.Now().UTC()
+	}
+	switch {
+	case status.TimedOut:
+		// Worker-enforced timeout: command was killed at its deadline.
+		// We observed the kill exit (typically 124); partial output remains in OutURI.
+		final.State = schema.ScratchExecTimedOut
+		final.Error = &schema.Status{
+			Code:    int(codes.DeadlineExceeded),
+			Message: "command exceeded TimeoutSeconds",
+		}
+	case status.ErrMsg != "":
+		// Worker reported an infra failure (spawn failed, stdin decode, ...).
+		// We do not have a known exit; treat as Lost.
+		final.State = schema.ScratchExecLost
+		final.Error = &schema.Status{
+			Code:    int(codes.Internal),
+			Message: status.ErrMsg,
+		}
+	default:
+		final.State = schema.ScratchExecCompleted
+	}
+	if err := deps.Execs.Update(ctx, final); err != nil {
+		return exec, errors.Wrap(err, "execs update final")
+	}
+	return final, nil
+}
+
+// finalize transitions exec to Lost with the given status and persists it;
+// idempotent against already-terminal records. On persist failure callers must
+// surface the error rather than project the unpersisted state, or the API
+// response will disagree with what subsequent Gets read from storage.
+func finalize(ctx context.Context, execs db.ScratchExecs, exec schema.ScratchExec, st *schema.Status) (schema.ScratchExec, error) {
+	if exec.State != schema.ScratchExecPending {
+		return exec, nil
+	}
+	exec.State = schema.ScratchExecLost
+	exec.Error = st
+	exec.FinishedAt = time.Now().UTC()
+	if err := execs.Update(ctx, exec); err != nil {
+		return exec, errors.Wrap(err, "finalize update")
+	}
+	return exec, nil
+}
+
+// outObjectFor returns the GCS object name for an op's merged output.
+func outObjectFor(obliviousID, opID string) string {
+	return obliviousID + "/" + opID + "/out"
+}
+
+// outURIFor returns the gs:// URI agents see in ExecResult.OutURI.
+func outURIFor(bucket, obliviousID, opID string) string {
+	return "gs://" + bucket + "/" + outObjectFor(obliviousID, opID)
+}
+
+func writeOut(ctx context.Context, gcs *storage.Client, bucket, obliviousID, opID string, buf []byte) error {
+	if len(buf) == 0 {
+		return nil
+	}
+	out := gcs.Bucket(bucket).Object(outObjectFor(obliviousID, opID))
+	w := out.NewWriter(ctx)
+	if _, err := bytes.NewReader(buf).WriteTo(w); err != nil {
+		_ = w.Close()
+		return err
+	}
+	return w.Close()
+}

--- a/internal/api/agentapiservice/scratch_exec_test.go
+++ b/internal/api/agentapiservice/scratch_exec_test.go
@@ -1,0 +1,443 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/api/scratchworkerservice"
+	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/internal/httpx"
+	"github.com/google/oss-rebuild/pkg/act/api/form"
+	"github.com/google/oss-rebuild/pkg/longrunning"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeWorker mimics the worker's /exec/start contract: parses the
+// form, records the request, returns {}. Tests can swap in a 500 to
+// exercise the POST-failure path.
+type fakeWorker struct {
+	srv        *httptest.Server
+	received   *scratchworkerservice.StartRequest
+	respStatus int
+}
+
+func newFakeWorker(t *testing.T) *fakeWorker {
+	t.Helper()
+	fw := &fakeWorker{respStatus: http.StatusOK}
+	fw.srv = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/exec/start" {
+			http.NotFound(rw, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var req scratchworkerservice.StartRequest
+		if err := form.Unmarshal(r.Form, &req); err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
+		}
+		fw.received = &req
+		if fw.respStatus != http.StatusOK {
+			http.Error(rw, "boom", fw.respStatus)
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		_, _ = rw.Write([]byte("{}"))
+	}))
+	t.Cleanup(fw.srv.Close)
+	return fw
+}
+
+func (f *fakeWorker) dialer() WorkerDialer {
+	return func(_ schema.Scratch) (httpx.BasicClient, *url.URL, error) {
+		u, _ := url.Parse(f.srv.URL)
+		return f.srv.Client(), u, nil
+	}
+}
+
+// fixture mints a ready scratch and returns wired deps + the fake worker.
+// The Get deps leave Syncer nil, exercising the no-sync code path.
+func fixture(t *testing.T, opID string, fw *fakeWorker) (*ScratchExecCreateDeps, *ScratchExecGetDeps, db.Scratch, db.ScratchExecs) {
+	t.Helper()
+	scratches := db.NewMemoryScratch()
+	if err := scratches.Insert(context.Background(), schema.Scratch{
+		ID: "s-1", State: schema.ScratchReady, VMName: "vm-1", InternalIP: "10.0.0.1",
+		ObliviousID: "obid-s-1",
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	execs := db.NewMemoryScratchExecs()
+	createDeps := &ScratchExecCreateDeps{
+		Scratches:    scratches,
+		Execs:        execs,
+		WorkerDialer: fw.dialer(),
+		OutputBucket: "test-output",
+		IDGen:        func() string { return opID },
+	}
+	getDeps := &ScratchExecGetDeps{Scratches: scratches, Execs: execs}
+	return createDeps, getDeps, scratches, execs
+}
+
+func TestScratchExecCreate_HappyPath(t *testing.T) {
+	const opID = "op-1"
+	fw := newFakeWorker(t)
+	createDeps, _, _, execs := fixture(t, opID, fw)
+
+	req := schema.ScratchExecRequest{
+		ScratchID:      "s-1",
+		Cmd:            []string{"sh", "-c", "echo hi"},
+		Cwd:            "/work",
+		Env:            map[string]string{"FOO": "bar"},
+		StdinB64:       "aGk=",
+		TimeoutSeconds: 30,
+	}
+	op, err := ScratchExecCreate(context.Background(), req, createDeps)
+	if err != nil {
+		t.Fatalf("ScratchExecCreate: %v", err)
+	}
+	if op.ID != opID {
+		t.Errorf("ID = %q; want %q", op.ID, opID)
+	}
+	if op.Done || op.Error != nil {
+		t.Errorf("op = %+v; want Done:false Error:nil", op)
+	}
+
+	stored, err := execs.Get(context.Background(), opID)
+	if err != nil {
+		t.Fatalf("execs.Get: %v", err)
+	}
+	if stored.State != schema.ScratchExecPending {
+		t.Errorf("persisted State = %q; want pending", stored.State)
+	}
+
+	if fw.received == nil {
+		t.Fatalf("worker did not receive a request")
+	}
+	want := scratchworkerservice.StartRequest{
+		OpID:           opID,
+		ScratchID:      "s-1",
+		Cmd:            []string{"sh", "-c", "echo hi"},
+		Cwd:            "/work",
+		Env:            map[string]string{"FOO": "bar"},
+		StdinB64:       "aGk=",
+		TimeoutSeconds: 30,
+	}
+	if diff := cmp.Diff(want, *fw.received); diff != "" {
+		t.Errorf("worker request mismatch (-want +got):\n%s", diff)
+	}
+	if op.Result == nil || op.Result.OutURI == "" {
+		t.Errorf("op.Result.OutURI unset; want pre-populated")
+	}
+	wantURI := "gs://test-output/obid-s-1/" + opID + "/out"
+	if op.Result != nil && op.Result.OutURI != wantURI {
+		t.Errorf("OutURI = %q; want %q", op.Result.OutURI, wantURI)
+	}
+}
+
+func TestScratchExecCreate_NoObliviousIDFails(t *testing.T) {
+	const opID = "op-no-obid"
+	fw := newFakeWorker(t)
+	scratches := db.NewMemoryScratch()
+	if err := scratches.Insert(context.Background(), schema.Scratch{
+		ID: "s-1", State: schema.ScratchReady,
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	deps := &ScratchExecCreateDeps{
+		Scratches:    scratches,
+		Execs:        db.NewMemoryScratchExecs(),
+		WorkerDialer: fw.dialer(),
+		OutputBucket: "test-output",
+		IDGen:        func() string { return opID },
+	}
+	_, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, deps)
+	if status.Code(err) != codes.Internal {
+		t.Errorf("code = %s; want Internal. err=%v", status.Code(err), err)
+	}
+}
+
+func TestScratchExecCreate_NotFound(t *testing.T) {
+	fw := newFakeWorker(t)
+	createDeps, _, _, _ := fixture(t, "op-x", fw)
+	_, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "missing", Cmd: []string{"true"},
+	}, createDeps)
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %s; want NotFound. err=%v", status.Code(err), err)
+	}
+}
+
+func TestScratchExecCreate_NotReady(t *testing.T) {
+	fw := newFakeWorker(t)
+	createDeps, _, scratches, _ := fixture(t, "op-x", fw)
+	if err := scratches.UpdateState(context.Background(), "s-1", schema.ScratchStarting); err != nil {
+		t.Fatalf("UpdateState: %v", err)
+	}
+	_, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, createDeps)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("code = %s; want FailedPrecondition. err=%v", status.Code(err), err)
+	}
+}
+
+func TestScratchExecCreate_WorkerPostFailureFinalizesLost(t *testing.T) {
+	const opID = "op-post-fail"
+	fw := newFakeWorker(t)
+	fw.respStatus = http.StatusInternalServerError
+	createDeps, _, _, execs := fixture(t, opID, fw)
+
+	op, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, createDeps)
+	if err != nil {
+		t.Fatalf("ScratchExecCreate: %v; want nil (Error returned via op)", err)
+	}
+	if !op.Done {
+		t.Errorf("Done = false; want true (finalized on POST failure)")
+	}
+	if op.Error == nil || op.Error.Code != int(codes.Unavailable) {
+		t.Errorf("op.Error = %+v; want code Unavailable", op.Error)
+	}
+
+	stored, err := execs.Get(context.Background(), opID)
+	if err != nil {
+		t.Fatalf("execs.Get: %v", err)
+	}
+	if stored.State != schema.ScratchExecLost {
+		t.Errorf("persisted State = %q; want lost", stored.State)
+	}
+	if stored.Error == nil || stored.Error.Code != int(codes.Unavailable) {
+		t.Errorf("persisted Error = %+v; want code Unavailable", stored.Error)
+	}
+}
+
+func TestScratchExecCreate_DialerFailureReturnsAPIError(t *testing.T) {
+	const opID = "op-dialer-fail"
+	scratches := db.NewMemoryScratch()
+	_ = scratches.Insert(context.Background(), schema.Scratch{
+		ID: "s-1", State: schema.ScratchReady, ObliviousID: "obid-s-1",
+	})
+	execs := db.NewMemoryScratchExecs()
+	deps := &ScratchExecCreateDeps{
+		Scratches: scratches,
+		Execs:     execs,
+		WorkerDialer: func(_ schema.Scratch) (httpx.BasicClient, *url.URL, error) {
+			return nil, nil, errors.New("dialer boom")
+		},
+		OutputBucket: "test-output",
+		IDGen:        func() string { return opID },
+	}
+	_, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, deps)
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("code = %s; want Unavailable. err=%v", status.Code(err), err)
+	}
+	// No exec record should exist: the dialer runs before Insert.
+	if _, gerr := execs.Get(context.Background(), opID); !errors.Is(gerr, db.ErrNotFound) {
+		t.Errorf("exec exists after dialer failure; want no record (gerr=%v)", gerr)
+	}
+}
+
+// faultingExecs wraps db.ScratchExecs and forces Update to fail with the
+// configured error. Insert and Get pass through unchanged.
+type faultingExecs struct {
+	db.ScratchExecs
+	updateErr error
+}
+
+func (f *faultingExecs) Update(ctx context.Context, e schema.ScratchExec) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	return f.ScratchExecs.Update(ctx, e)
+}
+
+// TestScratchExecCreate_FinalizePersistFailureSurfacesAPIError covers the
+// invariant that storage and the returned Operation must agree: if finalize
+// cannot persist the Lost transition, we return an API error rather than
+// project the unpersisted in-memory state (which would disagree with what a
+// subsequent Get reads from storage).
+func TestScratchExecCreate_FinalizePersistFailureSurfacesAPIError(t *testing.T) {
+	const opID = "op-finalize-fail"
+	fw := newFakeWorker(t)
+	fw.respStatus = http.StatusInternalServerError // force the worker-dispatch failure path
+
+	scratches := db.NewMemoryScratch()
+	_ = scratches.Insert(context.Background(), schema.Scratch{
+		ID: "s-1", State: schema.ScratchReady, ObliviousID: "obid-s-1",
+	})
+	execs := &faultingExecs{ScratchExecs: db.NewMemoryScratchExecs(), updateErr: errors.New("firestore boom")}
+	deps := &ScratchExecCreateDeps{
+		Scratches:    scratches,
+		Execs:        execs,
+		WorkerDialer: fw.dialer(),
+		OutputBucket: "test-output",
+		IDGen:        func() string { return opID },
+	}
+
+	_, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, deps)
+	if status.Code(err) != codes.Internal {
+		t.Errorf("code = %s; want Internal. err=%v", status.Code(err), err)
+	}
+
+	// Underlying record stays Pending because the finalize Update was rejected;
+	// the reaper is the eventual cleanup path.
+	stored, gerr := execs.Get(context.Background(), opID)
+	if gerr != nil {
+		t.Fatalf("execs.Get: %v", gerr)
+	}
+	if stored.State != schema.ScratchExecPending {
+		t.Errorf("persisted State = %q; want still pending (Update failed)", stored.State)
+	}
+}
+
+func TestScratchExecCreate_BumpsLastUsedOnSuccess(t *testing.T) {
+	const opID = "op-bump"
+	fw := newFakeWorker(t)
+	createDeps, _, scratches, _ := fixture(t, opID, fw)
+	before, _ := scratches.Get(context.Background(), "s-1")
+
+	if _, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, createDeps); err != nil {
+		t.Fatalf("ScratchExecCreate: %v", err)
+	}
+	after, _ := scratches.Get(context.Background(), "s-1")
+	if !after.LastUsed.After(before.LastUsed) {
+		t.Errorf("LastUsed before=%v after=%v; expected bump", before.LastUsed, after.LastUsed)
+	}
+}
+
+func TestScratchExecGet_RoundTrip(t *testing.T) {
+	const opID = "op-2"
+	fw := newFakeWorker(t)
+	createDeps, getDeps, _, execs := fixture(t, opID, fw)
+
+	if _, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, createDeps); err != nil {
+		t.Fatalf("ScratchExecCreate: %v", err)
+	}
+
+	op, err := ScratchExecGet(context.Background(), schema.GetOperationRequest{ID: opID}, getDeps)
+	if err != nil {
+		t.Fatalf("ScratchExecGet(pending): %v", err)
+	}
+	if op.Done {
+		t.Errorf("pending op Done = true; want false")
+	}
+
+	// Simulate a sync writing a terminal Completed record.
+	final, _ := execs.Get(context.Background(), opID)
+	final.State = schema.ScratchExecCompleted
+	final.ExitCode = 0
+	if err := execs.Update(context.Background(), final); err != nil {
+		t.Fatalf("Update final: %v", err)
+	}
+
+	op, err = ScratchExecGet(context.Background(), schema.GetOperationRequest{ID: opID}, getDeps)
+	if err != nil {
+		t.Fatalf("ScratchExecGet(final): %v", err)
+	}
+	if !op.Done || op.Result == nil {
+		t.Errorf("final op = %+v; want Done:true Result:set", op)
+	}
+	if op.Error != nil {
+		t.Errorf("Error = %+v; want nil (Completed)", op.Error)
+	}
+}
+
+func TestScratchExecGet_NotFound(t *testing.T) {
+	deps := &ScratchExecGetDeps{Execs: db.NewMemoryScratchExecs()}
+	_, err := ScratchExecGet(context.Background(), schema.GetOperationRequest{ID: "missing"}, deps)
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %s; want NotFound. err=%v", status.Code(err), err)
+	}
+}
+
+func TestProjectScratchExec_StateAndErrorToOperationError(t *testing.T) {
+	cases := []struct {
+		name     string
+		state    schema.ScratchExecState
+		errSt    *schema.Status
+		wantCode int
+		wantNil  bool
+	}{
+		{"completed → no error", schema.ScratchExecCompleted, nil, 0, true},
+		{"timed_out/deadline_exceeded", schema.ScratchExecTimedOut,
+			&schema.Status{Code: int(codes.DeadlineExceeded), Message: "timed out"},
+			int(codes.DeadlineExceeded), false},
+		{"lost/unavailable", schema.ScratchExecLost,
+			&schema.Status{Code: int(codes.Unavailable), Message: "worker gone"},
+			int(codes.Unavailable), false},
+		{"lost/internal", schema.ScratchExecLost,
+			&schema.Status{Code: int(codes.Internal), Message: "boom"},
+			int(codes.Internal), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := ProjectScratchExec(schema.ScratchExec{ID: "x", State: tc.state, Error: tc.errSt})
+			if tc.wantNil {
+				if op.Error != nil {
+					t.Errorf("Error = %+v; want nil", op.Error)
+				}
+				return
+			}
+			if op.Error == nil || op.Error.Code != tc.wantCode {
+				t.Errorf("Error = %+v; want code %d", op.Error, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestProjectScratchExec_PendingNotDone(t *testing.T) {
+	op := ProjectScratchExec(schema.ScratchExec{ID: "x", State: schema.ScratchExecPending})
+	if op.Done {
+		t.Errorf("Done = true; want false (pending)")
+	}
+	if op.Error != nil {
+		t.Errorf("Error = %+v; want nil", op.Error)
+	}
+}
+
+// TestProjectScratchExec_ResultAndErrorCoexist verifies the documented contract
+// that Result is always populated (snapshot of observable state) and Error is
+// added on top for terminal-error records. Partial OutURI remains accessible
+// via Result.
+func TestProjectScratchExec_ResultAndErrorCoexist(t *testing.T) {
+	op := ProjectScratchExec(schema.ScratchExec{
+		ID:        "x",
+		ScratchID: "s",
+		OutURI:    "gs://bkt/obid/x/out", // partial output captured before failure
+		State:     schema.ScratchExecLost,
+		Error:     &schema.Status{Code: int(codes.Unavailable), Message: "worker gone"},
+	})
+	if op.Result == nil || op.Result.OutURI != "gs://bkt/obid/x/out" {
+		t.Errorf("Result = %+v; want partial OutURI populated alongside Error", op.Result)
+	}
+	if op.Error == nil || op.Error.Code != int(codes.Unavailable) {
+		t.Errorf("Error = %+v; want Unavailable", op.Error)
+	}
+}
+
+// Compile-time assertion that ProjectScratchExec returns the expected
+// generic Operation type (avoids an unused longrunning import warning).
+var _ = longrunning.Operation[schema.ScratchExecResult]{}

--- a/internal/api/scratchworkerservice/cmd.go
+++ b/internal/api/scratchworkerservice/cmd.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package scratchworkerservice implements the per-VM scratch worker.
+package scratchworkerservice
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// killGrace is the time the runner waits after SIGTERM before SIGKILLing the
+// process group. Tunable for tests.
+var killGrace = 5 * time.Second
+
+// runSpec holds the inputs runCommand needs. Kept package-private as the
+// internal exec runner shape, independent of the wire-level StartRequest.
+type runSpec struct {
+	Cmd            []string
+	Cwd            string
+	Env            map[string]string
+	Stdin          io.Reader
+	TimeoutSeconds int
+}
+
+// runCommand spawns Cmd[0] with Cmd[1:] arguments, writing stdout/stderr to
+// the supplied writers. Stdin (if non-nil) is piped to the process. The
+// process is started in its own process group so timeout/cancel can reach
+// the entire subtree.
+//
+// Return semantics:
+//   - normal exit (any code): (code, nil)
+//   - command exceeded TimeoutSeconds: (124, context.DeadlineExceeded)
+//   - context cancelled by caller (not deadline): (0, context.Canceled)
+//   - spawn or unexpected wait failure: (0, err)
+//
+// Callers detect the timeout case with errors.Is(err, context.DeadlineExceeded).
+func runCommand(ctx context.Context, spec runSpec, stdout, stderr io.Writer) (exitCode int, err error) {
+	if len(spec.Cmd) == 0 {
+		return 0, errors.New("cmd is empty")
+	}
+
+	runCtx := ctx
+	if spec.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, time.Duration(spec.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
+
+	cmd := exec.Command(spec.Cmd[0], spec.Cmd[1:]...)
+	cmd.Stdin = spec.Stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Dir = spec.Cwd
+	cmd.Env = buildEnv(spec.Env)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	pgid := cmd.Process.Pid // Setpgid makes the child its own pgrp leader.
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case waitErr := <-done:
+		return classifyExit(cmd, waitErr)
+	case <-runCtx.Done():
+		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+		select {
+		case <-done:
+		case <-time.After(killGrace):
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			<-done
+		}
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			return 124, context.DeadlineExceeded
+		}
+		return 0, runCtx.Err()
+	}
+}
+
+func classifyExit(cmd *exec.Cmd, err error) (int, error) {
+	if err == nil {
+		return cmd.ProcessState.ExitCode(), nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+	return 0, err
+}
+
+// buildEnv returns the env slice for exec.Cmd. nil means "inherit parent's
+// environment" per exec docs. A non-empty extra map is layered on top of
+// os.Environ(); since exec uses the last value for duplicate keys, the
+// extras override the inherited values.
+func buildEnv(extra map[string]string) []string {
+	if len(extra) == 0 {
+		return nil
+	}
+	env := os.Environ()
+	for k, v := range extra {
+		env = append(env, k+"="+v)
+	}
+	return env
+}

--- a/internal/api/scratchworkerservice/cmd_test.go
+++ b/internal/api/scratchworkerservice/cmd_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scratchworkerservice
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Compress kill grace for tests so timeout cases finish quickly.
+func init() { killGrace = 200 * time.Millisecond }
+
+func TestRunCommand_ZeroExit(t *testing.T) {
+	code, err := runCommand(context.Background(),
+		runSpec{Cmd: []string{"sh", "-c", "exit 0"}}, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	if code != 0 {
+		t.Errorf("code = %d; want 0", code)
+	}
+}
+
+func TestRunCommand_NonZeroExit(t *testing.T) {
+	code, err := runCommand(context.Background(),
+		runSpec{Cmd: []string{"sh", "-c", "exit 7"}}, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+	if code != 7 {
+		t.Errorf("code = %d; want 7", code)
+	}
+}
+
+func TestRunCommand_StdoutStderrCapture(t *testing.T) {
+	var out, errb bytes.Buffer
+	code, err := runCommand(context.Background(),
+		runSpec{Cmd: []string{"sh", "-c", "echo out; echo err 1>&2"}}, &out, &errb)
+	if err != nil || code != 0 {
+		t.Fatalf("(code, err) = (%d, %v); want (0, nil)", code, err)
+	}
+	if got := out.String(); got != "out\n" {
+		t.Errorf("stdout = %q; want %q", got, "out\n")
+	}
+	if got := errb.String(); got != "err\n" {
+		t.Errorf("stderr = %q; want %q", got, "err\n")
+	}
+}
+
+func TestRunCommand_StdinEcho(t *testing.T) {
+	var out bytes.Buffer
+	stdin := strings.NewReader("hello world")
+	code, err := runCommand(context.Background(),
+		runSpec{Cmd: []string{"cat"}, Stdin: stdin}, &out, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("(code, err) = (%d, %v); want (0, nil)", code, err)
+	}
+	if got := out.String(); got != "hello world" {
+		t.Errorf("stdout = %q; want %q", got, "hello world")
+	}
+}
+
+func TestRunCommand_Cwd(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	code, err := runCommand(context.Background(),
+		runSpec{Cmd: []string{"sh", "-c", "pwd"}, Cwd: dir}, &out, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("(code, err) = (%d, %v); want (0, nil)", code, err)
+	}
+	// macOS may resolve /var/folders/... via a symlink that adds /private; allow either.
+	pwd := strings.TrimSpace(out.String())
+	if pwd != dir && pwd != "/private"+dir {
+		t.Errorf("pwd = %q; want %q (or /private prefix)", pwd, dir)
+	}
+}
+
+func TestRunCommand_EnvOverride(t *testing.T) {
+	var out bytes.Buffer
+	code, err := runCommand(context.Background(),
+		runSpec{
+			Cmd: []string{"sh", "-c", "echo $FOO"},
+			Env: map[string]string{"FOO": "bar"},
+		}, &out, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("(code, err) = (%d, %v); want (0, nil)", code, err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "bar" {
+		t.Errorf("stdout = %q; want %q", got, "bar")
+	}
+}
+
+func TestRunCommand_Timeout(t *testing.T) {
+	start := time.Now()
+	code, err := runCommand(context.Background(),
+		runSpec{Cmd: []string{"sleep", "30"}, TimeoutSeconds: 1}, io.Discard, io.Discard)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v; want context.DeadlineExceeded", err)
+	}
+	if code != 124 {
+		t.Errorf("code = %d; want 124", code)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("elapsed = %v; want < 3s", elapsed)
+	}
+}
+
+func TestRunCommand_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	_, err := runCommand(ctx,
+		runSpec{Cmd: []string{"sleep", "30"}}, io.Discard, io.Discard)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v; want context.Canceled", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v; want NOT context.DeadlineExceeded (caller cancel)", err)
+	}
+}
+
+func TestRunCommand_SpawnFail(t *testing.T) {
+	_, err := runCommand(context.Background(),
+		runSpec{Cmd: []string{"/this/does/not/exist"}}, io.Discard, io.Discard)
+	if err == nil {
+		t.Errorf("err = nil; want spawn failure")
+	}
+}
+
+func TestRunCommand_EmptyCmd(t *testing.T) {
+	_, err := runCommand(context.Background(),
+		runSpec{Cmd: nil}, io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "cmd is empty") {
+		t.Errorf("err = %v; want 'cmd is empty'", err)
+	}
+}
+
+func TestRunCommand_LargeStdoutToTempFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large-output test in -short mode")
+	}
+	// ~110 MB via dd of zero bytes; stderr suppressed because macOS dd lacks
+	// status=none.
+	const want = int64(110 * 1024 * 1024)
+	path := filepath.Join(t.TempDir(), "stdout.log")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	defer f.Close()
+
+	code, err := runCommand(context.Background(), runSpec{
+		Cmd: []string{"sh", "-c", "dd if=/dev/zero bs=1024 count=" + strconv.Itoa(int(want/1024)) + " 2>/dev/null"},
+	}, f, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("(code, err) = (%d, %v); want (0, nil)", code, err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if st.Size() != want {
+		t.Errorf("size = %d; want %d", st.Size(), want)
+	}
+}

--- a/internal/api/scratchworkerservice/exec.go
+++ b/internal/api/scratchworkerservice/exec.go
@@ -1,0 +1,354 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scratchworkerservice
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/google/oss-rebuild/pkg/act"
+	"github.com/pkg/errors"
+)
+
+// StartRequest is the body of POST exec/start. The broker mints OpID,
+// stamps ScratchID, and forwards. The worker spawns the command
+// asynchronously; the broker then pulls status + output via
+// exec/op/status and exec/op/output.
+type StartRequest struct {
+	OpID           string            `form:"op_id,required"`
+	ScratchID      string            `form:"scratch_id,required"`
+	Cmd            []string          `form:"cmd,required"`
+	Cwd            string            `form:"cwd"`
+	Env            map[string]string `form:"env"`
+	StdinB64       string            `form:"stdin_b64"`
+	TimeoutSeconds int               `form:"timeout_seconds"`
+}
+
+// Validate implements act.Input.
+func (r StartRequest) Validate() error {
+	if r.OpID == "" {
+		return errors.New("op_id is required")
+	}
+	if r.ScratchID == "" {
+		return errors.New("scratch_id is required")
+	}
+	if len(r.Cmd) == 0 {
+		return errors.New("cmd is required")
+	}
+	if r.TimeoutSeconds < 0 {
+		return errors.New("timeout_seconds must be >= 0")
+	}
+	return nil
+}
+
+// StatusRequest is the body of POST exec/op/status.
+type StatusRequest struct {
+	ID string `form:"id,required"`
+}
+
+// Validate implements act.Input.
+func (r StatusRequest) Validate() error {
+	if r.ID == "" {
+		return errors.New("id is required")
+	}
+	return nil
+}
+
+// ExecStatus is the worker's in-memory view of one op. Returned by
+// exec/op/status. The broker mirrors this into Firestore on sync.
+type ExecStatus struct {
+	Done       bool      `json:"done"`
+	ExitCode   int       `json:"exit_code,omitempty"`
+	TimedOut   bool      `json:"timed_out,omitempty"`
+	TotalBytes int64     `json:"total_bytes"` // Output bytes written. Monotonic.
+	StartedAt  time.Time `json:"started_at,omitzero"`
+	FinishedAt time.Time `json:"finished_at,omitzero"`
+	ErrMsg     string    `json:"err_msg,omitempty"` // Run error. If set, Done is true.
+}
+
+// OutputRequest is the body of POST exec/op/output. The broker fetches
+// the entire merged stdout+stderr buffer for an op each sync.
+//
+// TODO: Once act gains a streaming-response model, switch this to a
+// range-style request (Start offset) returning only the new tail bytes.
+// Today the worker JSON-encodes the full buffer on every call; that's
+// O(bytes-so-far) per poll and is fine for shortish builds but wasteful
+// for long-running ones.
+type OutputRequest struct {
+	ID string `form:"id,required"`
+}
+
+// Validate implements act.Input.
+func (r OutputRequest) Validate() error {
+	if r.ID == "" {
+		return errors.New("id is required")
+	}
+	return nil
+}
+
+// OutputResponse carries the full merged stdout+stderr buffer for an
+// op. Bytes is the entire buffer (no offset). TotalBytes equals
+// len(Bytes); it's repeated for parity with ExecStatus.TotalBytes so
+// callers don't need to inspect the byte slice.
+//
+// JSON encodes []byte as a base64 string; that's the in-memory
+// buffering pattern we're using until streaming support exists.
+// XXX: Inefficient
+type OutputResponse struct {
+	Bytes      []byte `json:"bytes,omitempty"`
+	TotalBytes int64  `json:"total_bytes"`
+}
+
+// execEntry is the in-memory record the worker keeps for one op. The
+// worker has no GCP credentials and writes nothing externally; the
+// broker pulls Status and Output on its own cadence (agent-poll-driven
+// + reaper sweep).
+type execEntry struct {
+	startedAt  time.Time
+	finishedAt time.Time
+	file       *os.File // merged stdout+stderr; lifetime = env lifetime
+	totalBytes int64    // updated under mu after each runCommand returns
+	done       bool
+	exitCode   int
+	timedOut   bool
+	errMsg     string
+}
+
+// ExecStore tracks per-opID state in the worker process. Concurrent
+// access from the spawn goroutine, the /status handler, and the
+// /output handler is mutex-guarded. Exported so tests can construct
+// one.
+type ExecStore struct {
+	mu      sync.Mutex
+	entries map[string]*execEntry
+}
+
+// NewExecStore returns an empty ExecStore.
+func NewExecStore() *ExecStore { return &ExecStore{entries: map[string]*execEntry{}} }
+
+func (s *ExecStore) create(opID string, f *os.File, started time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[opID] = &execEntry{startedAt: started, file: f}
+}
+
+func (s *ExecStore) finish(opID string, exitCode int, timedOut bool, errMsg string, totalBytes int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[opID]
+	if !ok {
+		return
+	}
+	e.done = true
+	e.exitCode = exitCode
+	e.timedOut = timedOut
+	e.errMsg = errMsg
+	e.finishedAt = time.Now().UTC()
+	e.totalBytes = totalBytes
+}
+
+// Forget releases the entry and its temp file. Called when the broker
+// has finalized the op via Firestore Update; the file is no longer
+// needed. Best-effort; missing entry is not an error.
+func (s *ExecStore) Forget(opID string) {
+	s.mu.Lock()
+	e, ok := s.entries[opID]
+	delete(s.entries, opID)
+	s.mu.Unlock()
+	if ok && e.file != nil {
+		_ = e.file.Close()
+		_ = os.Remove(e.file.Name())
+	}
+}
+
+// status returns a snapshot of the op's state. Returns (ExecStatus{}, false)
+// if the op is unknown.
+func (s *ExecStore) status(opID string) (ExecStatus, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[opID]
+	if !ok {
+		return ExecStatus{}, false
+	}
+	// Re-stat the file for the current size: writes from runCommand
+	// happen via the kernel's fd, not through this struct.
+	var total int64
+	if e.file != nil {
+		if info, err := e.file.Stat(); err == nil {
+			total = info.Size()
+		}
+	}
+	if e.done {
+		// Once done, the size is frozen at the value we recorded.
+		total = e.totalBytes
+	}
+	return ExecStatus{
+		Done:       e.done,
+		ExitCode:   e.exitCode,
+		TimedOut:   e.timedOut,
+		TotalBytes: total,
+		StartedAt:  e.startedAt,
+		FinishedAt: e.finishedAt,
+		ErrMsg:     e.errMsg,
+	}, true
+}
+
+// readAll returns the full merged stdout+stderr buffer for opID. The
+// buffer is read into memory (no streaming); see OutputRequest's TODO
+// about replacing this with a range-style streaming endpoint.
+func (s *ExecStore) readAll(opID string) ([]byte, error) {
+	s.mu.Lock()
+	e, ok := s.entries[opID]
+	s.mu.Unlock()
+	if !ok {
+		return nil, errors.Errorf("unknown op %q", opID)
+	}
+	if e.file == nil {
+		return nil, nil
+	}
+	info, err := e.file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	end := info.Size()
+	if e.done {
+		end = e.totalBytes
+	}
+	if end == 0 {
+		return nil, nil
+	}
+	buf := make([]byte, end)
+	if _, err := e.file.ReadAt(buf, 0); err != nil && err != io.EOF {
+		return nil, err
+	}
+	return buf, nil
+}
+
+type ExecDeps struct {
+	Store *ExecStore
+	// TempDir is where the captured output file is created.
+	// Empty uses the OS default.
+	TempDir string
+	// Workdir is the default cwd when a request omits Cwd.
+	Workdir string
+}
+
+// ExecStart spawns the requested command asynchronously and returns
+// immediately. The broker later polls /exec/op/status and /exec/op/output
+// to learn what happened.
+func ExecStart(_ context.Context, req StartRequest, deps *ExecDeps) (*act.NoOutput, error) {
+	go finalizeExec(req, deps)
+	return &act.NoOutput{}, nil
+}
+
+func finalizeExec(req StartRequest, deps *ExecDeps) {
+	// Detached: the HTTP context is gone by now. Use a fresh background
+	// ctx so cancellation of the broker call doesn't kill the spawned
+	// command. (The runspec's TimeoutSeconds is the real bound.)
+	ctx := context.Background()
+	started := time.Now().UTC()
+
+	outF, err := openMergedTemp(deps.TempDir)
+	if err != nil {
+		deps.Store.create(req.OpID, nil, started)
+		deps.Store.finish(req.OpID, 0, false, "open temp file: "+err.Error(), 0)
+		return
+	}
+	// NOTE: the file outlives this function. The broker can /output
+	// pull from it any time after we return. ExecStore.Forget (called
+	// after broker finalizes) is what closes + removes it.
+	deps.Store.create(req.OpID, outF, started)
+
+	cwd := req.Cwd
+	if cwd == "" {
+		cwd = deps.Workdir
+	}
+
+	stdin, err := decodeStdin(req.StdinB64)
+	if err != nil {
+		size, _ := outF.Stat()
+		var totalBytes int64
+		if size != nil {
+			totalBytes = size.Size()
+		}
+		deps.Store.finish(req.OpID, 0, false, "decode stdin: "+err.Error(), totalBytes)
+		return
+	}
+
+	// Merge stdout+stderr by passing the same *os.File to both. Go's
+	// exec package serializes writes when Stdout and Stderr compare ==,
+	// so writes from each stream are atomic within themselves.
+	code, runErr := runCommand(ctx, runSpec{
+		Cmd:            req.Cmd,
+		Cwd:            cwd,
+		Env:            req.Env,
+		Stdin:          stdin,
+		TimeoutSeconds: req.TimeoutSeconds,
+	}, outF, outF)
+
+	// Snapshot final size before announcing Done. Subsequent reads see
+	// this value (frozen after Done).
+	info, statErr := outF.Stat()
+	var total int64
+	if statErr == nil {
+		total = info.Size()
+	}
+	// A timeout is fully described by exit 124 + the TimedOut flag; we
+	// suppress the DeadlineExceeded error message to avoid double-reporting.
+	timedOut := errors.Is(runErr, context.DeadlineExceeded)
+	var msg string
+	if runErr != nil && !timedOut {
+		msg = errors.Wrap(runErr, "run").Error()
+	}
+	deps.Store.finish(req.OpID, code, timedOut, msg, total)
+}
+
+type StatusDeps struct {
+	Store *ExecStore
+}
+
+// Status returns the current ExecStatus for an op.
+func Status(_ context.Context, req StatusRequest, deps *StatusDeps) (*ExecStatus, error) {
+	if st, ok := deps.Store.status(req.ID); ok {
+		return &st, nil
+	}
+	return nil, errors.Errorf("unknown op %q", req.ID)
+}
+
+// OutputDeps wires Output.
+type OutputDeps struct {
+	Store *ExecStore
+}
+
+// Output returns the entire merged stdout+stderr buffer for an op.
+//
+// TODO(streaming): see OutputRequest godoc. Replace with a streaming
+// range endpoint once act supports it.
+func Output(_ context.Context, req OutputRequest, deps *OutputDeps) (*OutputResponse, error) {
+	buf, err := deps.Store.readAll(req.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &OutputResponse{Bytes: buf, TotalBytes: int64(len(buf))}, nil
+}
+
+func decodeStdin(b64 string) (io.Reader, error) {
+	if b64 == "" {
+		return nil, nil
+	}
+	b, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(b), nil
+}
+
+func openMergedTemp(dir string) (*os.File, error) {
+	return os.CreateTemp(dir, "exec-out-*")
+}

--- a/internal/api/scratchworkerservice/exec_test.go
+++ b/internal/api/scratchworkerservice/exec_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scratchworkerservice
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestDeps(t *testing.T) (*ExecDeps, *ExecStore) {
+	t.Helper()
+	store := NewExecStore()
+	return &ExecDeps{
+		Store:   store,
+		TempDir: t.TempDir(),
+		Workdir: t.TempDir(),
+	}, store
+}
+
+// stdReq builds a WorkerStartRequest with the minimum fields.
+func stdReq(opID, envID string, cmd ...string) StartRequest {
+	return StartRequest{OpID: opID, ScratchID: envID, Cmd: cmd}
+}
+
+func waitForDone(t *testing.T, store *ExecStore, opID string, timeout time.Duration) ExecStatus {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		st, ok := store.status(opID)
+		if ok && st.Done {
+			return st
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("op %s not done within %v", opID, timeout)
+	return ExecStatus{}
+}
+
+func readAll(t *testing.T, store *ExecStore, opID string) []byte {
+	t.Helper()
+	b, err := store.readAll(opID)
+	if err != nil {
+		t.Fatalf("readAll: %v", err)
+	}
+	return b
+}
+
+func TestExecStart_NormalCompletion(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-normal"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "echo hi"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	st := waitForDone(t, store, opID, 3*time.Second)
+	if st.ExitCode != 0 || st.TimedOut || st.ErrMsg != "" {
+		t.Errorf("status = %+v; want clean exit", st)
+	}
+	if got := string(readAll(t, store, opID)); got != "hi\n" {
+		t.Errorf("output = %q; want %q", got, "hi\n")
+	}
+}
+
+func TestExecStart_NonZeroExit(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-nonzero"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "exit 7"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	st := waitForDone(t, store, opID, 3*time.Second)
+	if st.ExitCode != 7 {
+		t.Errorf("ExitCode = %d; want 7", st.ExitCode)
+	}
+}
+
+func TestExecStart_Timeout(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-timeout"
+	req := stdReq(opID, "env-1", "sleep", "30")
+	req.TimeoutSeconds = 1
+	if _, err := ExecStart(context.Background(), req, deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	st := waitForDone(t, store, opID, 5*time.Second)
+	if !st.TimedOut || st.ExitCode != 124 {
+		t.Errorf("status = %+v; want TimedOut + 124", st)
+	}
+}
+
+func TestExecStart_SpawnFail(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-spawnfail"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "/this/does/not/exist"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	st := waitForDone(t, store, opID, 3*time.Second)
+	if st.ErrMsg == "" {
+		t.Errorf("ErrMsg empty; want spawn failure")
+	}
+}
+
+func TestExecStart_StdinEcho(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-stdin"
+	payload := "piped via stdin"
+	req := stdReq(opID, "env-1", "cat")
+	req.StdinB64 = base64.StdEncoding.EncodeToString([]byte(payload))
+	if _, err := ExecStart(context.Background(), req, deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 3*time.Second)
+	if got := string(readAll(t, store, opID)); got != payload {
+		t.Errorf("output = %q; want %q", got, payload)
+	}
+}
+
+func TestExecStart_BadStdinB64(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-badstdin"
+	req := stdReq(opID, "env-1", "cat")
+	req.StdinB64 = "not-valid-base64!!!"
+	if _, err := ExecStart(context.Background(), req, deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	st := waitForDone(t, store, opID, 2*time.Second)
+	if st.ErrMsg == "" || !strings.Contains(st.ErrMsg, "decode stdin") {
+		t.Errorf("ErrMsg = %q; want decode-stdin failure", st.ErrMsg)
+	}
+}
+
+func TestExecStart_NonBlocking(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-nonblock"
+	req := stdReq(opID, "env-1", "sleep", "30")
+	req.TimeoutSeconds = 1
+	start := time.Now()
+	if _, err := ExecStart(context.Background(), req, deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("ExecStart took %v; want <100ms (must not block)", elapsed)
+	}
+	waitForDone(t, store, opID, 5*time.Second)
+}
+
+func TestExecStart_MergedStdoutStderr(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-merged"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "echo OUT; echo ERR 1>&2"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 3*time.Second)
+	got := string(readAll(t, store, opID))
+	if !strings.Contains(got, "OUT") || !strings.Contains(got, "ERR") {
+		t.Errorf("merged output = %q; want OUT and ERR both present", got)
+	}
+}
+
+func TestExecStart_TimeoutPartialOutputPreserved(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-timeout-partial"
+	req := stdReq(opID, "env-1", "sh", "-c", "echo before-timeout; sleep 30")
+	req.TimeoutSeconds = 1
+	if _, err := ExecStart(context.Background(), req, deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	st := waitForDone(t, store, opID, 5*time.Second)
+	if !st.TimedOut {
+		t.Fatalf("status = %+v; want TimedOut", st)
+	}
+	if got := string(readAll(t, store, opID)); !strings.Contains(got, "before-timeout") {
+		t.Errorf("output = %q; want 'before-timeout' preserved", got)
+	}
+}
+
+func TestExecStore_ReadAllReturnsFullBuffer(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-full-buf"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "printf abcdef"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 3*time.Second)
+	if got := string(readAll(t, store, opID)); got != "abcdef" {
+		t.Errorf("readAll = %q; want %q", got, "abcdef")
+	}
+}
+
+func TestExecStore_ForgetReleasesFile(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-forget"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "echo bye"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 3*time.Second)
+	store.Forget(opID)
+	if _, ok := store.status(opID); ok {
+		t.Errorf("status after Forget; want unknown")
+	}
+}
+
+func TestStatus_UnknownOp(t *testing.T) {
+	store := NewExecStore()
+	deps := &StatusDeps{Store: store}
+	if _, err := Status(context.Background(), StatusRequest{ID: "missing"}, deps); err == nil {
+		t.Errorf("Status(missing) = nil; want error")
+	}
+}

--- a/internal/db/scratch_exec.go
+++ b/internal/db/scratch_exec.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/api/iterator"
+)
+
+// ScratchExecs persists scratch-exec records. The broker inserts
+// pending execs and updates them as the worker progresses. The reaper
+// enumerates pending execs via ListPending.
+type ScratchExecs interface {
+	Resource[schema.ScratchExec, string]
+	// ListPending returns all execs with State == Pending. Backed by a
+	// single-field index on "state" in Firestore.
+	ListPending(ctx context.Context) ([]schema.ScratchExec, error)
+}
+
+const scratchExecCollection = "scratch-execs"
+
+func scratchExecPath(r schema.ScratchExec) []string { return []string{scratchExecCollection, r.ID} }
+func scratchExecKey(id string) []string             { return []string{scratchExecCollection, id} }
+
+type firestoreScratchExecs struct {
+	*firestoreResource[schema.ScratchExec, string]
+	client *firestore.Client
+}
+
+// NewFirestoreScratchExecs returns a ScratchExecs backed by Firestore.
+func NewFirestoreScratchExecs(c *firestore.Client) ScratchExecs {
+	return &firestoreScratchExecs{
+		firestoreResource: &firestoreResource[schema.ScratchExec, string]{
+			client: c, pathFor: scratchExecPath, pathForKey: scratchExecKey,
+		},
+		client: c,
+	}
+}
+
+func (f *firestoreScratchExecs) ListPending(ctx context.Context) ([]schema.ScratchExec, error) {
+	iter := f.client.Collection(scratchExecCollection).
+		Where("state", "==", string(schema.ScratchExecPending)).
+		Documents(ctx)
+	defer iter.Stop()
+	var out []schema.ScratchExec
+	for {
+		snap, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var r schema.ScratchExec
+		if err := snap.DataTo(&r); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+type memoryScratchExecs struct {
+	*memoryResource[schema.ScratchExec, string]
+}
+
+// NewMemoryScratchExecs returns an in-memory ScratchExecs for tests.
+func NewMemoryScratchExecs() ScratchExecs {
+	return &memoryScratchExecs{
+		memoryResource: &memoryResource[schema.ScratchExec, string]{
+			data: map[string]schema.ScratchExec{}, pathFor: scratchExecPath, pathForKey: scratchExecKey,
+		},
+	}
+}
+
+func (m *memoryScratchExecs) ListPending(ctx context.Context) ([]schema.ScratchExec, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []schema.ScratchExec
+	for _, r := range m.data {
+		if r.State == schema.ScratchExecPending {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}

--- a/internal/db/scratch_exec_test.go
+++ b/internal/db/scratch_exec_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+func TestMemoryScratchExecs_ListPending(t *testing.T) {
+	ctx := context.Background()
+	execs := NewMemoryScratchExecs()
+
+	mustInsert := func(r schema.ScratchExec) {
+		t.Helper()
+		if err := execs.Insert(ctx, r); err != nil {
+			t.Fatalf("Insert(%s): %v", r.ID, err)
+		}
+	}
+	mustInsert(schema.ScratchExec{ID: "pending-1", ScratchID: "s-a", State: schema.ScratchExecPending})
+	mustInsert(schema.ScratchExec{ID: "pending-2", ScratchID: "s-b", State: schema.ScratchExecPending})
+	mustInsert(schema.ScratchExec{ID: "finalized", State: schema.ScratchExecCompleted, ExitCode: 0})
+
+	got, err := execs.ListPending(ctx)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	var ids []string
+	for _, r := range got {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids)
+	want := []string{"pending-1", "pending-2"}
+	if diff := cmp.Diff(want, ids); diff != "" {
+		t.Errorf("pending ids (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/longrunning/operation.go
+++ b/pkg/longrunning/operation.go
@@ -6,6 +6,15 @@ package longrunning
 import "fmt"
 
 // Operation represents a long-running operation.
+//
+// Unlike google.longrunning.Operation's strict oneof of {error, response},
+// Result and Error here may coexist: projection functions are encouraged to
+// populate Result as a snapshot of observable state (e.g. partial output URIs,
+// timing metadata) and additionally set Error when the operation has terminally
+// failed. Callers must check Error first to decide whether the Result data
+// represents a successful outcome or partial/diagnostic state captured before
+// failure. See agentapiservice.ProjectScratchExec and apiservice.ProjectRebuildAttempt
+// for established uses of this pattern.
 type Operation[R any] struct {
 	ID     string          `json:"id"`
 	Done   bool            `json:"done"`
@@ -14,6 +23,10 @@ type Operation[R any] struct {
 }
 
 // OperationError represents an error that occurred during a long-running operation.
+//
+// Code is a gRPC status code (google.golang.org/grpc/codes) cast to int.
+// Existing in-tree usage is gradually migrating from HTTP-status values to
+// this convention; new projections should emit gRPC codes.
 type OperationError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`

--- a/pkg/rebuild/schema/scratch.go
+++ b/pkg/rebuild/schema/scratch.go
@@ -32,6 +32,7 @@ const (
 type Scratch struct {
 	ID           string       `json:"id,omitempty" firestore:"id,omitempty"`
 	BuildID      string       `json:"build_id,omitempty" firestore:"build_id,omitempty"`
+	ObliviousID  string       `json:"oblivious_id,omitempty" firestore:"oblivious_id,omitempty"`
 	MachineClass MachineClass `json:"machine_class,omitempty" firestore:"machine_class,omitempty"`
 	VMName       string       `json:"vm_name,omitempty" firestore:"vm_name,omitempty"`
 	InternalIP   string       `json:"internal_ip,omitempty" firestore:"internal_ip,omitempty"`
@@ -89,4 +90,92 @@ func (r ScratchDeleteRequest) Validate() error {
 type ScratchDeleteResponse struct {
 	ScratchID string       `json:"scratch_id"`
 	State     ScratchState `json:"state"`
+}
+
+// ScratchExecState is the lifecycle state of one exec on a scratch.
+//
+// Pending is the only non-terminal value; transitions to any other state
+// are one-way and the record becomes immutable afterwards.
+type ScratchExecState string
+
+const (
+	ScratchExecPending   ScratchExecState = "pending"
+	ScratchExecCompleted ScratchExecState = "completed" // worker observed the command's exit (any code)
+	ScratchExecTimedOut  ScratchExecState = "timed_out" // worker- or broker-enforced deadline
+	ScratchExecLost      ScratchExecState = "lost"      // dispatch failed, scratch gone, or sync failure
+)
+
+// Status is a structured diagnostic for a terminal failure. It is
+// modeled after google.rpc.Status; Code is a gRPC status code carried
+// as an int (matching longrunning.OperationError.Code so the projection
+// is a direct copy).
+//
+// The schema package deliberately does not import google.golang.org/grpc/codes
+// to keep the type free of RPC-layer dependencies. Callers should construct
+// Status values with int(codes.X). Common values emitted by the broker today
+// are codes.DeadlineExceeded, codes.Unavailable, and codes.Internal. Readers
+// should treat unknown codes as equivalent to codes.Internal.
+type Status struct {
+	Code    int    `json:"code" firestore:"code"`
+	Message string `json:"message,omitempty" firestore:"message,omitempty"`
+}
+
+// ScratchExec is the stored form of one exec on a scratch. It is the
+// canonical source of truth; the wire-facing Operation[ScratchExecResult]
+// is derived from it (see agentapiservice.ProjectScratchExec).
+//
+// stdout and stderr are merged on the worker into a single interleaved
+// stream published at OutURI; the broker writes that object on each
+// sync poll. OutURI is set at creation and updated incrementally during
+// execution and may hold partial data in any State, including Failed.
+//
+// Field validity by State:
+//   - Pending:   ExitCode 0; Error nil; OutURI may be partial.
+//   - Completed: ExitCode is the observed command exit; Error nil; OutURI complete.
+//   - TimedOut:  ExitCode is the kill exit (typically 124); Error carries detail; OutURI may be partial.
+//   - Lost:      Error non-nil; ExitCode 0 (no exit observed); OutURI may be partial.
+type ScratchExec struct {
+	ID         string           `json:"id" firestore:"id"`
+	ScratchID  string           `json:"scratch_id,omitempty" firestore:"scratch_id,omitempty"`
+	Cmd        []string         `json:"cmd,omitempty" firestore:"cmd,omitempty"`
+	Cwd        string           `json:"cwd,omitempty" firestore:"cwd,omitempty"`
+	OutURI     string           `json:"out_uri,omitempty" firestore:"out_uri,omitempty"`
+	StartedAt  time.Time        `json:"started_at,omitzero" firestore:"started_at,omitempty"`
+	FinishedAt time.Time        `json:"finished_at,omitzero" firestore:"finished_at,omitempty"`
+	State      ScratchExecState `json:"state" firestore:"state"`
+	ExitCode   int              `json:"exit_code,omitempty" firestore:"exit_code,omitempty"`
+	Error      *Status          `json:"error,omitempty" firestore:"error,omitempty"`
+}
+
+// ScratchExecResult is the API payload inside derived from ScratchExec.
+type ScratchExecResult struct {
+	ScratchID  string    `json:"scratch_id"`
+	ExitCode   int       `json:"exit_code"`
+	OutURI     string    `json:"out_uri,omitempty"`
+	StartedAt  time.Time `json:"started_at,omitzero"`
+	FinishedAt time.Time `json:"finished_at,omitzero"`
+}
+
+// ScratchExecRequest is the agent's input to /scratch/exec/op/create.
+type ScratchExecRequest struct {
+	ScratchID      string            `form:"scratch_id,required"`
+	Cmd            []string          `form:"cmd,required"`
+	Cwd            string            `form:"cwd"`
+	Env            map[string]string `form:"env"`
+	StdinB64       string            `form:"stdin_b64"`
+	TimeoutSeconds int               `form:"timeout_seconds"`
+}
+
+// Validate implements act.Input.
+func (r ScratchExecRequest) Validate() error {
+	if r.ScratchID == "" {
+		return errors.New("scratch_id is required")
+	}
+	if len(r.Cmd) == 0 {
+		return errors.New("cmd is required")
+	}
+	if r.TimeoutSeconds < 0 {
+		return errors.New("timeout_seconds must be >= 0")
+	}
+	return nil
 }


### PR DESCRIPTION
This change enables us to run commands on the scratch instance. This
enables us to utilize it for actual tasks. Since commands can take some
time to run, we model the API using the longrunning idiom recently
introduced.

When an Operation is polled, the API polls the worker itself to fetch
its state. On completion, we also fetch its output logs to store in GCS.