### PR TITLE
Add scratch user to docker group

### DIFF
--- a/deployments/scratch_startup.sh
+++ b/deployments/scratch_startup.sh
@@ -38,6 +38,7 @@ if [ -e /dev/nvme0n1 ]; then
 fi
 
 useradd --create-home --home-dir /home/builder --shell /bin/bash builder || true
+usermod -aG docker builder
 mkdir -p /opt/builder
 chown -R builder:builder /opt/builder /home/builder
 


### PR DESCRIPTION
As written, the scratch builder wouldn't have access to the docker
socket and, consequently, wouldn't be able to run docker builds.