### PR TITLE
Consolidate default dir inference

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -15,7 +15,6 @@ import (
 	"io/fs"
 	"log"
 	"path"
-	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -74,12 +73,11 @@ func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string
 	_, pkgPath, err := findCargoTOML(r.Repository, c, t.Package)
 	if err != nil {
 		log.Printf("Cargo.toml path heuristic failed [pkg=%s,repo=%s]: %s\n", t.Package, r.URI, err.Error())
-		r.Dir = "."
 		log.Println("Skipping ref map search")
 		r.RefMap = make(map[string]string)
 		err = nil
 	} else {
-		r.Dir = path.Dir(pkgPath)
+		r.Dir = rebuild.DirOf(pkgPath)
 		// Do version heuristic search.
 		r.RefMap, err = cargoTOMLSearch(t.Package, pkgPath, r.Repository)
 		if err != nil {
@@ -121,7 +119,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 			} else {
 				log.Printf("using registry ref: %s", cargoVCSGuess[:9])
 				ref = cargoVCSGuess
-				dir = filepath.Dir(newPath)
+				dir = rebuild.DirOf(newPath)
 				return ref, dir, nil
 			}
 		} else if err == plumbing.ErrObjectNotFound {
@@ -139,7 +137,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 			} else {
 				log.Printf("using tag heuristic ref: %s", tagGuess[:9])
 				ref = tagGuess
-				dir = filepath.Dir(newPath)
+				dir = rebuild.DirOf(newPath)
 				return ref, dir, nil
 			}
 		} else if err == plumbing.ErrObjectNotFound {
@@ -157,7 +155,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 			} else {
 				log.Printf("using git log heuristic ref: %s", cargoTOMLGuess[:9])
 				ref = cargoTOMLGuess
-				dir = filepath.Dir(newPath)
+				dir = rebuild.DirOf(newPath)
 				return ref, dir, nil
 			}
 		} else if err == plumbing.ErrObjectNotFound {

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -67,7 +67,7 @@ func TestInferStrategy(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["version-bump"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion: "1.35.0",
 				}
@@ -99,7 +99,7 @@ func TestInferStrategy(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["version-bump"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion: "1.65.0",
 				}
@@ -132,7 +132,7 @@ func TestInferStrategy(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["tagged-target"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion: "1.35.0",
 				}
@@ -165,7 +165,7 @@ func TestInferStrategy(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["tagged-target"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion: "1.35.0",
 				}
@@ -197,7 +197,7 @@ func TestInferStrategy(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["version-bump"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion: "1.35.0",
 				}
@@ -386,7 +386,7 @@ version = "1.0.150"
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["version-bump"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion:    "1.79.0",
 					RegistryCommit: "abcd1234567890abcdef1234567890abcdef1234",
@@ -459,7 +459,7 @@ version = "1.0.150"
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["version-bump"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion: "1.68.0",
 				}
@@ -516,7 +516,7 @@ version = "1.21.2"
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["version-bump"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion:    "1.35.0",
 					RegistryCommit: "abcd1234567890abcdef1234567890abcdef1234",
@@ -560,7 +560,7 @@ version = 3
 					Location: rebuild.Location{
 						Repo: "https://github.com/serde-rs/serde",
 						Ref:  repo.Commits["version-bump"].String(),
-						Dir:  ".",
+						Dir:  "",
 					},
 					RustVersion:    "1.79.0",
 					RegistryCommit: "abcd1234567890abcdef1234567890abcdef1234",
@@ -581,7 +581,7 @@ version = 3
 			rcfg := rebuild.RepoConfig{
 				Repository: repo.Repository,
 				URI:        "https://github.com/serde-rs/serde",
-				Dir:        ".",
+				Dir:        "",
 				RefMap:     map[string]string{"1.0.150": repo.Commits["version-bump"].String()},
 			}
 			files := tc.files

--- a/pkg/rebuild/maven/gradleinfer.go
+++ b/pkg/rebuild/maven/gradleinfer.go
@@ -108,7 +108,7 @@ func findBuildGradleDir(commit *object.Commit, pkg string) (string, error) {
 		}
 		// Look for build.gradle or build.gradle.kts files to identify potential project directories.
 		if strings.HasSuffix(f.Name, ".gradle") || strings.HasSuffix(f.Name, ".gradle.kts") {
-			candidateDirs = append(candidateDirs, path.Dir(f.Name))
+			candidateDirs = append(candidateDirs, rebuild.DirOf(f.Name))
 		}
 		return nil
 	})
@@ -121,7 +121,7 @@ func findBuildGradleDir(commit *object.Commit, pkg string) (string, error) {
 	// Find the candidate with the minimum edit distance to the artifact name
 	minDist := math.MaxInt
 	// Default to the root directory if no better match is found
-	bestMatch := "."
+	bestMatch := ""
 	for _, candidate := range candidateDirs {
 		dist := minEditDistance(path.Base(candidate), pkg)
 		if dist == 0 {

--- a/pkg/rebuild/maven/gradleinfer_test.go
+++ b/pkg/rebuild/maven/gradleinfer_test.go
@@ -30,7 +30,7 @@ func TestFindBuildGradleDir(t *testing.T) {
                     build.gradle: |
                         group='com.example'`,
 			pkg:         "com.example:myapp",
-			expectedDir: ".",
+			expectedDir: "",
 			wantErr:     false,
 		},
 		{
@@ -42,7 +42,7 @@ func TestFindBuildGradleDir(t *testing.T) {
                     build.gradle.kts: |
                         group='org.sample'`,
 			pkg:         "org.sample:lib",
-			expectedDir: ".",
+			expectedDir: "",
 			wantErr:     false,
 		},
 		{

--- a/pkg/rebuild/maven/maveninfer.go
+++ b/pkg/rebuild/maven/maveninfer.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -34,6 +33,7 @@ func MavenInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, 
 		return nil, errors.Wrapf(err, "[INTERNAL] tag heuristic error")
 	}
 	var dir, ref string
+	var found bool
 	var commit *object.Commit
 	var msg string
 	if tagGuess != "" {
@@ -41,14 +41,14 @@ func MavenInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, 
 		if err != nil {
 			return nil, errors.Wrapf(err, "[INTERNAL] Failed to get commit from tag [repo=%s,ref=%s]", repoConfig.URI, tagGuess)
 		}
-		if dir, msg = findBuildDir(commit, t); dir != "" {
+		if dir, found, msg = findBuildDir(commit, t); found {
 			ref = tagGuess
 		}
 		log.Printf("using tag heuristic: %s", msg)
 	}
 	// 2. Git Log Heuristic
 	var pomXMLGuess string
-	if dir == "" {
+	if !found {
 		head, _ := repoConfig.Repository.Head()
 		commitObject, _ := repoConfig.Repository.CommitObject(head.Hash())
 		_, pkgPath, err := findPomXML(commitObject, t.Package)
@@ -66,7 +66,7 @@ func MavenInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, 
 		}
 		commit, err = repoConfig.Repository.CommitObject(plumbing.NewHash(pomXMLGuess))
 		if err == nil {
-			if dir, msg = findBuildDir(commit, t); dir != "" {
+			if dir, found, msg = findBuildDir(commit, t); found {
 				ref = pomXMLGuess
 			}
 			log.Printf("using git log heuristic: %s", msg)
@@ -76,19 +76,19 @@ func MavenInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, 
 	}
 	// 3. Source Jar Heuristic
 	var sourceJarGuess *object.Commit
-	if dir == "" {
+	if !found {
 		sourceJarGuess, err = findClosestCommitToSource(ctx, t, mux, repoConfig.Repository)
 		if err != nil {
 			log.Printf("source jar heuristic failed: %s", err)
 		}
 		if sourceJarGuess != nil {
-			if dir, msg = findBuildDir(sourceJarGuess, t); dir != "" {
+			if dir, found, msg = findBuildDir(sourceJarGuess, t); found {
 				ref = sourceJarGuess.Hash.String()
 			}
 			log.Printf("using source jar heuristic: %s", msg)
 		}
 	}
-	if dir == "" {
+	if !found {
 		if pomXMLGuess != "" || tagGuess != "" || sourceJarGuess != nil {
 			return nil, errors.Errorf("no valid git ref")
 		}
@@ -109,19 +109,19 @@ func MavenInfer(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, 
 }
 
 // findBuildDir is a helper that checks if a given commit contains a valid pom.xml for the package.
-// It returns the directory containing the pom.xml and a summary.
-// If no valid pom.xml is found, it returns an empty directory and a summary indicating the failure reason.
-func findBuildDir(commit *object.Commit, t rebuild.Target) (dir string, summary string) {
+// It returns the directory containing the pom.xml ("" for the repo root), whether one was found,
+// and a summary. If no valid pom.xml is found, the summary indicates the failure reason.
+func findBuildDir(commit *object.Commit, t rebuild.Target) (dir string, found bool, summary string) {
 	pomXML, foundPkgPath, err := findPomXML(commit, t.Package)
 	if err != nil {
-		return "", fmt.Sprintf("could not find a pom.xml for the package in ref %s", commit.Hash.String()[:9])
+		return "", false, fmt.Sprintf("could not find a pom.xml for the package in ref %s", commit.Hash.String()[:9])
 	}
-	dir = filepath.Dir(foundPkgPath)
+	dir = rebuild.DirOf(foundPkgPath)
 	ref := commit.Hash.String()
 	if pomXML.Version() != t.Version {
-		return dir, fmt.Sprintf("with mismatched version [expected=%s,actual=%s,path=%s,ref=%s]", t.Version, pomXML.Version(), path.Join(dir, "pom.xml"), ref[:9])
+		return dir, true, fmt.Sprintf("with mismatched version [expected=%s,actual=%s,path=%s,ref=%s]", t.Version, pomXML.Version(), path.Join(dir, "pom.xml"), ref[:9])
 	} else {
-		return dir, fmt.Sprintf("with pkg and version match ref [version=%s,path=%s,ref=%s]", t.Version, path.Join(dir, "pom.xml"), ref[:9])
+		return dir, true, fmt.Sprintf("with pkg and version match ref [version=%s,path=%s,ref=%s]", t.Version, path.Join(dir, "pom.xml"), ref[:9])
 	}
 }
 

--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -58,7 +58,7 @@ func (b *MavenBuild) ToWorkflow() *rebuild.WorkflowStrategy {
 				Uses: "maven/export-java",
 			},
 			{
-				Runs: "mvn clean package -DskipTests --batch-mode -f {{.Location.Dir}} -Dmaven.javadoc.skip=true",
+				Runs: "mvn clean package -DskipTests --batch-mode{{if and (ne .Location.Dir \".\") (ne .Location.Dir \"\")}} -f {{.Location.Dir}}{{end}} -Dmaven.javadoc.skip=true",
 				// Note `maven` from apt also pull in jdk-21 and hence we must export JAVA_HOME and PATH in the step before
 				Needs: []string{"maven"},
 			},

--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -62,7 +61,7 @@ func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string
 	if err != nil {
 		log.Printf("package.json path heuristic failed [pkg=%s,repo=%s]: %s\n", t.Package, r.URI, err.Error())
 	}
-	r.Dir = path.Dir(pkgPath)
+	r.Dir = rebuild.DirOf(pkgPath)
 	// Do version heuristic search.
 	r.RefMap, err = pkgJSONSearch(t.Package, pkgPath, r.Repository)
 	if err != nil {
@@ -136,10 +135,8 @@ func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.Rep
 			log.Printf("package.json path disagreement [metadata=%s,heuristic=%s]\n", vmeta.Directory, rcfg.Dir)
 		}
 		loc.Dir = vmeta.Directory
-	} else if rcfg.Dir != "" {
-		loc.Dir = rcfg.Dir
 	} else {
-		loc.Dir = "."
+		loc.Dir = rcfg.Dir
 	}
 	// Determine git ref to rebuild
 	registryRef := vmeta.GitHEAD
@@ -162,7 +159,7 @@ func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.Rep
 			} else {
 				log.Printf("using registry ref: %s", registryRef[:9])
 				loc.Ref = registryRef
-				loc.Dir = filepath.Dir(newPath)
+				loc.Dir = rebuild.DirOf(newPath)
 				return loc, "", nil
 			}
 		} else if err == plumbing.ErrObjectNotFound {
@@ -182,7 +179,7 @@ func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.Rep
 			} else {
 				log.Printf("using tag heuristic ref: %s", tagGuess[:9])
 				loc.Ref = tagGuess
-				loc.Dir = filepath.Dir(newPath)
+				loc.Dir = rebuild.DirOf(newPath)
 				return loc, "", nil
 			}
 		} else if err == plumbing.ErrObjectNotFound {
@@ -201,7 +198,7 @@ func InferLocation(t rebuild.Target, vmeta *npmreg.NPMVersion, rcfg *rebuild.Rep
 			} else {
 				log.Printf("using git log heuristic ref: %s", pkgJSONGuess[:9])
 				loc.Ref = pkgJSONGuess
-				loc.Dir = filepath.Dir(newPath)
+				loc.Dir = rebuild.DirOf(newPath)
 				return loc, "", nil
 			}
 		} else if err == plumbing.ErrObjectNotFound {

--- a/pkg/rebuild/npm/infer_test.go
+++ b/pkg/rebuild/npm/infer_test.go
@@ -203,7 +203,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/test-org/test-package",
 						Ref:  commitID,
-						Dir:  ".",
+						Dir:  "",
 					},
 					NPMVersion: "8.1.2",
 				}
@@ -230,7 +230,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/test-org/test-package",
 						Ref:  commitID,
-						Dir:  ".",
+						Dir:  "",
 					},
 					NPMVersion: "7.5.0",
 				}
@@ -256,7 +256,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/test-org/test-package",
 						Ref:  commitID,
-						Dir:  ".",
+						Dir:  "",
 					},
 					NPMVersion: "6.14.0",
 				}
@@ -282,7 +282,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/test-org/test-package",
 						Ref:  commitID,
-						Dir:  ".",
+						Dir:  "",
 					},
 					NPMVersion:        "8.2.0",
 					NodeVersion:       "10.17.0",
@@ -312,7 +312,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/test-org/test-package",
 						Ref:  commitID,
-						Dir:  ".",
+						Dir:  "",
 					},
 					NPMVersion:   "9.0.0",
 					NodeVersion:  "10.17.0",
@@ -340,7 +340,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/test-org/test-package",
 						Ref:  commitID,
-						Dir:  ".",
+						Dir:  "",
 					},
 					NPMVersion:        "6.2.0",
 					NodeVersion:       "10.17.0",
@@ -412,7 +412,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 					Location: rebuild.Location{
 						Repo: "https://github.com/test-org/test-package",
 						Ref:  commitID,
-						Dir:  ".",
+						Dir:  "",
 					},
 					NPMVersion: "8.1.2",
 				}
@@ -436,7 +436,7 @@ func TestInferStrategy_NPM(t *testing.T) {
 			rcfg := rebuild.RepoConfig{
 				Repository: repo.Repository,
 				URI:        "https://github.com/test-org/test-package",
-				Dir:        ".",
+				Dir:        "",
 				RefMap:     map[string]string{"1.0.0": repo.Commits["version-bump"].String()},
 			}
 			client := httpxtest.MockClient{

--- a/pkg/rebuild/pypi/parsing/resolver.go
+++ b/pkg/rebuild/pypi/parsing/resolver.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/pkg/errors"
 )
 
@@ -74,10 +75,5 @@ func DiscoverBuildDir(ctx context.Context, tree *object.Tree, name, version, hin
 	}
 	sortedVerification := sortVerifications(verifiedFiles)
 	bestFile := sortedVerification[0]
-	dir := filepath.Dir(bestFile.foundF.Name)
-	// Account for "." as base dir
-	if dir == "." {
-		dir = ""
-	}
-	return dir, nil
+	return rebuild.DirOf(bestFile.foundF.Name), nil
 }

--- a/pkg/rebuild/rebuild/strategy.go
+++ b/pkg/rebuild/rebuild/strategy.go
@@ -5,6 +5,7 @@ package rebuild
 
 import (
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/pkg/errors"
@@ -17,6 +18,15 @@ type Location struct {
 	Repo string `json:"repo" yaml:"repo"`
 	Ref  string `json:"ref" yaml:"ref"`
 	Dir  string `json:"dir" yaml:"dir,omitempty"`
+}
+
+// DirOf returns the directory containing the repo-relative file path p for use
+// as a Location.Dir, normalizing the repo root to the canonical "".
+func DirOf(p string) string {
+	if d := path.Dir(p); d != "." {
+		return d
+	}
+	return ""
 }
 
 // RequiredEnv describes any required properties about the build environment

--- a/pkg/rebuild/rubygems/infer.go
+++ b/pkg/rebuild/rubygems/infer.go
@@ -112,10 +112,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			log.Printf("warning: gemspec search failed for %s: %v", t.Package, err)
 		} else {
 			gemspec = path.Base(gemspecPath)
-			dir = path.Dir(gemspecPath)
-			if dir == "." {
-				dir = ""
-			}
+			dir = rebuild.DirOf(gemspecPath)
 		}
 	} else {
 		// TODO: Find gemspec when dir hint provided.


### PR DESCRIPTION
By default, we won't set Location.Dir which will indicate the package
location is the base dir of the repo. We can still include the logic to
handle explicit "." in our helpers. Still, we shouldn't produce both
values from inference, nor should we surface diffs in explicit build
defs which differentiate between the two.