### PR TITLE
Fix local git cache

### DIFF
--- a/cmd/git_cache/main.go
+++ b/cmd/git_cache/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/google/oss-rebuild/internal/gitcache"
 )
@@ -19,9 +20,18 @@ var (
 )
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), `
+Note: The git cache supports checking out submodules but it won't cache them, nor is it used to fetch them.
+`)
+	}
+
 	flag.Parse()
 	if *cache == "" {
-		log.Fatalln("-cache flag is required")
+		flag.Usage()
+		log.Fatalln("Error: -cache flag is required")
 	}
 	ctx := context.Background()
 	s, err := gitcache.NewServer(ctx, *cache)

--- a/internal/gitcache/client.go
+++ b/internal/gitcache/client.go
@@ -69,12 +69,15 @@ func (c Client) GetLinkWithRef(repo string, contains time.Time, ref string) (uri
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	var errs []byte
 	switch resp.StatusCode {
 	case http.StatusFound:
 		uri = resp.Header.Get("Location")
 		// FIXME: Figure out why this URL parsing artifact is being reintroduced.
 		return strings.ReplaceAll(uri, "%252F", "%2F"), nil
+	case http.StatusOK:
+		return u.String(), nil
 	case http.StatusBadRequest:
 		errs, err = io.ReadAll(resp.Body)
 		if err != nil {
@@ -91,7 +94,7 @@ func (c Client) GetLinkWithRef(repo string, contains time.Time, ref string) (uri
 
 // Clone provides an interface to clone a git repo using the GitCache.
 func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*git.Repository, error) {
-	if opt.Auth != nil || opt.RemoteName != "" || opt.Depth != 0 || opt.RecurseSubmodules != 0 || opt.Tags != git.InvalidTagMode || opt.InsecureSkipTLS || len(opt.CABundle) > 0 {
+	if opt.Auth != nil || opt.RemoteName != "" || opt.Depth != 0 || opt.Tags != git.InvalidTagMode || opt.InsecureSkipTLS || len(opt.CABundle) > 0 {
 		// No support for non-trivial opts aside from NoCheckout, ReferenceName, and SingleBranch.
 		return nil, errors.New("Unsupported opt")
 	}
@@ -133,7 +136,7 @@ func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem
 	}
 	defer gr.Close()
 	tr := tar.NewReader(gr)
-	if err := archive.ExtractTar(tr, extractFS, archive.ExtractOptions{SubDir: git.GitDirName}); err != nil {
+	if err := archive.ExtractTar(tr, extractFS, archive.ExtractOptions{}); err != nil {
 		return nil, errors.Wrap(err, "tar extract error")
 	}
 	// Copy staged data into the target storer if needed.

--- a/internal/gitcache/client.go
+++ b/internal/gitcache/client.go
@@ -158,6 +158,14 @@ func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem
 		if err := wt.Checkout(&git.CheckoutOptions{Branch: plumbing.HEAD}); err != nil {
 			return nil, errors.Wrap(err, "checkout error")
 		}
+		s, err := wt.Submodules()
+		if err != nil {
+			return nil, errors.Wrap(err, "submodule loading error")
+		}
+		o := &git.SubmoduleUpdateOptions{Init: true, RecurseSubmodules: opt.RecurseSubmodules}
+		if err = s.UpdateContext(ctx, o); err != nil {
+			return nil, errors.Wrap(err, "submodule update error")
+		}
 	}
 	return repo, nil
 }

--- a/internal/gitcache/client_test.go
+++ b/internal/gitcache/client_test.go
@@ -38,8 +38,7 @@ commits:
 func setupCloneTestServer(t *testing.T, yamlSpec string) Client {
 	t.Helper()
 	// Create a repo on disk with git metadata in a .git subdirectory.
-	// Client.Clone uses ExtractTar with SubDir=".git", so the tarball
-	// entries must be prefixed with ".git/".
+	// The client expects the tarball to contain the bare git files at the root.
 	repoDir := t.TempDir()
 	gitDir := filepath.Join(repoDir, git.GitDirName)
 	if err := os.MkdirAll(gitDir, 0o755); err != nil {
@@ -54,7 +53,7 @@ func setupCloneTestServer(t *testing.T, yamlSpec string) Client {
 	// Remove the index to match production behavior (bare clone has no index).
 	os.Remove(filepath.Join(gitDir, "index"))
 	var tarball bytes.Buffer
-	if err := createTarball(repoDir, &tarball); err != nil {
+	if err := createTarball(gitDir, &tarball); err != nil {
 		t.Fatalf("failed to create tarball: %v", err)
 	}
 	tarballBytes := tarball.Bytes()


### PR DESCRIPTION
Fixes multiple issues with the git cache
- The GCS backend returns a 302 found redirect which was always expected, but the local backend returns a 200 response which would default to an error response by the cache
- At least the `ctl infer` command uses `git.DefaultSubmoduleRecursionDepth` which is set to 10, but the git cache explicitly only allowed recursion depth 0
- The cache server would pack the repo files into the tgz so that the contents of the .git dir are in the root. However, when extracting, it would expect them to be within a `.git` directory, and thus always extracted an empty git repo.


Some notes:
- I have no GCS backend so i couldn't / didn't test whether these changes might break the GCS backend (e.g. idk when GCS might return a 200 HTTP code and what that might mean)
- I have removed the recursion depth check entirely. In my few tests this wasn't an issue, but i don't know whether there might be times where this is an issue for the cache. Specifically, i don't know any repos that require submodules so in my tests this probably just didn't have any effect.