### PR TITLE
Add incremental scratch output syncing

### DIFF
--- a/internal/api/agentapiservice/scratch_exec.go
+++ b/internal/api/agentapiservice/scratch_exec.go
@@ -6,7 +6,10 @@ package agentapiservice
 import (
 	"context"
 	"log"
+	"math"
+	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -18,6 +21,7 @@ import (
 	"github.com/google/oss-rebuild/pkg/longrunning"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/pkg/errors"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 )
 
@@ -252,28 +256,95 @@ func ScratchExecGet(ctx context.Context, req schema.GetOperationRequest, deps *S
 	return &op, nil
 }
 
-// gcsSyncer pulls from the worker's /status + /output endpoints and
-// overwrites the op's GCS object with the buffer on every poll that has
-// new bytes.
+// SyncStep is one bucket in a SyncSchedule. Until is the upper bound on
+// exec age (exclusive); Interval is the minimum gap between non-terminal
+// composes while the exec's age is below Until.
+type SyncStep struct {
+	Until    time.Duration
+	Interval time.Duration
+}
+
+// DefaultSyncSchedule throttles compose frequency to bound the lifetime
+// component count on the GCS composite object: 5s polls for the first
+// 10 minutes, 30s thereafter.
 //
-// The /output call gets piped straight into a GCS Writer, so the broker
-// never materializes the whole buffer in memory. Bytes-on-wire is still
-// O(total) per poll (we re-fetch from offset 0 and overwrite GCS, since
-// GCS doesn't expose append). A future optimization is to use Compose to
-// stitch incremental tail objects, at which point the OutputRequest.Offset
-// becomes load-bearing.
+// Cumulative composes:
+//   - 10m:   120
+//   - 1h:    220
+//   - 6h:    820  (target ceiling; ~200-component cushion under the 1024 cap)
+//
+// A terminal sync (status.Done) is never skipped, so the final tail
+// always reaches GCS regardless of where in the schedule the exec finishes.
+var DefaultSyncSchedule = []SyncStep{
+	{Until: 10 * time.Minute, Interval: 5 * time.Second},
+	// Sentinel-large Until. This step's Interval applies for the
+	// remainder of any exec's lifetime.
+	{Until: math.MaxInt64, Interval: 30 * time.Second},
+}
+
+// gcsSyncer appends new worker output to the op's GCS object on each
+// poll. Append is implemented as Compose (see pullOutput); the schedule
+// keeps main's lifetime component count under GCS's 1024 cap.
 type gcsSyncer struct {
 	gcs          *storage.Client
 	bucket       string
 	execs        db.ScratchExecs
 	workerDialer WorkerDialer
+	schedule     []SyncStep
 }
 
-// NewGCSSyncer returns a Syncer that overwrites the op's GCS object
-// with the full worker buffer when new bytes are available, and
-// finalizes Firestore on the Done transition.
-func NewGCSSyncer(gcs *storage.Client, bucket string, execs db.ScratchExecs, wd WorkerDialer) Syncer {
-	return &gcsSyncer{gcs: gcs, bucket: bucket, execs: execs, workerDialer: wd}
+// SyncerOption configures a gcsSyncer.
+type SyncerOption func(*gcsSyncer)
+
+// WithSyncSchedule overrides DefaultSyncSchedule. Empty/nil keeps the default.
+func WithSyncSchedule(steps []SyncStep) SyncerOption {
+	return func(s *gcsSyncer) {
+		if len(steps) > 0 {
+			s.schedule = steps
+		}
+	}
+}
+
+// NewGCSSyncer returns a Syncer that appends new worker output to GCS
+// and finalizes Firestore on the Done transition. Tests that need clock
+// control should use [testing/synctest.Run]. The syncer uses
+// [time.Now] directly with no injection hook.
+func NewGCSSyncer(gcs *storage.Client, bucket string, execs db.ScratchExecs, wd WorkerDialer, opts ...SyncerOption) Syncer {
+	s := &gcsSyncer{
+		gcs:          gcs,
+		bucket:       bucket,
+		execs:        execs,
+		workerDialer: wd,
+		schedule:     DefaultSyncSchedule,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// intervalAt returns the minimum gap between non-terminal composes given
+// the exec's current age. The last step's Interval applies indefinitely
+// past its Until.
+func (s *gcsSyncer) intervalAt(age time.Duration) time.Duration {
+	for _, step := range s.schedule {
+		if age < step.Until {
+			return step.Interval
+		}
+	}
+	return s.schedule[len(s.schedule)-1].Interval
+}
+
+// shouldCompose returns true when this sync should run pullOutput.
+// Terminal syncs always run. First syncs (lastModified zero) always
+// run because sinceLastCompose is effectively unbounded. Otherwise,
+// the schedule's interval-for-age gates the call.
+func (s *gcsSyncer) shouldCompose(now, startedAt, lastModified time.Time, done bool) bool {
+	if done {
+		return true
+	}
+	age := now.Sub(startedAt)
+	return now.Sub(lastModified) >= s.intervalAt(age)
 }
 
 func (s *gcsSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch schema.Scratch) (schema.ScratchExec, error) {
@@ -288,18 +359,29 @@ func (s *gcsSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch s
 		return exec, errors.Wrap(err, "worker status")
 	}
 
-	// Only round-trip the full buffer if the worker has more bytes than GCS
-	// does. The status call's TotalBytes is cheap; /output is O(buffer).
+	// Only round-trip the tail if the worker has more bytes than GCS
+	// does. The status call's TotalBytes is cheap.
 	out := s.gcs.Bucket(s.bucket).Object(outObjectFor(scratch.ObliviousID, exec.ID))
-	var currentSize int64
+	var (
+		currentSize  int64
+		currentGen   int64
+		lastModified time.Time
+	)
 	if attrs, err := out.Attrs(ctx); err == nil {
 		currentSize = attrs.Size
+		currentGen = attrs.Generation
+		lastModified = attrs.Updated
 	} else if !errors.Is(err, storage.ErrObjectNotExist) {
 		return exec, errors.Wrap(err, "stat out")
 	}
 
-	if status.TotalBytes > currentSize {
-		if err := s.pullOutput(ctx, client, baseURL, scratch.ObliviousID, exec.ID); err != nil {
+	// Compose throttling: skip the upload if we composed recently enough
+	// for our current age bucket. A terminal sync (status.Done) is never
+	// skipped so the final tail always lands in GCS. A first sync
+	// (lastModified zero) is also never skipped because sinceLastCompose
+	// is enormous.
+	if status.TotalBytes > currentSize && s.shouldCompose(time.Now().UTC(), exec.StartedAt, lastModified, status.Done) {
+		if err := s.pullOutput(ctx, client, baseURL, scratch.ObliviousID, exec.ID, currentSize, currentGen); err != nil {
 			return exec, errors.Wrap(err, "pull output")
 		}
 	}
@@ -368,36 +450,93 @@ func outURIFor(bucket, obliviousID, opID string) string {
 	return "gs://" + bucket + "/" + outObjectFor(obliviousID, opID)
 }
 
-// pullOutput pulls /exec/op/output from offset 0 and pipes each chunk
-// into a fresh GCS Writer that overwrites the op's output object. The
-// broker holds only one chunk in memory at a time, regardless of the
-// total buffer size.
+// pullOutput streams the worker's tail past currentSize into a part
+// object and composes it onto main. Race-safety:
 //
-// On any stream error we cancel the writer's context (aborting the
-// upload server-side) and return the error, avoiding committing truncated
-// content to GCS.
-func (s *gcsSyncer) pullOutput(ctx context.Context, client httpx.BasicClient, baseURL *url.URL, obliviousID, opID string) error {
+//  1. Part write uses DoesNotExist. Same-offset collisions return 412
+//     and the loser bails cleanly.
+//  2. Compose uses GenerationMatch on main (or DoesNotExist on the
+//     first sync). If another sync extended main since we Stat'd, our
+//     compose returns 412 and we bail. The next poll picks up.
+//
+// The part is deleted on success, failure, and precondition loss. Broker
+// crashes between part write and compose leave orphans; a parts/
+// lifecycle rule is the deploy-side backstop.
+func (s *gcsSyncer) pullOutput(ctx context.Context, client httpx.BasicClient, baseURL *url.URL, obliviousID, opID string, currentSize, currentGen int64) error {
 	output := api.StreamStub[scratchworkerservice.OutputRequest, scratchworkerservice.OutputFrame](client, baseURL.JoinPath("exec/op/output"))
+
+	mainName := outObjectFor(obliviousID, opID)
+	// Part name keys on start offset only: concurrent same-offset pulls
+	// collide on DoesNotExist and dedup. End offset isn't stable (the
+	// worker may Stat more bytes than we saw in /status).
+	partName := mainName + "/parts/" + strconv.FormatInt(currentSize, 10)
+	main := s.gcs.Bucket(s.bucket).Object(mainName)
+	part := s.gcs.Bucket(s.bucket).Object(partName)
 
 	wctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	out := s.gcs.Bucket(s.bucket).Object(outObjectFor(obliviousID, opID))
-	w := out.NewWriter(wctx)
+	w := part.If(storage.Conditions{DoesNotExist: true}).NewWriter(wctx)
 
-	for frame, err := range output(ctx, scratchworkerservice.OutputRequest{ID: opID}) {
+	var wrote int64
+	for frame, err := range output(ctx, scratchworkerservice.OutputRequest{ID: opID, Offset: currentSize}) {
 		if err != nil {
 			cancel()
 			_ = w.Close()
+			_ = part.Delete(context.Background())
 			return err
 		}
-		if _, err := w.Write(frame.Content); err != nil {
+		n, werr := w.Write(frame.Content)
+		if werr != nil {
 			cancel()
 			_ = w.Close()
-			return errors.Wrap(err, "gcs write")
+			_ = part.Delete(context.Background())
+			return errors.Wrap(werr, "gcs write part")
 		}
+		wrote += int64(n)
 	}
 	if err := w.Close(); err != nil {
-		return errors.Wrap(err, "gcs close")
+		if isPreconditionFailed(err) {
+			// Another sync claimed this offset. Nothing was finalized;
+			// next poll re-stats and continues from the new size.
+			return nil
+		}
+		return errors.Wrap(err, "gcs close part")
 	}
+	if wrote == 0 {
+		// The worker had no bytes past currentSize (its snapshot
+		// disagreed with the earlier /status). Drop the empty part.
+		_ = part.Delete(context.Background())
+		return nil
+	}
+
+	// Compose. First sync: main doesn't exist, copy part → main via a
+	// single-source compose with DoesNotExist. Subsequent syncs:
+	// [main, part] → main with GenerationMatch.
+	var composer *storage.Composer
+	if currentGen == 0 {
+		composer = main.If(storage.Conditions{DoesNotExist: true}).ComposerFrom(part)
+	} else {
+		composer = main.If(storage.Conditions{GenerationMatch: currentGen}).ComposerFrom(main, part)
+	}
+	if _, err := composer.Run(ctx); err != nil {
+		_ = part.Delete(context.Background())
+		if isPreconditionFailed(err) {
+			// Another sync extended main first. Bail cleanly; next poll
+			// re-stats and continues from the new size.
+			return nil
+		}
+		return errors.Wrap(err, "gcs compose")
+	}
+	_ = part.Delete(context.Background())
 	return nil
+}
+
+// isPreconditionFailed reports whether err is an HTTP 412 from GCS,
+// indicating a lost race on a generation / DoesNotExist precondition.
+func isPreconditionFailed(err error) bool {
+	var ae *googleapi.Error
+	if errors.As(err, &ae) {
+		return ae.Code == http.StatusPreconditionFailed
+	}
+	return false
 }

--- a/internal/api/agentapiservice/scratch_exec_sync_test.go
+++ b/internal/api/agentapiservice/scratch_exec_sync_test.go
@@ -1,0 +1,201 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agentapiservice
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// schedule mirroring DefaultSyncSchedule's shape, but with named
+// constants so test cases below stay readable as the default changes.
+var testSchedule = []SyncStep{
+	{Until: 10 * time.Minute, Interval: 5 * time.Second},
+	// Past 10 min: 5s remains the last step's Interval. Overridden
+	// below to confirm the boundary behavior matches the documented
+	// "last interval applies indefinitely" contract for tests that
+	// care.
+}
+
+func TestSyncer_IntervalAt_DefaultSchedule(t *testing.T) {
+	s := &gcsSyncer{schedule: DefaultSyncSchedule}
+	tests := []struct {
+		name string
+		age  time.Duration
+		want time.Duration
+	}{
+		{"at start", 0, 5 * time.Second},
+		{"30s in", 30 * time.Second, 5 * time.Second},
+		{"5m in", 5 * time.Minute, 5 * time.Second},
+		{"just under 10m boundary", 10*time.Minute - time.Nanosecond, 5 * time.Second},
+		{"at 10m boundary", 10 * time.Minute, 30 * time.Second},
+		{"1h in", time.Hour, 30 * time.Second},
+		{"6h in", 6 * time.Hour, 30 * time.Second},
+		{"24h in (well past last step)", 24 * time.Hour, 30 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.intervalAt(tc.age); got != tc.want {
+				t.Errorf("intervalAt(%v) = %v, want %v", tc.age, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSyncer_IntervalAt_MultiStep(t *testing.T) {
+	// A 3-step schedule to confirm bucket-walking handles >1 boundary.
+	s := &gcsSyncer{schedule: []SyncStep{
+		{Until: time.Minute, Interval: time.Second},
+		{Until: 10 * time.Minute, Interval: 5 * time.Second},
+		{Until: time.Hour, Interval: 30 * time.Second},
+	}}
+	tests := []struct {
+		age  time.Duration
+		want time.Duration
+	}{
+		{0, time.Second},
+		{59 * time.Second, time.Second},
+		{time.Minute, 5 * time.Second},
+		{9 * time.Minute, 5 * time.Second},
+		{10 * time.Minute, 30 * time.Second},
+		{59 * time.Minute, 30 * time.Second},
+		{time.Hour, 30 * time.Second},      // past last Until: stick at last Interval
+		{24 * time.Hour, 30 * time.Second}, // way past: still last Interval
+	}
+	for _, tc := range tests {
+		if got := s.intervalAt(tc.age); got != tc.want {
+			t.Errorf("intervalAt(%v) = %v, want %v", tc.age, got, tc.want)
+		}
+	}
+}
+
+func TestSyncer_ShouldCompose(t *testing.T) {
+	// Tight test schedule: 1s for the first 10s, 5s thereafter. Lets
+	// every case land in single-digit-second deltas.
+	s := &gcsSyncer{schedule: []SyncStep{
+		{Until: 10 * time.Second, Interval: time.Second},
+		{Until: math.MaxInt64, Interval: 5 * time.Second},
+	}}
+	// "started" is the reference point for age computations below.
+	started := time.Unix(1_700_000_000, 0).UTC()
+
+	tests := []struct {
+		name         string
+		now          time.Time
+		lastModified time.Time
+		done         bool
+		want         bool
+	}{
+		{
+			name:         "first sync, no prior object",
+			now:          started.Add(2 * time.Second),
+			lastModified: time.Time{}, // zero → sinceLastCompose huge
+			done:         false,
+			want:         true,
+		},
+		{
+			name:         "second sync, just composed within first-step interval",
+			now:          started.Add(2 * time.Second),
+			lastModified: started.Add(1*time.Second + 500*time.Millisecond), // 500ms ago, interval=1s
+			done:         false,
+			want:         false,
+		},
+		{
+			name:         "interval elapsed in first step",
+			now:          started.Add(3 * time.Second),
+			lastModified: started.Add(2 * time.Second), // 1s ago, interval=1s → equal, run
+			done:         false,
+			want:         true,
+		},
+		{
+			name:         "in slow step, recently composed",
+			now:          started.Add(20 * time.Second),
+			lastModified: started.Add(17 * time.Second), // 3s ago, interval=5s
+			done:         false,
+			want:         false,
+		},
+		{
+			name:         "in slow step, interval elapsed",
+			now:          started.Add(20 * time.Second),
+			lastModified: started.Add(15 * time.Second), // 5s ago, interval=5s
+			done:         false,
+			want:         true,
+		},
+		{
+			name:         "done overrides skip in fast step",
+			now:          started.Add(2 * time.Second),
+			lastModified: started.Add(1*time.Second + 500*time.Millisecond), // 500ms ago
+			done:         true,
+			want:         true,
+		},
+		{
+			name:         "done overrides skip in slow step",
+			now:          started.Add(20 * time.Second),
+			lastModified: started.Add(19 * time.Second), // 1s ago, interval=5s
+			done:         true,
+			want:         true,
+		},
+		{
+			name:         "exec age past last step uses last interval",
+			now:          started.Add(time.Hour),
+			lastModified: started.Add(time.Hour - 3*time.Second), // 3s ago, interval=5s
+			done:         false,
+			want:         false,
+		},
+		{
+			name:         "exec age past last step, interval elapsed",
+			now:          started.Add(time.Hour),
+			lastModified: started.Add(time.Hour - 6*time.Second), // 6s ago, interval=5s
+			done:         false,
+			want:         true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.shouldCompose(tc.now, started, tc.lastModified, tc.done); got != tc.want {
+				t.Errorf("shouldCompose(now+%v, lastMod=%v, done=%v) = %v, want %v",
+					tc.now.Sub(started), tc.lastModified.Sub(started), tc.done, got, tc.want)
+			}
+		})
+	}
+}
+
+// Sanity check the DefaultSyncSchedule's documented cumulative compose
+// counts so a future tweak doesn't silently drift past the 1024 cap.
+func TestSyncer_DefaultScheduleBudget(t *testing.T) {
+	// Worst case (ignoring race losses) is one compose per interval
+	// at each age slice. Compute cumulative count at the documented
+	// checkpoints and assert plenty of headroom under 1024.
+	s := &gcsSyncer{schedule: DefaultSyncSchedule}
+	checkpoints := []struct {
+		age      time.Duration
+		maxCount int
+	}{
+		{10 * time.Minute, 130},
+		{time.Hour, 240},
+		{6 * time.Hour, 900},
+	}
+	cumulative := 0
+	prev := time.Duration(0)
+	cursor := time.Duration(0)
+	for _, cp := range checkpoints {
+		// Walk from cursor → cp.age, counting composes at each
+		// interval boundary.
+		for cursor < cp.age {
+			interval := s.intervalAt(cursor)
+			cursor += interval
+			if cursor <= cp.age {
+				cumulative++
+			}
+		}
+		if cumulative > cp.maxCount {
+			t.Errorf("at age %v: cumulative composes = %d, want <= %d (slice from %v)", cp.age, cumulative, cp.maxCount, prev)
+		}
+		prev = cp.age
+	}
+	if cumulative >= 1024 {
+		t.Errorf("schedule consumes full 1024-component budget by 6h (got %d); leave headroom for races + the rewrite backstop", cumulative)
+	}
+}


### PR DESCRIPTION
Each poll fetches only the tail past the GCS object's current size and
composes the new and existing parts together. The amendment is also
race-safe due to IfGenerationMatch. One constraint of GCS is only 1024
components may comprise an object so we implement a sync schedule (5s
during the first 10 min, 30s thereafter) to throttle compose frequency
so main's lifetime component count stays under the cap through ~6h of
build runtime.