### PR TITLE
Add periodic clean up of scratch and execs

### DIFF
--- a/cmd/agent-api/main.go
+++ b/cmd/agent-api/main.go
@@ -42,13 +42,14 @@ var (
 	port                 = flag.Int("port", 8080, "port on which to serve")
 
 	// Scratch flags. Gated by --scratch-enabled.
-	scratchEnabled      = flag.Bool("scratch-enabled", false, "register the scratch routes")
-	scratchZones        = flag.String("scratch-zones", "", "comma-separated, ordered list of GCE zones to try for scratch VMs (required when scratch enabled); first listed is preferred, later zones used only on stockout fallthrough")
-	scratchZone         = flag.String("scratch-zone", "", "GCE zone for scratch VMs (required when scratch enabled)")
-	scratchWorkerPort   = flag.Int("scratch-worker-port", 8080, "port the worker listens on")
-	scratchStandardTmpl = flag.String("scratch-instance-standard-template", "", "GCE instance template URL for the standard machine class (required when scratch enabled)")
-	scratchJumboTmpl    = flag.String("scratch-instance-jumbo-template", "", "GCE instance template URL for the jumbo machine class (optional)")
-	scratchOutputBucket = flag.String("scratch-output-bucket", "", "GCS bucket the broker writes exec output into (required when --scratch-enabled)")
+	scratchEnabled       = flag.Bool("scratch-enabled", false, "register the scratch routes")
+	scratchZones         = flag.String("scratch-zones", "", "comma-separated, ordered list of GCE zones to try for scratch VMs (required when scratch enabled); first listed is preferred, later zones used only on stockout fallthrough")
+	scratchWorkerPort    = flag.Int("scratch-worker-port", 8080, "port the worker listens on")
+	scratchStandardTmpl  = flag.String("scratch-instance-standard-template", "", "GCE instance template URL for the standard machine class (required when scratch enabled)")
+	scratchJumboTmpl     = flag.String("scratch-instance-jumbo-template", "", "GCE instance template URL for the jumbo machine class (optional)")
+	scratchOutputBucket  = flag.String("scratch-output-bucket", "", "GCS bucket the broker writes exec output into (required when --scratch-enabled)")
+	scratchIdleThreshold = flag.Duration("scratch-idle-threshold", 30*time.Minute, "scratches whose LastUsed is older than this and that have no in-deadline pending exec are reaped")
+	scratchOpDeadline    = flag.Duration("scratch-op-deadline", 2*time.Hour, "default and maximum exec duration, stamped on each exec; bounds how long a pending exec exempts its scratch from idle reaping")
 )
 
 // parseScratchZones splits --scratch-zones on commas, trimming whitespace
@@ -252,6 +253,7 @@ func ScratchExecCreateInit(ctx context.Context) (*agentapiservice.ScratchExecCre
 		Execs:        db.NewFirestoreScratchExecs(fs),
 		WorkerDialer: scratchWorkerDialer(ctx, *scratchWorkerPort),
 		OutputBucket: *scratchOutputBucket,
+		OpTimeout:    *scratchOpDeadline,
 	}, nil
 }
 
@@ -272,6 +274,29 @@ func ScratchExecGetInit(ctx context.Context) (*agentapiservice.ScratchExecGetDep
 	}, nil
 }
 
+func ScratchReapInit(ctx context.Context) (*agentapiservice.ScratchReapDeps, error) {
+	fs, err := firestore.NewClient(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "firestore client")
+	}
+	gce, err := agentapiservice.NewComputeGCE(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "compute client")
+	}
+	gcs, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "storage client")
+	}
+	execs := db.NewFirestoreScratchExecs(fs)
+	return &agentapiservice.ScratchReapDeps{
+		Scratches:     db.NewFirestoreScratch(fs),
+		Execs:         execs,
+		GCE:           gce,
+		Syncer:        agentapiservice.NewGCSSyncer(gcs, *scratchOutputBucket, execs, scratchWorkerDialer(ctx, *scratchWorkerPort)),
+		IdleThreshold: *scratchIdleThreshold,
+	}, nil
+}
+
 func main() {
 	flag.Parse()
 	mux := http.NewServeMux()
@@ -284,6 +309,7 @@ func main() {
 		mux.HandleFunc("/scratch/delete", api.Handler(ScratchDeleteInit, agentapiservice.ScratchDelete))
 		mux.HandleFunc("/scratch/exec/op/create", api.Handler(ScratchExecCreateInit, agentapiservice.ScratchExecCreate))
 		mux.HandleFunc("/scratch/exec/op/get", api.Handler(ScratchExecGetInit, agentapiservice.ScratchExecGet))
+		mux.HandleFunc("/scratch/reap", api.Handler(ScratchReapInit, agentapiservice.ScratchReap))
 	}
 
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), mux); err != nil {

--- a/deployments/iam.tf
+++ b/deployments/iam.tf
@@ -410,6 +410,14 @@ resource "google_cloud_run_v2_service_iam_member" "agent-calls-agent-api" {
   role     = "roles/run.invoker"
   member   = google_service_account.agent-job.member
 }
+resource "google_cloud_run_v2_service_iam_member" "orchestrator-calls-agent-api" {
+  count    = var.enable_scratch ? 1 : 0
+  location = google_cloud_run_v2_service.agent-api.location
+  project  = google_cloud_run_v2_service.agent-api.project
+  name     = google_cloud_run_v2_service.agent-api.name
+  role     = "roles/run.invoker"
+  member   = google_service_account.orchestrator.member
+}
 resource "google_storage_bucket_iam_member" "builder-agent-writes-metadata" {
   bucket = google_storage_bucket.agent-metadata.name
   role   = "roles/storage.objectCreator"

--- a/deployments/platform.tf
+++ b/deployments/platform.tf
@@ -160,6 +160,25 @@ resource "google_app_engine_application" "dummy_app" {
   depends_on    = [google_project_service.gae]
 }
 
+# Composite index used by the reaper's ListIdleSince query
+resource "google_firestore_index" "scratch-state-last-used" {
+  count      = var.enable_scratch ? 1 : 0
+  collection = "scratch"
+  fields {
+    field_path = "state"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "last_used"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "__name__"
+    order      = "ASCENDING"
+  }
+  depends_on = [google_app_engine_application.dummy_app]
+}
+
 ## PubSub
 
 resource "google_pubsub_topic" "attestation-topic" {
@@ -336,4 +355,28 @@ resource "google_compute_firewall" "scratch-worker-ingress" {
   }
   source_ranges = [google_compute_subnetwork.subnet[0].ip_cidr_range]
   target_tags   = ["scratch"]
+}
+
+resource "google_project_service" "cloudscheduler" {
+  count   = var.enable_scratch ? 1 : 0
+  service = "cloudscheduler.googleapis.com"
+}
+
+resource "google_cloud_scheduler_job" "scratch-reap" {
+  count    = var.enable_scratch ? 1 : 0
+  name     = "${var.host}-scratch-reap"
+  schedule = "*/30 * * * *" # every 30 minutes
+  region   = "us-central1"
+  http_target {
+    uri         = "${google_cloud_run_v2_service.agent-api.uri}/scratch/reap"
+    http_method = "POST"
+    headers = {
+      "Content-Type" = "application/x-www-form-urlencoded"
+    }
+    oidc_token {
+      service_account_email = google_service_account.orchestrator.email
+      audience              = google_cloud_run_v2_service.agent-api.uri
+    }
+  }
+  depends_on = [google_project_service.cloudscheduler]
 }

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -61,9 +61,14 @@ resource "google_compute_instance_template" "scratch-standard" {
   machine_type = "n2-standard-8"
   region       = "us-central1"
 
-  service_account {
-    email  = var.public ? "" : google_service_account.scratch-worker[0].email
-    scopes = var.public ? [] : ["https://www.googleapis.com/auth/devstorage.read_only"]
+  # NOTE: This block needs to be conditionally omitted to ensure an empty
+  # "email" field isn't interpreted as the default compute service account.
+  dynamic "service_account" {
+    for_each = var.public ? [] : [1]
+    content {
+      email  = google_service_account.scratch-worker[0].email
+      scopes = ["https://www.googleapis.com/auth/devstorage.read_only"]
+    }
   }
 
   disk {

--- a/internal/api/agentapiservice/scratch_exec.go
+++ b/internal/api/agentapiservice/scratch_exec.go
@@ -34,6 +34,7 @@ type ScratchExecCreateDeps struct {
 	WorkerDialer WorkerDialer
 	OutputBucket string
 	IDGen        func() string // For op IDs. If nil, defaults to uuid.New()
+	OpTimeout    time.Duration // Default and max exec timeout. Zero leaves execs unbounded
 }
 
 // ScratchExecGetDeps wires ScratchExecGet.
@@ -103,6 +104,18 @@ func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps 
 	if scratch.ObliviousID == "" {
 		return nil, api.AsStatus(codes.Internal, errors.Errorf("scratch %q missing ObliviousID", req.ScratchID))
 	}
+	// When OpTimeout is configured, every exec gets a worker-enforced bound:
+	// the request value, defaulted when omitted and capped at the maximum.
+	// The reaper derives the op's hard deadline from the stamped value and
+	// leaves unbounded ops' scratches up.
+	maxTimeout := int(deps.OpTimeout.Seconds())
+	if maxTimeout > 0 && req.TimeoutSeconds > maxTimeout {
+		return nil, api.AsStatus(codes.InvalidArgument, errors.Errorf("timeout_seconds %d exceeds maximum %d", req.TimeoutSeconds, maxTimeout))
+	}
+	timeoutSeconds := req.TimeoutSeconds
+	if timeoutSeconds == 0 {
+		timeoutSeconds = maxTimeout
+	}
 
 	// Prepare the worker client before Insert so a dialer failure (auth setup,
 	// URL parse) is a request-time error rather than a dangling Pending record.
@@ -114,13 +127,14 @@ func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps 
 	opID := mintID(deps.IDGen)
 	startedAt := time.Now().UTC()
 	exec := schema.ScratchExec{
-		ID:        opID,
-		ScratchID: req.ScratchID,
-		Cmd:       req.Cmd,
-		Cwd:       req.Cwd,
-		State:     schema.ScratchExecPending,
-		OutURI:    outURIFor(deps.OutputBucket, scratch.ObliviousID, opID),
-		StartedAt: startedAt,
+		ID:             opID,
+		ScratchID:      req.ScratchID,
+		Cmd:            req.Cmd,
+		Cwd:            req.Cwd,
+		TimeoutSeconds: timeoutSeconds,
+		State:          schema.ScratchExecPending,
+		OutURI:         outURIFor(deps.OutputBucket, scratch.ObliviousID, opID),
+		StartedAt:      startedAt,
 	}
 	if err := deps.Execs.Insert(ctx, exec); err != nil {
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "execs insert"))
@@ -137,7 +151,7 @@ func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps 
 		Cwd:            req.Cwd,
 		Env:            req.Env,
 		StdinB64:       req.StdinB64,
-		TimeoutSeconds: req.TimeoutSeconds,
+		TimeoutSeconds: timeoutSeconds,
 	}); err != nil {
 		log.Printf("scratch %q exec %q: worker dispatch: %v", req.ScratchID, opID, err)
 		exec, ferr := finalize(ctx, deps.Execs, exec, &schema.Status{
@@ -165,7 +179,8 @@ func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps 
 // pending and a Syncer is configured, ScratchExecGet triggers a sync:
 // pulling the worker's latest status + any new output bytes, rolling
 // those bytes into the op's GCS object, and (on the Done transition)
-// finalizing Firestore.
+// finalizing Firestore and bumping the scratch's LastUsed so the agent
+// has a fresh idle window to act on the result.
 //
 // Sync errors follow the last-error-is-final policy: any failure to reach the
 // worker, read its state, or persist the output transitions the exec to Failed
@@ -223,6 +238,16 @@ func ScratchExecGet(ctx context.Context, req schema.GetOperationRequest, deps *S
 		}
 		op := ProjectScratchExec(exec)
 		return &op, nil
+	}
+	// Bump LastUsed when this poll observed the Pending→terminal transition:
+	// a long exec finishes with LastUsed still at dispatch time, and without
+	// the bump the scratch is reaped before the agent can act on the result.
+	// One write per exec; lives here rather than in Syncer.Sync so the
+	// reaper's pull-through never extends the life of an abandoned scratch.
+	if synced.State != schema.ScratchExecPending {
+		if err := deps.Scratches.UpdateLastUsed(ctx, scratch.ID, time.Now().UTC()); err != nil {
+			log.Printf("exec %q: update last_used: %v", exec.ID, err)
+		}
 	}
 	op := ProjectScratchExec(synced)
 	return &op, nil

--- a/internal/api/agentapiservice/scratch_exec_test.go
+++ b/internal/api/agentapiservice/scratch_exec_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/internal/api/scratchworkerservice"
@@ -309,6 +310,49 @@ func TestScratchExecCreate_FinalizePersistFailureSurfacesAPIError(t *testing.T) 
 	}
 }
 
+// A request without TimeoutSeconds gets the configured default stamped on
+// the record and forwarded to the worker, so every exec is bounded.
+func TestScratchExecCreate_TimeoutDefaultedAndStamped(t *testing.T) {
+	const opID = "op-default-timeout"
+	fw := newFakeWorker(t)
+	createDeps, _, _, execs := fixture(t, opID, fw)
+	createDeps.OpTimeout = time.Hour
+
+	if _, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"},
+	}, createDeps); err != nil {
+		t.Fatalf("ScratchExecCreate: %v", err)
+	}
+	stored, err := execs.Get(context.Background(), opID)
+	if err != nil {
+		t.Fatalf("execs.Get: %v", err)
+	}
+	if want := 3600; stored.TimeoutSeconds != want {
+		t.Errorf("persisted TimeoutSeconds = %d; want %d", stored.TimeoutSeconds, want)
+	}
+	if fw.received == nil || fw.received.TimeoutSeconds != 3600 {
+		t.Errorf("worker TimeoutSeconds = %+v; want 3600", fw.received)
+	}
+}
+
+func TestScratchExecCreate_TimeoutOverMaxRejected(t *testing.T) {
+	const opID = "op-over-max"
+	fw := newFakeWorker(t)
+	createDeps, _, _, execs := fixture(t, opID, fw)
+	createDeps.OpTimeout = time.Minute
+
+	_, err := ScratchExecCreate(context.Background(), schema.ScratchExecRequest{
+		ScratchID: "s-1", Cmd: []string{"true"}, TimeoutSeconds: 61,
+	}, createDeps)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("code = %s; want InvalidArgument. err=%v", status.Code(err), err)
+	}
+	// Rejection happens before Insert: no dangling record.
+	if _, gerr := execs.Get(context.Background(), opID); !errors.Is(gerr, db.ErrNotFound) {
+		t.Errorf("exec exists after rejection; want no record (gerr=%v)", gerr)
+	}
+}
+
 func TestScratchExecCreate_BumpsLastUsedOnSuccess(t *testing.T) {
 	const opID = "op-bump"
 	fw := newFakeWorker(t)
@@ -403,6 +447,56 @@ func TestScratchExecGet_PendingTriggersSync(t *testing.T) {
 	}
 	if !op.Done {
 		t.Errorf("Done = false; want true (Syncer returned terminal)")
+	}
+}
+
+// The poll that observes the Pending→terminal transition bumps LastUsed so
+// the agent gets a fresh idle window to act on the result of a long exec.
+func TestScratchExecGet_CompletionBumpsLastUsed(t *testing.T) {
+	const opID = "op-done-bump"
+	fw := newFakeWorker(t)
+	_, getDeps, scratches, execs := fixture(t, opID, fw)
+	if err := execs.Insert(context.Background(), schema.ScratchExec{
+		ID: opID, ScratchID: "s-1", State: schema.ScratchExecPending,
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+	getDeps.Syncer = &fakeSyncer{returns: schema.ScratchExec{
+		ID: opID, ScratchID: "s-1", State: schema.ScratchExecCompleted,
+	}}
+	before, _ := scratches.Get(context.Background(), "s-1")
+
+	if _, err := ScratchExecGet(context.Background(), schema.GetOperationRequest{ID: opID}, getDeps); err != nil {
+		t.Fatalf("ScratchExecGet: %v", err)
+	}
+	after, _ := scratches.Get(context.Background(), "s-1")
+	if !after.LastUsed.After(before.LastUsed) {
+		t.Errorf("LastUsed before=%v after=%v; expected bump on completion", before.LastUsed, after.LastUsed)
+	}
+}
+
+// A poll that finds the exec still running writes nothing to the scratch:
+// in-flight liveness is the reaper's busy exemption, not LastUsed churn.
+func TestScratchExecGet_PendingPollDoesNotBumpLastUsed(t *testing.T) {
+	const opID = "op-still-running"
+	fw := newFakeWorker(t)
+	_, getDeps, scratches, execs := fixture(t, opID, fw)
+	if err := execs.Insert(context.Background(), schema.ScratchExec{
+		ID: opID, ScratchID: "s-1", State: schema.ScratchExecPending,
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+	getDeps.Syncer = &fakeSyncer{returns: schema.ScratchExec{
+		ID: opID, ScratchID: "s-1", State: schema.ScratchExecPending,
+	}}
+	before, _ := scratches.Get(context.Background(), "s-1")
+
+	if _, err := ScratchExecGet(context.Background(), schema.GetOperationRequest{ID: opID}, getDeps); err != nil {
+		t.Fatalf("ScratchExecGet: %v", err)
+	}
+	after, _ := scratches.Get(context.Background(), "s-1")
+	if !after.LastUsed.Equal(before.LastUsed) {
+		t.Errorf("LastUsed before=%v after=%v; want unchanged on pending poll", before.LastUsed, after.LastUsed)
 	}
 }
 

--- a/internal/api/agentapiservice/scratch_reap.go
+++ b/internal/api/agentapiservice/scratch_reap.go
@@ -1,0 +1,231 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/api"
+	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	pkgerrors "github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+)
+
+type ScratchReapRequest struct{}
+
+func (ScratchReapRequest) Validate() error { return nil }
+
+// ScratchReapResponse reports the counts from a single reap cycle.
+type ScratchReapResponse struct {
+	ScratchesReaped int `json:"scratches_reaped"`
+	OpsFinalized    int `json:"ops_finalized"`
+}
+
+// opDeadlineGrace pads each op's worker-enforced timeout to allow for
+// dispatch latency, clock skew, and sync slack before the reaper treats
+// the op as expired.
+const opDeadlineGrace = 10 * time.Minute
+
+// ScratchReapDeps wires the reaper.
+type ScratchReapDeps struct {
+	Scratches db.Scratch
+	Execs     db.ScratchExecs
+	GCE       GCE
+	// Syncer (optional) is invoked for every pending op on an idle
+	// scratch BEFORE teardown, and for expired ops during the sweep, so
+	// we capture the worker's final status while it's still reachable.
+	// nil disables; affected ops get finalized blind instead.
+	Syncer Syncer
+	// IdleThreshold: ready scratches with no in-deadline pending exec
+	// and LastUsed older than this get torn down.
+	IdleThreshold time.Duration // default: 30m
+}
+
+func (d *ScratchReapDeps) idleThreshold() time.Duration {
+	if d.IdleThreshold > 0 {
+		return d.IdleThreshold
+	}
+	return 30 * time.Minute
+}
+
+// deadlineFor returns the op's hard deadline: its worker-enforced timeout
+// plus grace. Only meaningful for bounded ops (TimeoutSeconds set); ops
+// without a bound never expire and exempt their scratch from teardown.
+func deadlineFor(exec schema.ScratchExec) time.Time {
+	return exec.StartedAt.Add(time.Duration(exec.TimeoutSeconds)*time.Second + opDeadlineGrace)
+}
+
+// ScratchReap deletes idle scratches and finalizes obsolete ops.
+// A pending op inside its deadline exempts its scratch from idle teardown,
+// so raising the exec timeout — not the idle threshold — is how longer
+// executions are accommodated. Ops bound to a no-longer-Ready scratch are
+// marked Lost and expired ops are pulled through the worker for their real
+// final status before falling back to a blind TimedOut. Best-effort: each
+// item's failure is logged and the loop continues so a single bad row
+// can't block the rest.
+func ScratchReap(ctx context.Context, _ ScratchReapRequest, deps *ScratchReapDeps) (*ScratchReapResponse, error) {
+	now := time.Now().UTC()
+	idleCutoff := now.Add(-deps.idleThreshold())
+	// Snapshot pending ops to derive busy scratches. An unknown busy set
+	// must abort the pass: reaping blind could kill active execs.
+	pending, err := deps.Execs.ListPending(ctx)
+	if err != nil {
+		return nil, api.AsStatus(codes.Internal, pkgerrors.Wrap(err, "list pending execs"))
+	}
+	busy := make(map[string]bool)
+	for _, exec := range pending {
+		if exec.StartedAt.IsZero() {
+			continue
+		}
+		if exec.TimeoutSeconds <= 0 {
+			// No bound to expire against: leave the scratch up rather than
+			// risk killing a live exec, but make the zombie visible.
+			log.Printf("reap: op %s on scratch %s has no time bound; exempting from teardown", exec.ID, exec.ScratchID)
+			busy[exec.ScratchID] = true
+		} else if now.Before(deadlineFor(exec)) {
+			busy[exec.ScratchID] = true
+		}
+	}
+	// Reap idle, non-busy scratches. Before tearing down each one, try
+	// to sync any pending ops on it so we capture exit codes while the
+	// worker is still reachable.
+	idle, err := deps.Scratches.ListIdleSince(ctx, idleCutoff)
+	if err != nil {
+		return nil, api.AsStatus(codes.Internal, pkgerrors.Wrap(err, "list idle scratches"))
+	}
+	var scratchesReaped int
+	for _, scratch := range idle {
+		if busy[scratch.ID] {
+			continue
+		}
+		if deps.Syncer != nil {
+			syncPendingFor(ctx, deps, scratch, pending)
+		}
+		// Re-check before the destructive step: an exec dispatched after
+		// the idle snapshot bumps LastUsed, and tearing down its scratch
+		// would orphan it.
+		if cur, err := deps.Scratches.Get(ctx, scratch.ID); err != nil {
+			log.Printf("reap re-check scratch %s: %v", scratch.ID, err)
+			continue
+		} else if cur.State != schema.ScratchReady || !cur.LastUsed.Before(idleCutoff) {
+			continue
+		}
+		if err := teardownScratch(ctx, deps, scratch); err != nil {
+			log.Printf("reap teardown scratch %s: %v", scratch.ID, err)
+			continue
+		}
+		scratchesReaped++
+	}
+	// Sweep pending ops. Mark ops Lost whose scratch is gone and finalize
+	// expired ones. Re-list rather than reuse the earlier snapshot: the
+	// pre-teardown sync may have finalized ops, and Execs.Update is a
+	// full-record overwrite that would clobber those records with a stale
+	// Pending base.
+	pending, err = deps.Execs.ListPending(ctx)
+	if err != nil {
+		return nil, api.AsStatus(codes.Internal, pkgerrors.Wrap(err, "list pending execs"))
+	}
+	var opsFinalized int
+	for _, exec := range pending {
+		next, errStatus := terminalStateFor(ctx, deps, exec, now)
+		if next == schema.ScratchExecPending {
+			continue
+		}
+		exec.State = next
+		exec.Error = errStatus
+		exec.FinishedAt = now
+		if err := deps.Execs.Update(ctx, exec); err != nil {
+			log.Printf("reap finalize op %s: %v", exec.ID, err)
+			continue
+		}
+		opsFinalized++
+	}
+	return &ScratchReapResponse{ScratchesReaped: scratchesReaped, OpsFinalized: opsFinalized}, nil
+}
+
+// syncPendingFor invokes Syncer for each pending op on scratch. Each op
+// gets a final update before the teardown loses access.
+func syncPendingFor(ctx context.Context, deps *ScratchReapDeps, scratch schema.Scratch, pending []schema.ScratchExec) {
+	for _, exec := range pending {
+		if exec.ScratchID != scratch.ID {
+			continue
+		}
+		if _, err := deps.Syncer.Sync(ctx, exec, scratch); err != nil {
+			log.Printf("reap pre-teardown sync op %s: %v", exec.ID, err)
+		}
+	}
+}
+
+// terminalStateFor returns the State to transition exec to in this reap
+// pass plus the diagnostic Status to attach, or ScratchExecPending with a
+// nil Status if it should stay pending or was already finalized here (an
+// expired op pulled through a still-reachable worker is persisted by the
+// Syncer itself).
+//
+// The deadline check stays ahead of the scratch-state checks so ops on a
+// scratch torn down earlier in the pass finalize TimedOut, not Lost.
+func terminalStateFor(ctx context.Context, deps *ScratchReapDeps, exec schema.ScratchExec, now time.Time) (schema.ScratchExecState, *schema.Status) {
+	if exec.TimeoutSeconds > 0 && !exec.StartedAt.IsZero() && now.After(deadlineFor(exec)) {
+		// The worker killed the command at its timeout, so a reachable
+		// worker has the real exit status and output. Pull those through
+		// before falling back to a blind TimedOut.
+		if deps.Syncer != nil {
+			if scratch, err := deps.Scratches.Get(ctx, exec.ScratchID); err == nil && scratch.State == schema.ScratchReady {
+				if synced, err := deps.Syncer.Sync(ctx, exec, scratch); err != nil {
+					log.Printf("reap pull-through sync op %s: %v", exec.ID, err)
+				} else if synced.State != schema.ScratchExecPending {
+					return schema.ScratchExecPending, nil
+				}
+			}
+		}
+		return schema.ScratchExecTimedOut, &schema.Status{
+			Code:    int(codes.DeadlineExceeded),
+			Message: "reaper: op past hard deadline",
+		}
+	}
+	if exec.ScratchID == "" {
+		return schema.ScratchExecPending, nil
+	}
+	scratch, err := deps.Scratches.Get(ctx, exec.ScratchID)
+	if errors.Is(err, db.ErrNotFound) {
+		return schema.ScratchExecLost, &schema.Status{
+			Code:    int(codes.Unavailable),
+			Message: "reaper: scratch not found",
+		}
+	}
+	if err != nil {
+		// Don't fail the op on a transient store error; the next reap pass retries.
+		log.Printf("reap scratches.Get(%s): %v", exec.ScratchID, err)
+		return schema.ScratchExecPending, nil
+	}
+	if scratch.State != schema.ScratchReady && scratch.State != schema.ScratchStarting {
+		return schema.ScratchExecLost, &schema.Status{
+			Code:    int(codes.Unavailable),
+			Message: fmt.Sprintf("reaper: scratch %s not ready (state=%s)", scratch.ID, scratch.State),
+		}
+	}
+	return schema.ScratchExecPending, nil
+}
+
+// teardownScratch mirrors ScratchDelete's GCE + state flow. Records
+// persist with state=Deleted for audit.
+func teardownScratch(ctx context.Context, deps *ScratchReapDeps, scratch schema.Scratch) error {
+	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleting); err != nil {
+		return pkgerrors.Wrap(err, "scratches update state deleting")
+	}
+	if scratch.VMName != "" {
+		if err := deps.GCE.DeleteInstance(ctx, scratch.Zone, scratch.VMName); err != nil {
+			log.Printf("reap DeleteInstance(%s): %v", scratch.VMName, err)
+		}
+	}
+	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleted); err != nil {
+		return pkgerrors.Wrap(err, "scratches update state deleted")
+	}
+	return nil
+}

--- a/internal/api/agentapiservice/scratch_reap_test.go
+++ b/internal/api/agentapiservice/scratch_reap_test.go
@@ -1,0 +1,515 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+func reapDeps(t *testing.T, scratches db.Scratch, execs db.ScratchExecs, gce GCE) *ScratchReapDeps {
+	t.Helper()
+	return &ScratchReapDeps{
+		Scratches:     scratches,
+		Execs:         execs,
+		GCE:           gce,
+		IdleThreshold: 30 * time.Minute,
+	}
+}
+
+func TestScratchReap_IdleReapedFreshPreserved(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	gce := NewMemoryGCE()
+	now := time.Now().UTC()
+
+	zone := "us-central1-a"
+	stale := schema.Scratch{
+		ID: "stale", State: schema.ScratchReady, Zone: zone,
+		VMName:   "scratch-stale",
+		LastUsed: now.Add(-1 * time.Hour),
+	}
+	fresh := schema.Scratch{
+		ID: "fresh", State: schema.ScratchReady, Zone: zone,
+		VMName:   "scratch-fresh",
+		LastUsed: now.Add(-5 * time.Minute),
+	}
+	dead := schema.Scratch{
+		ID: "dead", State: schema.ScratchDeleted, Zone: zone,
+		LastUsed: now.Add(-2 * time.Hour),
+	}
+	for _, s := range []schema.Scratch{stale, fresh, dead} {
+		if err := scratches.Insert(ctx, s); err != nil {
+			t.Fatalf("seed %s: %v", s.ID, err)
+		}
+	}
+	if _, err := gce.InsertInstanceFromTemplate(ctx, zone, stale.VMName, "tpl", nil); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, db.NewMemoryScratchExecs(), gce))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 1 {
+		t.Errorf("ScratchesReaped = %d; want 1 (only stale)", resp.ScratchesReaped)
+	}
+	got, _ := scratches.Get(ctx, "stale")
+	if got.State != schema.ScratchDeleted {
+		t.Errorf("stale.State = %q; want deleted", got.State)
+	}
+	got, _ = scratches.Get(ctx, "fresh")
+	if got.State != schema.ScratchReady {
+		t.Errorf("fresh.State = %q; want ready (left alone)", got.State)
+	}
+	if gce.InstanceExists(zone, stale.VMName) {
+		t.Errorf("stale VM not torn down")
+	}
+}
+
+func TestScratchReap_OpOnDeadScratchFinalizesLost(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	gce := NewMemoryGCE()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-1", State: schema.ScratchDeleted, Zone: "z",
+		VMName:   "vm",
+		LastUsed: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
+		StartedAt: now.Add(-5 * time.Minute),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, execs, gce))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 0 || resp.OpsFinalized != 1 {
+		t.Errorf("response = %+v; want ScratchesReaped=0 OpsFinalized=1", resp)
+	}
+	stored, _ := execs.Get(ctx, "op-1")
+	if stored.State != schema.ScratchExecLost {
+		t.Errorf("State = %q; want lost", stored.State)
+	}
+	if stored.FinishedAt.IsZero() {
+		t.Errorf("FinishedAt not set on finalize")
+	}
+}
+
+// An op without a time bound never expires and exempts its scratch from
+// teardown indefinitely (the reaper warns instead): there is no deadline
+// to expire against, so killing the scratch could kill a live exec.
+func TestScratchReap_UnboundedOpExemptsScratch(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-h", State: schema.ScratchReady, Zone: "z",
+		LastUsed: now.Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-old", ScratchID: "s-h", State: schema.ScratchExecPending,
+		StartedAt: now.Add(-3 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, execs, NewMemoryGCE()))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 0 || resp.OpsFinalized != 0 {
+		t.Errorf("response = %+v; want ScratchesReaped=0 OpsFinalized=0", resp)
+	}
+	if stored, _ := execs.Get(ctx, "op-old"); stored.State != schema.ScratchExecPending {
+		t.Errorf("State = %q; want pending", stored.State)
+	}
+	if got, _ := scratches.Get(ctx, "s-h"); got.State != schema.ScratchReady {
+		t.Errorf("scratch State = %q; want ready (exempt while unbounded op pending)", got.State)
+	}
+}
+
+func TestScratchReap_PendingOpOnHealthyScratchStaysPending(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-h", State: schema.ScratchReady, LastUsed: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-fresh", ScratchID: "s-h", State: schema.ScratchExecPending,
+		StartedAt: now.Add(-5 * time.Minute),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, execs, NewMemoryGCE()))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.OpsFinalized != 0 {
+		t.Errorf("OpsFinalized = %d; want 0", resp.OpsFinalized)
+	}
+	stored, _ := execs.Get(ctx, "op-fresh")
+	if stored.State != schema.ScratchExecPending {
+		t.Errorf("State = %q; want pending", stored.State)
+	}
+}
+
+func TestScratchReap_OrphanedOpScratchMissingEntirely(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-orphan", ScratchID: "vanished", State: schema.ScratchExecPending,
+		StartedAt: now.Add(-5 * time.Minute),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, execs, NewMemoryGCE()))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.OpsFinalized != 1 {
+		t.Errorf("OpsFinalized = %d; want 1", resp.OpsFinalized)
+	}
+	stored, _ := execs.Get(ctx, "op-orphan")
+	if stored.State != schema.ScratchExecLost {
+		t.Errorf("State = %q; want lost", stored.State)
+	}
+}
+
+func TestScratchReap_EmptyState(t *testing.T) {
+	resp, err := ScratchReap(context.Background(), ScratchReapRequest{}, reapDeps(t,
+		db.NewMemoryScratch(), db.NewMemoryScratchExecs(), NewMemoryGCE()))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 0 || resp.OpsFinalized != 0 {
+		t.Errorf("response = %+v; want zero/zero", resp)
+	}
+}
+
+// An expired pending op no longer exempts its idle scratch: the syncer is
+// invoked pre-teardown to capture output while the worker is reachable, the
+// scratch is torn down, and the sweep finalizes the op TimedOut (not Lost:
+// the deadline check precedes the scratch-state check).
+func TestScratchReap_PreTeardownSyncerInvokedPerPendingOp(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-1", State: schema.ScratchReady, Zone: "z",
+		LastUsed: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
+		TimeoutSeconds: 3600,
+		StartedAt:      now.Add(-3 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	sync := &fakeSyncer{}
+	deps := reapDeps(t, scratches, execs, NewMemoryGCE())
+	deps.Syncer = sync
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, deps)
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if sync.calls != 1 {
+		t.Errorf("Syncer.Sync calls = %d; want 1 (one pending op on reaped scratch)", sync.calls)
+	}
+	if resp.ScratchesReaped != 1 || resp.OpsFinalized != 1 {
+		t.Errorf("response = %+v; want ScratchesReaped=1 OpsFinalized=1", resp)
+	}
+	stored, _ := execs.Get(ctx, "op-1")
+	if stored.State != schema.ScratchExecTimedOut {
+		t.Errorf("State = %q; want timed_out", stored.State)
+	}
+}
+
+// A pending op inside its deadline exempts its idle scratch from teardown;
+// an idle scratch without one is still reaped in the same pass.
+func TestScratchReap_IdleButBusyScratchSkipped(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	for _, s := range []schema.Scratch{
+		{ID: "busy-s", State: schema.ScratchReady, Zone: "z", LastUsed: now.Add(-time.Hour)},
+		{ID: "idle-s", State: schema.ScratchReady, Zone: "z", LastUsed: now.Add(-time.Hour)},
+	} {
+		if err := scratches.Insert(ctx, s); err != nil {
+			t.Fatalf("seed %s: %v", s.ID, err)
+		}
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-long", ScratchID: "busy-s", State: schema.ScratchExecPending,
+		TimeoutSeconds: 4 * 60 * 60,
+		StartedAt:      now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, execs, NewMemoryGCE()))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 1 || resp.OpsFinalized != 0 {
+		t.Errorf("response = %+v; want ScratchesReaped=1 OpsFinalized=0", resp)
+	}
+	if got, _ := scratches.Get(ctx, "busy-s"); got.State != schema.ScratchReady {
+		t.Errorf("busy-s.State = %q; want ready (exempt while op in deadline)", got.State)
+	}
+	if got, _ := scratches.Get(ctx, "idle-s"); got.State != schema.ScratchDeleted {
+		t.Errorf("idle-s.State = %q; want deleted", got.State)
+	}
+	if stored, _ := execs.Get(ctx, "op-long"); stored.State != schema.ScratchExecPending {
+		t.Errorf("op-long.State = %q; want pending", stored.State)
+	}
+}
+
+// The stamped per-exec timeout, not the global OpDeadline, bounds the op:
+// a 60s exec is expired 20m after dispatch even though the fallback
+// deadline is 2h.
+func TestScratchReap_StampedTimeoutExpiryFinalizesTimedOut(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-h", State: schema.ScratchReady, LastUsed: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-short", ScratchID: "s-h", State: schema.ScratchExecPending,
+		TimeoutSeconds: 60,
+		StartedAt:      now.Add(-20 * time.Minute),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, execs, NewMemoryGCE()))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 0 || resp.OpsFinalized != 1 {
+		t.Errorf("response = %+v; want ScratchesReaped=0 OpsFinalized=1", resp)
+	}
+	if stored, _ := execs.Get(ctx, "op-short"); stored.State != schema.ScratchExecTimedOut {
+		t.Errorf("State = %q; want timed_out", stored.State)
+	}
+}
+
+// persistingSyncer finalizes the exec via Execs.Update, mimicking the
+// production gcsSyncer observing the worker's Done transition.
+type persistingSyncer struct {
+	execs db.ScratchExecs
+	calls int
+}
+
+func (p *persistingSyncer) Sync(ctx context.Context, exec schema.ScratchExec, _ schema.Scratch) (schema.ScratchExec, error) {
+	p.calls++
+	exec.State = schema.ScratchExecCompleted
+	exec.FinishedAt = time.Now().UTC()
+	if err := p.execs.Update(ctx, exec); err != nil {
+		return exec, err
+	}
+	return exec, nil
+}
+
+// An expired op on a reachable scratch is pulled through the worker: the
+// syncer's Completed result stands and the sweep does not overwrite it
+// with a blind TimedOut.
+func TestScratchReap_PullThroughSyncFinalizes(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-live", State: schema.ScratchReady, LastUsed: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-exp", ScratchID: "s-live", State: schema.ScratchExecPending,
+		TimeoutSeconds: 60,
+		StartedAt:      now.Add(-20 * time.Minute),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	sync := &persistingSyncer{execs: execs}
+	deps := reapDeps(t, scratches, execs, NewMemoryGCE())
+	deps.Syncer = sync
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, deps)
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if sync.calls != 1 {
+		t.Errorf("Syncer.Sync calls = %d; want 1", sync.calls)
+	}
+	if resp.OpsFinalized != 0 {
+		t.Errorf("OpsFinalized = %d; want 0 (syncer persisted the terminal state)", resp.OpsFinalized)
+	}
+	if stored, _ := execs.Get(ctx, "op-exp"); stored.State != schema.ScratchExecCompleted {
+		t.Errorf("State = %q; want completed (pull-through result preserved)", stored.State)
+	}
+}
+
+// When the pull-through sync fails, the expired op still finalizes blind.
+func TestScratchReap_PullThroughSyncErrorFallsBackTimedOut(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-live", State: schema.ScratchReady, LastUsed: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-exp", ScratchID: "s-live", State: schema.ScratchExecPending,
+		TimeoutSeconds: 60,
+		StartedAt:      now.Add(-20 * time.Minute),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	deps := reapDeps(t, scratches, execs, NewMemoryGCE())
+	deps.Syncer = &fakeSyncer{err: errors.New("worker unreachable")}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, deps)
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.OpsFinalized != 1 {
+		t.Errorf("OpsFinalized = %d; want 1", resp.OpsFinalized)
+	}
+	if stored, _ := execs.Get(ctx, "op-exp"); stored.State != schema.ScratchExecTimedOut {
+		t.Errorf("State = %q; want timed_out", stored.State)
+	}
+}
+
+// The sweep re-lists pending ops rather than reusing the pre-teardown
+// snapshot: an op the pre-teardown sync finalized as Completed must not be
+// clobbered back to TimedOut by a stale full-record Update.
+func TestScratchReap_SweepDoesNotClobberPreTeardownSync(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-1", State: schema.ScratchReady, Zone: "z",
+		LastUsed: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
+		TimeoutSeconds: 3600,
+		StartedAt:      now.Add(-3 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	sync := &persistingSyncer{execs: execs}
+	deps := reapDeps(t, scratches, execs, NewMemoryGCE())
+	deps.Syncer = sync
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, deps)
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 1 || resp.OpsFinalized != 0 {
+		t.Errorf("response = %+v; want ScratchesReaped=1 OpsFinalized=0", resp)
+	}
+	if stored, _ := execs.Get(ctx, "op-1"); stored.State != schema.ScratchExecCompleted {
+		t.Errorf("State = %q; want completed (pre-teardown sync result preserved)", stored.State)
+	}
+}
+
+// bumpingSyncer stands in for an agent interaction racing the reaper:
+// it bumps LastUsed during the pre-teardown sync, so the teardown
+// re-check must spare the scratch.
+type bumpingSyncer struct {
+	scratches db.Scratch
+}
+
+func (b *bumpingSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch schema.Scratch) (schema.ScratchExec, error) {
+	if err := b.scratches.UpdateLastUsed(ctx, scratch.ID, time.Now().UTC()); err != nil {
+		return exec, err
+	}
+	return exec, nil
+}
+
+func TestScratchReap_TeardownRecheckSparesRevivedScratch(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	execs := db.NewMemoryScratchExecs()
+	now := time.Now().UTC()
+
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "s-1", State: schema.ScratchReady, Zone: "z",
+		LastUsed: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	if err := execs.Insert(ctx, schema.ScratchExec{
+		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
+		TimeoutSeconds: 3600,
+		StartedAt:      now.Add(-3 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed exec: %v", err)
+	}
+
+	deps := reapDeps(t, scratches, execs, NewMemoryGCE())
+	deps.Syncer = &bumpingSyncer{scratches: scratches}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, deps)
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 0 {
+		t.Errorf("ScratchesReaped = %d; want 0 (LastUsed moved before teardown)", resp.ScratchesReaped)
+	}
+	if got, _ := scratches.Get(ctx, "s-1"); got.State != schema.ScratchReady {
+		t.Errorf("State = %q; want ready (spared by re-check)", got.State)
+	}
+}

--- a/pkg/rebuild/schema/scratch.go
+++ b/pkg/rebuild/schema/scratch.go
@@ -40,7 +40,11 @@ type Scratch struct {
 	State        ScratchState `json:"state,omitempty" firestore:"state,omitempty"`
 	Created      time.Time    `json:"created,omitzero" firestore:"created,omitempty"`
 	Updated      time.Time    `json:"updated,omitzero" firestore:"updated,omitempty"`
-	LastUsed     time.Time    `json:"last_used,omitzero" firestore:"last_used,omitempty"`
+	// LastUsed is the last agent interaction: exec dispatch or an
+	// agent poll observing exec completion. The reaper treats Ready
+	// scratches with stale LastUsed and no in-deadline pending execs
+	// as idle.
+	LastUsed time.Time `json:"last_used,omitzero" firestore:"last_used,omitempty"`
 }
 
 // ScratchCreateRequest is the input to /scratch/create.
@@ -135,16 +139,21 @@ type Status struct {
 //   - TimedOut:  ExitCode is the kill exit (typically 124); Error carries detail; OutURI may be partial.
 //   - Lost:      Error non-nil; ExitCode 0 (no exit observed); OutURI may be partial.
 type ScratchExec struct {
-	ID         string           `json:"id" firestore:"id"`
-	ScratchID  string           `json:"scratch_id,omitempty" firestore:"scratch_id,omitempty"`
-	Cmd        []string         `json:"cmd,omitempty" firestore:"cmd,omitempty"`
-	Cwd        string           `json:"cwd,omitempty" firestore:"cwd,omitempty"`
-	OutURI     string           `json:"out_uri,omitempty" firestore:"out_uri,omitempty"`
-	StartedAt  time.Time        `json:"started_at,omitzero" firestore:"started_at,omitempty"`
-	FinishedAt time.Time        `json:"finished_at,omitzero" firestore:"finished_at,omitempty"`
-	State      ScratchExecState `json:"state" firestore:"state"`
-	ExitCode   int              `json:"exit_code,omitempty" firestore:"exit_code,omitempty"`
-	Error      *Status          `json:"error,omitempty" firestore:"error,omitempty"`
+	ID        string   `json:"id" firestore:"id"`
+	ScratchID string   `json:"scratch_id,omitempty" firestore:"scratch_id,omitempty"`
+	Cmd       []string `json:"cmd,omitempty" firestore:"cmd,omitempty"`
+	Cwd       string   `json:"cwd,omitempty" firestore:"cwd,omitempty"`
+	// TimeoutSeconds is the worker-enforced execution bound, stamped by the
+	// broker at create (request value, or the configured default when the
+	// request omits it). The reaper derives each op's hard deadline from it.
+	// Zero means unbounded: the reaper warns and leaves the scratch up.
+	TimeoutSeconds int              `json:"timeout_seconds,omitempty" firestore:"timeout_seconds,omitempty"`
+	OutURI         string           `json:"out_uri,omitempty" firestore:"out_uri,omitempty"`
+	StartedAt      time.Time        `json:"started_at,omitzero" firestore:"started_at,omitempty"`
+	FinishedAt     time.Time        `json:"finished_at,omitzero" firestore:"finished_at,omitempty"`
+	State          ScratchExecState `json:"state" firestore:"state"`
+	ExitCode       int              `json:"exit_code,omitempty" firestore:"exit_code,omitempty"`
+	Error          *Status          `json:"error,omitempty" firestore:"error,omitempty"`
 }
 
 // ScratchExecResult is the API payload inside derived from ScratchExec.


### PR DESCRIPTION
This adds support for out-of-band op finalization and scratch instances
deletion. Instance teardown happens after a fixed period of inactivity
(currently 30m) after the last op ran. Instances with ops outstanding
will never be cleaned up.