### PR TITLE
Reimplement Output with streaming

### DIFF
--- a/cmd/scratch-worker/main.go
+++ b/cmd/scratch-worker/main.go
@@ -71,7 +71,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/exec/start", mw(api.Handler(execInit, scratchworkerservice.ExecStart)))
 	mux.Handle("/exec/op/status", mw(api.Handler(statusInit, scratchworkerservice.Status)))
-	mux.Handle("/exec/op/output", mw(api.Handler(outputInit, scratchworkerservice.Output)))
+	mux.Handle("/exec/op/output", mw(api.StreamHandler(outputInit, scratchworkerservice.Output)))
 	// TODO: Add /exec/op/kill
 	mux.Handle("/stat", mw(api.Handler(statInit, scratchworkerservice.Stat)))
 	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, _ *http.Request) { rw.WriteHeader(http.StatusOK) })

--- a/internal/api/agentapiservice/scratch_exec.go
+++ b/internal/api/agentapiservice/scratch_exec.go
@@ -4,7 +4,6 @@
 package agentapiservice
 
 import (
-	"bytes"
 	"context"
 	"log"
 	"net/url"
@@ -254,13 +253,15 @@ func ScratchExecGet(ctx context.Context, req schema.GetOperationRequest, deps *S
 }
 
 // gcsSyncer pulls from the worker's /status + /output endpoints and
-// overwrites the op's GCS object with the full buffer on every poll
-// that has new bytes.
+// overwrites the op's GCS object with the buffer on every poll that has
+// new bytes.
 //
-// TODO(streaming): the worker JSON-encodes the entire stdout+stderr
-// buffer per poll today (see scratchworkerservice.OutputRequest). Once
-// act gains a streaming-response model, switch to incremental tail
-// fetches + rolling Compose.
+// The /output call gets piped straight into a GCS Writer, so the broker
+// never materializes the whole buffer in memory. Bytes-on-wire is still
+// O(total) per poll (we re-fetch from offset 0 and overwrite GCS, since
+// GCS doesn't expose append). A future optimization is to use Compose to
+// stitch incremental tail objects, at which point the OutputRequest.Offset
+// becomes load-bearing.
 type gcsSyncer struct {
 	gcs          *storage.Client
 	bucket       string
@@ -298,13 +299,8 @@ func (s *gcsSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch s
 	}
 
 	if status.TotalBytes > currentSize {
-		outputStub := api.Stub[scratchworkerservice.OutputRequest, scratchworkerservice.OutputResponse](client, baseURL.JoinPath("exec/op/output"))
-		body, err := outputStub(ctx, scratchworkerservice.OutputRequest{ID: exec.ID})
-		if err != nil {
-			return exec, errors.Wrap(err, "worker output")
-		}
-		if err := s.writeOut(ctx, scratch.ObliviousID, exec.ID, body.Bytes); err != nil {
-			return exec, errors.Wrap(err, "write out")
+		if err := s.pullOutput(ctx, client, baseURL, scratch.ObliviousID, exec.ID); err != nil {
+			return exec, errors.Wrap(err, "pull output")
 		}
 	}
 
@@ -372,15 +368,36 @@ func outURIFor(bucket, obliviousID, opID string) string {
 	return "gs://" + bucket + "/" + outObjectFor(obliviousID, opID)
 }
 
-func (s *gcsSyncer) writeOut(ctx context.Context, obliviousID, opID string, buf []byte) error {
-	if len(buf) == 0 {
-		return nil
-	}
+// pullOutput pulls /exec/op/output from offset 0 and pipes each chunk
+// into a fresh GCS Writer that overwrites the op's output object. The
+// broker holds only one chunk in memory at a time, regardless of the
+// total buffer size.
+//
+// On any stream error we cancel the writer's context (aborting the
+// upload server-side) and return the error, avoiding committing truncated
+// content to GCS.
+func (s *gcsSyncer) pullOutput(ctx context.Context, client httpx.BasicClient, baseURL *url.URL, obliviousID, opID string) error {
+	output := api.StreamStub[scratchworkerservice.OutputRequest, scratchworkerservice.OutputFrame](client, baseURL.JoinPath("exec/op/output"))
+
+	wctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	out := s.gcs.Bucket(s.bucket).Object(outObjectFor(obliviousID, opID))
-	w := out.NewWriter(ctx)
-	if _, err := bytes.NewReader(buf).WriteTo(w); err != nil {
-		_ = w.Close()
-		return err
+	w := out.NewWriter(wctx)
+
+	for frame, err := range output(ctx, scratchworkerservice.OutputRequest{ID: opID}) {
+		if err != nil {
+			cancel()
+			_ = w.Close()
+			return err
+		}
+		if _, err := w.Write(frame.Content); err != nil {
+			cancel()
+			_ = w.Close()
+			return errors.Wrap(err, "gcs write")
+		}
 	}
-	return w.Close()
+	if err := w.Close(); err != nil {
+		return errors.Wrap(err, "gcs close")
+	}
+	return nil
 }

--- a/internal/api/scratchworkerservice/exec.go
+++ b/internal/api/scratchworkerservice/exec.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"io"
+	"iter"
 	"os"
 	"sync"
 	"time"
@@ -15,6 +16,9 @@ import (
 	"github.com/google/oss-rebuild/pkg/act"
 	"github.com/pkg/errors"
 )
+
+// outputChunkSize is the byte target for each /exec/op/output frame.
+const outputChunkSize = 64 << 10
 
 // StartRequest is the body of POST exec/start. The broker mints OpID,
 // stamps ScratchID, and forwards. The worker spawns the command
@@ -60,6 +64,33 @@ func (r StatusRequest) Validate() error {
 	return nil
 }
 
+// OutputRequest is the input to stream bytes from the op's capture file.
+// It streams bytes from the requested Offset up to the capture file's size at
+// receipt of the request. Writes that land after entry are not included.
+type OutputRequest struct {
+	ID     string `form:"id,required"`
+	Offset int64  `form:"offset"`
+}
+
+// Validate implements act.Input.
+func (r OutputRequest) Validate() error {
+	if r.ID == "" {
+		return errors.New("id is required")
+	}
+	if r.Offset < 0 {
+		return errors.New("offset must be >= 0")
+	}
+	return nil
+}
+
+// OutputFrame is one chunk of the merged stdout+stderr output. Frames are
+// contiguous from the request's Offset; consumers can rely on the chunks
+// arriving in increasing-Offset order.
+type OutputFrame struct {
+	Offset  int64  `json:"offset"`
+	Content []byte `json:"content"`
+}
+
 // ExecStatus is the worker's in-memory view of one op. Returned by
 // exec/op/status. The broker mirrors this into Firestore on sync.
 type ExecStatus struct {
@@ -70,39 +101,6 @@ type ExecStatus struct {
 	StartedAt  time.Time `json:"started_at,omitzero"`
 	FinishedAt time.Time `json:"finished_at,omitzero"`
 	ErrMsg     string    `json:"err_msg,omitempty"` // Run error. If set, Done is true.
-}
-
-// OutputRequest is the body of POST exec/op/output. The broker fetches
-// the entire merged stdout+stderr buffer for an op each sync.
-//
-// TODO: Once act gains a streaming-response model, switch this to a
-// range-style request (Start offset) returning only the new tail bytes.
-// Today the worker JSON-encodes the full buffer on every call; that's
-// O(bytes-so-far) per poll and is fine for shortish builds but wasteful
-// for long-running ones.
-type OutputRequest struct {
-	ID string `form:"id,required"`
-}
-
-// Validate implements act.Input.
-func (r OutputRequest) Validate() error {
-	if r.ID == "" {
-		return errors.New("id is required")
-	}
-	return nil
-}
-
-// OutputResponse carries the full merged stdout+stderr buffer for an
-// op. Bytes is the entire buffer (no offset). TotalBytes equals
-// len(Bytes); it's repeated for parity with ExecStatus.TotalBytes so
-// callers don't need to inspect the byte slice.
-//
-// JSON encodes []byte as a base64 string; that's the in-memory
-// buffering pattern we're using until streaming support exists.
-// XXX: Inefficient
-type OutputResponse struct {
-	Bytes      []byte `json:"bytes,omitempty"`
-	TotalBytes int64  `json:"total_bytes"`
 }
 
 // execEntry is the in-memory record the worker keeps for one op. The
@@ -199,35 +197,62 @@ func (s *ExecStore) status(opID string) (ExecStatus, bool) {
 	}, true
 }
 
-// readAll returns the full merged stdout+stderr buffer for opID. The
-// buffer is read into memory (no streaming); see OutputRequest's TODO
-// about replacing this with a range-style streaming endpoint.
-func (s *ExecStore) readAll(opID string) ([]byte, error) {
-	s.mu.Lock()
-	e, ok := s.entries[opID]
-	s.mu.Unlock()
-	if !ok {
-		return nil, errors.Errorf("unknown op %q", opID)
+// outputFrom emits the captured stdout+stderr buffer for opID, starting
+// at offset, in outputChunkSize-byte chunks. Snapshot at Stat time:
+// bytes written after handler entry are excluded from this response and
+// will be picked up on the next call.
+func (s *ExecStore) outputFrom(ctx context.Context, opID string, offset int64) iter.Seq2[*OutputFrame, error] {
+	return func(yield func(*OutputFrame, error) bool) {
+		s.mu.Lock()
+		e, ok := s.entries[opID]
+		s.mu.Unlock()
+		if !ok {
+			yield(nil, errors.Errorf("unknown op %q", opID))
+			return
+		}
+		if e.file == nil {
+			return
+		}
+		info, err := e.file.Stat()
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		end := info.Size()
+		if offset >= end {
+			return
+		}
+		buf := make([]byte, outputChunkSize)
+		pos := offset
+		for pos < end {
+			if ctx.Err() != nil {
+				yield(nil, ctx.Err())
+				return
+			}
+			n := outputChunkSize
+			if remaining := end - pos; int64(n) > remaining {
+				n = int(remaining)
+			}
+			rd, err := e.file.ReadAt(buf[:n], pos)
+			if rd > 0 {
+				frame := &OutputFrame{
+					Offset:  pos,
+					Content: append([]byte(nil), buf[:rd]...),
+				}
+				if !yield(frame, nil) {
+					return
+				}
+				pos += int64(rd)
+			}
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+		}
 	}
-	if e.file == nil {
-		return nil, nil
-	}
-	info, err := e.file.Stat()
-	if err != nil {
-		return nil, err
-	}
-	end := info.Size()
-	if e.done {
-		end = e.totalBytes
-	}
-	if end == 0 {
-		return nil, nil
-	}
-	buf := make([]byte, end)
-	if _, err := e.file.ReadAt(buf, 0); err != nil && err != io.EOF {
-		return nil, err
-	}
-	return buf, nil
 }
 
 type ExecDeps struct {
@@ -321,21 +346,20 @@ func Status(_ context.Context, req StatusRequest, deps *StatusDeps) (*ExecStatus
 	return nil, errors.Errorf("unknown op %q", req.ID)
 }
 
-// OutputDeps wires Output.
+// OutputDeps wires the Output handler.
 type OutputDeps struct {
 	Store *ExecStore
 }
 
-// Output returns the entire merged stdout+stderr buffer for an op.
+// Output emits the captured output of an op as a sequence of OutputFrames
+// starting at req.Offset. The end of the response is whatever the
+// capture file was sized at when the handler stat'd it; bytes that land
+// after entry are not included (callers fetch them on a subsequent call).
 //
-// TODO(streaming): see OutputRequest godoc. Replace with a streaming
-// range endpoint once act supports it.
-func Output(_ context.Context, req OutputRequest, deps *OutputDeps) (*OutputResponse, error) {
-	buf, err := deps.Store.readAll(req.ID)
-	if err != nil {
-		return nil, err
-	}
-	return &OutputResponse{Bytes: buf, TotalBytes: int64(len(buf))}, nil
+// Unknown opID is a pre-stream error (yielded as the first (nil, err)
+// pair), which the streaming layer maps to a unary HTTP error response.
+func Output(ctx context.Context, req OutputRequest, deps *OutputDeps) iter.Seq2[*OutputFrame, error] {
+	return deps.Store.outputFrom(ctx, req.ID, req.Offset)
 }
 
 func decodeStdin(b64 string) (io.Reader, error) {

--- a/internal/api/scratchworkerservice/exec_test.go
+++ b/internal/api/scratchworkerservice/exec_test.go
@@ -6,6 +6,7 @@ package scratchworkerservice
 import (
 	"context"
 	"encoding/base64"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -40,13 +41,29 @@ func waitForDone(t *testing.T, store *ExecStore, opID string, timeout time.Durat
 	return ExecStatus{}
 }
 
+// collectOutput drains the output iterator into the concatenated content,
+// the per-frame offsets observed, and the terminal error (nil on clean
+// end).
+func collectOutput(t *testing.T, store *ExecStore, opID string, offset int64) (content []byte, offsets []int64, err error) {
+	t.Helper()
+	for frame, e := range store.outputFrom(context.Background(), opID, offset) {
+		if e != nil {
+			err = e
+			return
+		}
+		offsets = append(offsets, frame.Offset)
+		content = append(content, frame.Content...)
+	}
+	return
+}
+
 func readAll(t *testing.T, store *ExecStore, opID string) []byte {
 	t.Helper()
-	b, err := store.readAll(opID)
+	content, _, err := collectOutput(t, store, opID, 0)
 	if err != nil {
 		t.Fatalf("readAll: %v", err)
 	}
-	return b
+	return content
 }
 
 func TestExecStart_NormalCompletion(t *testing.T) {
@@ -176,18 +193,6 @@ func TestExecStart_TimeoutPartialOutputPreserved(t *testing.T) {
 	}
 }
 
-func TestExecStore_ReadAllReturnsFullBuffer(t *testing.T) {
-	deps, store := newTestDeps(t)
-	const opID = "op-full-buf"
-	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "printf abcdef"), deps); err != nil {
-		t.Fatalf("ExecStart: %v", err)
-	}
-	waitForDone(t, store, opID, 3*time.Second)
-	if got := string(readAll(t, store, opID)); got != "abcdef" {
-		t.Errorf("readAll = %q; want %q", got, "abcdef")
-	}
-}
-
 func TestExecStore_ForgetReleasesFile(t *testing.T) {
 	deps, store := newTestDeps(t)
 	const opID = "op-forget"
@@ -206,5 +211,109 @@ func TestStatus_UnknownOp(t *testing.T) {
 	deps := &StatusDeps{Store: store}
 	if _, err := Status(context.Background(), StatusRequest{ID: "missing"}, deps); err == nil {
 		t.Errorf("Status(missing) = nil; want error")
+	}
+}
+
+func TestOutput_FromZero(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-stream-zero"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "printf 'hello stream'"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 3*time.Second)
+
+	got, offsets, err := collectOutput(t, store, opID, 0)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if string(got) != "hello stream" {
+		t.Errorf("content = %q, want %q", got, "hello stream")
+	}
+	if len(offsets) == 0 || offsets[0] != 0 {
+		t.Errorf("offsets = %v, want first 0", offsets)
+	}
+}
+
+func TestOutput_FromMidOffset(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-stream-mid"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "printf 0123456789"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 3*time.Second)
+
+	got, offsets, err := collectOutput(t, store, opID, 4)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if string(got) != "456789" {
+		t.Errorf("content = %q, want %q", got, "456789")
+	}
+	if offsets[0] != 4 {
+		t.Errorf("first offset = %d, want 4", offsets[0])
+	}
+}
+
+func TestOutput_OffsetAtOrPastEnd(t *testing.T) {
+	deps, store := newTestDeps(t)
+	const opID = "op-stream-past"
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", "sh", "-c", "printf abc"), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 3*time.Second)
+
+	got, offsets, err := collectOutput(t, store, opID, 100)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("content = %q, want empty", got)
+	}
+	if len(offsets) != 0 {
+		t.Errorf("offsets = %v, want none", offsets)
+	}
+}
+
+func TestOutput_MultiChunk(t *testing.T) {
+	// Produce enough output to span multiple stream chunks.
+	deps, store := newTestDeps(t)
+	const opID = "op-stream-multi"
+	// outputChunkSize * 2.5 bytes of "x" via printf %0Nd (faster than yes/dd in tests).
+	const total = outputChunkSize * 5 / 2
+	cmd := []string{"sh", "-c", "head -c " + strconv.Itoa(total) + " /dev/zero | tr '\\0' x"}
+	if _, err := ExecStart(context.Background(), stdReq(opID, "env-1", cmd...), deps); err != nil {
+		t.Fatalf("ExecStart: %v", err)
+	}
+	waitForDone(t, store, opID, 5*time.Second)
+
+	got, offsets, err := collectOutput(t, store, opID, 0)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if len(got) != total {
+		t.Errorf("len(content) = %d, want %d", len(got), total)
+	}
+	if len(offsets) < 3 {
+		t.Errorf("got %d frames, want >=3 (chunk size = %d)", len(offsets), outputChunkSize)
+	}
+	// Offsets are contiguous and monotonic.
+	var pos int64
+	for i, o := range offsets {
+		if o != pos {
+			t.Errorf("offsets[%d] = %d, want %d", i, o, pos)
+			break
+		}
+		// All but the last frame should be exactly chunkSize.
+		if i < len(offsets)-1 {
+			pos += outputChunkSize
+		}
+	}
+}
+
+func TestOutput_UnknownOp(t *testing.T) {
+	store := NewExecStore()
+	_, _, err := collectOutput(t, store, "missing", 0)
+	if err == nil {
+		t.Errorf("stream(missing) = nil; want error")
 	}
 }


### PR DESCRIPTION
Note: this doesn't quite get us to the incremental point that we'd like
since we're still re-fetching the full file each time (coming in the
next change). This does, however avoid buffering the full file in the
worker before dispatch.