### PR TITLE
Port more commit inference strategies to npm

### DIFF
--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/oss-rebuild/internal/gitx"
@@ -310,26 +309,5 @@ func findClosestCommitToSource(ctx context.Context, t rebuild.Target, mux rebuil
 	if err != nil {
 		return nil, errors.Wrap(err, "hashing source jar contents")
 	}
-	searchStrategy := gitscan.ExactTreeCount{}
-	closest, matched, total, err := searchStrategy.Search(ctx, repo, hashes)
-	if err != nil {
-		return nil, errors.Wrap(err, "searching for matching commit based on source jar")
-	}
-	log.Printf("commits (%d): %v", len(closest), closest)
-	log.Printf("matched %d/%d files using git index scan", matched, total)
-	if len(closest) == 0 {
-		// No matches found so we will not use the source jar heuristic, but this is not an error.
-		// The caller should try other heuristics.
-		log.Printf("no matching commit found using source jar heuristic")
-		return nil, nil
-	}
-	// TODO: use a better heuristic here like using commit time
-	commitString := closest[0]
-	// Verify if commit exists in the repository
-	commitHash := plumbing.NewHash(commitString)
-	commitObject, err := repo.CommitObject(commitHash)
-	if err != nil {
-		return nil, errors.Wrapf(err, "resolving commit %s", commitString)
-	}
-	return commitObject, nil
+	return gitscan.FindClosestCommitToSource(ctx, repo, hashes)
 }

--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -4,9 +4,13 @@
 package npm
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"path"
 	"path/filepath"
@@ -22,6 +26,7 @@ import (
 	"github.com/google/oss-rebuild/internal/uri"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	npmreg "github.com/google/oss-rebuild/pkg/registry/npm"
+	"github.com/google/oss-rebuild/pkg/vcs/gitscan"
 	"github.com/pkg/errors"
 )
 
@@ -125,7 +130,7 @@ func PickNPMVersion(meta *npmreg.NPMVersion) (string, error) {
 	return npmv, nil
 }
 
-func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.RepoConfig) (loc rebuild.Location, versionOverride string, err error) {
+func InferLocation(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, vmeta *npmreg.NPMVersion, rcfg *rebuild.RepoConfig) (loc rebuild.Location, versionOverride string, err error) {
 	// Initialize location with repo URI from config
 	loc = rebuild.Location{
 		Repo: rcfg.URI,
@@ -211,16 +216,24 @@ func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.Rep
 		}
 		fallthrough
 	default:
-		if badVersionRef != "" {
-			log.Printf("using version override recovery: %s", badVersionRef[:9])
-			c, _ = rcfg.Repository.CommitObject(plumbing.NewHash(badVersionRef))
-			loc.Ref = badVersionRef
-			versionOverride = t.Version
-			return loc, versionOverride, nil
-		} else if registryRef == "" && tagGuess == "" && pkgJSONGuess == "" {
-			return loc, "", errors.Errorf("no git ref")
+		commit, err := findClosestCommitToSource(ctx, t, mux, rcfg.Repository)
+		if err == nil && commit != nil {
+			commitHashHex := commit.Hash.String()
+			loc.Ref = commitHashHex
+			return loc, "", nil
 		} else {
-			return loc, "", errors.Errorf("no valid git ref")
+			log.Printf("Failed to use closest commit as ref: %s", err)
+			if badVersionRef != "" {
+				log.Printf("using version override recovery: %s", badVersionRef[:9])
+				c, _ = rcfg.Repository.CommitObject(plumbing.NewHash(badVersionRef))
+				loc.Ref = badVersionRef
+				versionOverride = t.Version
+				return loc, versionOverride, nil
+			} else if registryRef == "" && tagGuess == "" && pkgJSONGuess == "" {
+				return loc, "", errors.Errorf("no git ref")
+			} else {
+				return loc, "", errors.Errorf("no valid git ref")
+			}
 		}
 	}
 }
@@ -245,7 +258,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			loc.Dir = lh.Dir
 		}
 	} else {
-		loc, versionOverride, err = InferLocation(t, vmeta, rcfg)
+		loc, versionOverride, err = InferLocation(ctx, t, mux, vmeta, rcfg)
 		if err != nil {
 			return nil, err
 		}
@@ -454,4 +467,29 @@ func pkgJSONSearch(pkg, pkgJSONPath string, repo *git.Repository) (tm map[string
 		}
 	}
 	return
+}
+
+func findClosestCommitToSource(ctx context.Context, target rebuild.Target, mux rebuild.RegistryMux, repo *git.Repository) (*object.Commit, error) {
+	sourceTar, err := mux.NPM.Artifact(ctx, target.Package, target.Version)
+	if err != nil {
+		return nil, err
+	}
+	defer sourceTar.Close()
+	gzReader, err := gzip.NewReader(sourceTar)
+	if err != nil {
+		return nil, err
+	}
+	defer gzReader.Close()
+	tarData, err := io.ReadAll(gzReader)
+	if err != nil {
+		return nil, err
+	}
+	tarReader := tar.NewReader(bytes.NewReader(tarData))
+
+	hashes, err := gitscan.BlobHashesFromTar(tarReader)
+	if err != nil {
+		return nil, errors.Wrap(err, "hashing source jar contents")
+	}
+
+	return gitscan.FindClosestCommitToSource(ctx, repo, hashes)
 }

--- a/pkg/rebuild/npm/infer_test.go
+++ b/pkg/rebuild/npm/infer_test.go
@@ -180,6 +180,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 		wantCommitID    string
 		wantStrategyFn  func(commitID string) rebuild.Strategy
 		wantErr         bool
+		extraMockCalls  []httpxtest.Call
 	}{
 		{
 			name:    "NPMPackBuild - ref from gitHead",
@@ -363,8 +364,24 @@ func TestInferStrategy_NPM(t *testing.T) {
       package.json: "this is not json" # Invalid package.json in the repo commit
 `,
 			versionMetadata: `{"name":"test-package","version":"1.0.0","_npmVersion":"8.0.0","dist":{"tarball":"url6"},"gitHead":"INSERT_COMMIT_ID"}`,
-			packageMetadata: `{"name":"test-package","time":{"1.0.0":"2023-01-01T12:00:00.000Z"}}`,
 			wantErr:         true,
+			extraMockCalls: []httpxtest.Call{
+				{
+					URL: "https://registry.npmjs.org/test-package/1.0.0",
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       httpxtest.Body(`{"name":"test-package","version":"1.0.0","_npmVersion":"8.0.0","dist":{"tarball":"url6"}}`),
+					},
+				},
+				{
+					URL: "url6",
+					Response: &http.Response{
+						StatusCode: 404,
+						Status:     "Not Found",
+						Body:       httpxtest.Body("not found"),
+					},
+				},
+			},
 		},
 		{
 			name:    "Error - missing upload time for custom build",
@@ -459,6 +476,9 @@ func TestInferStrategy_NPM(t *testing.T) {
 						Body:       httpxtest.Body(tc.packageMetadata),
 					},
 				})
+			}
+			if tc.extraMockCalls != nil {
+				client.Calls = append(client.Calls, tc.extraMockCalls...)
 			}
 			mux := rebuild.RegistryMux{NPM: &reg.HTTPRegistry{Client: &client}}
 			s, err := Rebuilder{}.InferStrategy(ctx, target, mux, &rcfg, tc.locationHint)

--- a/pkg/vcs/gitscan/gitscan.go
+++ b/pkg/vcs/gitscan/gitscan.go
@@ -4,9 +4,11 @@
 package gitscan
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"context"
 	"io"
+	"log"
 	"sort"
 	"time"
 
@@ -17,6 +19,31 @@ import (
 	"github.com/google/oss-rebuild/internal/bitmap"
 	"github.com/pkg/errors"
 )
+
+func FindClosestCommitToSource(ctx context.Context, repo *git.Repository, source_hashes []plumbing.Hash) (*object.Commit, error) {
+	searchStrategy := ExactTreeCount{}
+	closest, matched, total, err := searchStrategy.Search(ctx, repo, source_hashes)
+	if err != nil {
+		return nil, errors.Wrap(err, "searching for matching commit based on commit file overlap")
+	}
+	log.Printf("commits (%d): %v", len(closest), closest)
+	log.Printf("matched %d/%d files using git index scan", matched, total)
+	if len(closest) == 0 {
+		// No matches found so we will not use the commit file overlap heuristic, but this is not an error.
+		// The caller should try other heuristics.
+		log.Printf("no matching commit found using commit file overlap heuristics")
+		return nil, nil
+	}
+	// TODO: use a better heuristic here like using commit time
+	commitString := closest[0]
+	// Verify if commit exists in the repository
+	commitHash := plumbing.NewHash(commitString)
+	commitObject, err := repo.CommitObject(commitHash)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolving commit %s", commitString)
+	}
+	return commitObject, nil
+}
 
 // BlobHashesFromZip computes the git blob hashes for all files in the provided zip archive.
 func BlobHashesFromZip(zr *zip.Reader) (files []plumbing.Hash, err error) {
@@ -42,6 +69,30 @@ func BlobHashesFromZip(zr *zip.Reader) (files []plumbing.Hash, err error) {
 			return nil, err
 		}
 		files = append(files, h.Sum())
+	}
+	return files, nil
+}
+
+// BlobHashesFromTar computes the git blob hashes for all files in the provided tar archive.
+func BlobHashesFromTar(tr *tar.Reader) (files []plumbing.Hash, err error) {
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, errors.Errorf("failed reading tar file: %s", err)
+		}
+		// tar.TypeReg is the flag for a regular file
+		// unsure if we need to support other file types like links?
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		hasher := plumbing.NewHasher(plumbing.BlobObject, header.Size)
+		if _, err := io.CopyN(hasher, tr, header.Size); err != nil {
+			return nil, err
+		}
+		files = append(files, hasher.Sum())
 	}
 	return files, nil
 }


### PR DESCRIPTION
Replaces #1284 with only the npm-related additional commit inference strategies