### PR TITLE
Only fetch and start the tetragon_sysgraph when needed

### DIFF
--- a/pkg/build/gcb/planner.go
+++ b/pkg/build/gcb/planner.go
@@ -307,15 +307,14 @@ var gcbStandardBuildTpl = template.Must(
 			apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq .access_token > /tmp/token
 			(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 			{{- end}}
+			{{- if .UseSyscallMonitor}}
 			{{- if .TetragonSysgraphURL}}
 			curl {{if .TetragonSysgraphAuth}}-H @/tmp/auth_header {{end}}{{.TetragonSysgraphURL}} > tetragon_sysgraph
 			chmod +x tetragon_sysgraph
 			docker run --name=sysgraph --detach --cpu-shares=5120 -v=/workspace/:/workspace/ docker.io/library/alpine:3.21 /workspace/tetragon_sysgraph -server unix:///workspace/tetragon/tetragon.sock -output /workspace/sysgraph.zip
 			docker logs --follow sysgraph &
 			SYSGRAPH_PID=$(docker inspect -f '{{printf "%s" "{{.State.Pid}}"}}' sysgraph)
-			{{- end}}
-			{{- if .UseSyscallMonitor}}
-			{{- if not .TetragonSysgraphURL}}
+			{{- else}}
 			SYSGRAPH_PID=0
 			{{- end}}
 			PROXY_PID=0

--- a/pkg/build/gcb/planner_test.go
+++ b/pkg/build/gcb/planner_test.go
@@ -730,6 +730,30 @@ func TestGCBPlannerBuildScriptWithSysgraph(t *testing.T) {
 					`)[1:]
 			},
 		},
+		{
+			name: "Syscall monitor disabled but sysgraph URL set",
+			opts: build.PlanOptions{
+				UseSyscallMonitor: false,
+				Resources: build.Resources{
+					BaseImageConfig: baseImageConfig,
+					AssetStore:      rebuild.NewFilesystemAssetStore(memfs.New()),
+					ToolURLs: map[build.ToolType]string{
+						build.TetragonSysgraphTool: sysgraphURL,
+					},
+				},
+			},
+			want: func(dockerfile string) string {
+				return textwrap.Dedent(`
+					#!/usr/bin/env bash
+					set -eux
+					echo 'Starting rebuild for {Ecosystem:npm Package:test-package Version:1.0.0 Artifact:test-package-1.0.0.tgz}'
+					cat <<'EOS' | docker buildx build --tag=img -
+					`)[1:] + dockerfile + "\nEOS" + textwrap.Dedent(`
+
+					docker run --name=container img
+					`)[1:]
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			plan, err := planner.GeneratePlan(ctx, input, tc.opts)


### PR DESCRIPTION
This is the sysgraph monitor which consumes sysgraph events from
tetragon, no tetragon itself which is where the larger overhead comes
from. However, it's still a non-trivial fetch and conatiner start that
happens at the beginning of each build, even though it's usually
unnecessary.