### PR TITLE
Improve boundary semantics of scratch lifecycle

### DIFF
--- a/internal/api/agentapiservice/scratch.go
+++ b/internal/api/agentapiservice/scratch.go
@@ -98,7 +98,7 @@ type ScratchDeleteDeps struct {
 //	InternalIP -> poll HealthProbe -> UpdateState(Ready) -> return.
 //
 // If any step fails after resources are created, best-effort teardown is
-// run and the record is marked Deleted (records persist for audit).
+// run (see deleteScratch; records persist for audit).
 func ScratchCreate(ctx context.Context, req schema.ScratchCreateRequest, deps *ScratchCreateDeps) (*schema.Scratch, error) {
 	class, err := selectClass(req.MachineClass, deps.Standard, deps.Jumbo)
 	if err != nil {
@@ -117,6 +117,10 @@ func ScratchCreate(ctx context.Context, req schema.ScratchCreateRequest, deps *S
 		State:        schema.ScratchStarting,
 		Created:      now,
 		Updated:      now,
+		// Seeded at insert: Firestore range filters skip docs missing the
+		// field, which would hide a crashed create from the reaper's
+		// ListIdleSince query.
+		LastUsed: now,
 		// Zone is set after the fallthrough loop is able to allocate.
 	}
 	if err := deps.Scratches.Insert(ctx, scratch); err != nil {
@@ -126,16 +130,11 @@ func ScratchCreate(ctx context.Context, req schema.ScratchCreateRequest, deps *S
 	// Best-effort teardown on failure past this point. scratch.Zone gates
 	// DeleteInstance: insertWithFallthrough sets it whenever a VM may
 	// exist (success, or non-stockout orphan), and leaves it "" when GCE
-	// semantics guarantee none (all-stockouts).
+	// semantics guarantee none (all-stockouts). On failure the record is
+	// left in Deleting for the reaper to retry.
 	cleanup := func() {
-		bg := context.Background()
-		if scratch.Zone != "" {
-			if err := deps.GCE.DeleteInstance(bg, scratch.Zone, scratch.VMName); err != nil {
-				log.Printf("teardown DeleteInstance(%s/%s): %v", scratch.Zone, scratch.VMName, err)
-			}
-		}
-		if err := deps.Scratches.UpdateState(bg, scratchID, schema.ScratchDeleted); err != nil {
-			log.Printf("teardown UpdateState(%s, Deleted): %v", scratchID, err)
+		if err := deleteScratch(context.Background(), deps.Scratches, deps.GCE, scratch); err != nil {
+			log.Printf("scratch %s teardown: %v", scratchID, err)
 		}
 	}
 
@@ -148,10 +147,6 @@ func ScratchCreate(ctx context.Context, req schema.ScratchCreateRequest, deps *S
 
 	scratch.InternalIP = inst.InternalIP
 	scratch.Updated = time.Now().UTC()
-	// Seed LastUsed at provisioning so the reaper's ListIdleSince doesn't
-	// pick up a brand-new scratch whose zero-time LastUsed satisfies the
-	// "last_used < cutoff" filter.
-	scratch.LastUsed = scratch.Updated
 	if err := deps.Scratches.Update(ctx, scratch); err != nil {
 		cleanup()
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update with IP"))
@@ -184,7 +179,8 @@ func ScratchGet(ctx context.Context, req schema.ScratchGetRequest, deps *Scratch
 
 // ScratchDelete tears down the GCE resources and records the scratch as
 // Deleted. The record itself is preserved for audit (a separate retention
-// sweep can later hard-delete via Scratches.Delete).
+// sweep can later hard-delete via Scratches.Delete). On a failed VM delete
+// the record stays Deleting and the reaper retries.
 func ScratchDelete(ctx context.Context, req schema.ScratchDeleteRequest, deps *ScratchDeleteDeps) (*schema.ScratchDeleteResponse, error) {
 	scratch, err := deps.Scratches.Get(ctx, req.ScratchID)
 	if err != nil {
@@ -193,19 +189,29 @@ func ScratchDelete(ctx context.Context, req schema.ScratchDeleteRequest, deps *S
 		}
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches get"))
 	}
-
-	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleting); err != nil {
-		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update state deleting"))
-	}
-	if scratch.VMName != "" {
-		if err := deps.GCE.DeleteInstance(ctx, scratch.Zone, scratch.VMName); err != nil {
-			log.Printf("DeleteInstance(%s): %v", scratch.VMName, err)
-		}
-	}
-	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleted); err != nil {
-		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "scratches update state deleted"))
+	if err := deleteScratch(ctx, deps.Scratches, deps.GCE, scratch); err != nil {
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "delete scratch"))
 	}
 	return &schema.ScratchDeleteResponse{ScratchID: scratch.ID, State: schema.ScratchDeleted}, nil
+}
+
+// deleteScratch is the shared teardown: Deleting -> DeleteInstance ->
+// Deleted. The record advances to Deleted only once the VM is confirmed
+// gone (DeleteInstance is idempotent), so any failure leaves it Deleting
+// and a later reap pass retries.
+func deleteScratch(ctx context.Context, scratches db.Scratch, gce GCE, scratch schema.Scratch) error {
+	if err := scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleting); err != nil {
+		return errors.Wrap(err, "update state deleting")
+	}
+	if scratch.VMName != "" && scratch.Zone != "" {
+		if err := gce.DeleteInstance(ctx, scratch.Zone, scratch.VMName); err != nil {
+			return errors.Wrap(err, "delete instance")
+		}
+	}
+	if err := scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleted); err != nil {
+		return errors.Wrap(err, "update state deleted")
+	}
+	return nil
 }
 
 func waitHealthy(ctx context.Context, deps *ScratchCreateDeps, ip string) error {

--- a/internal/api/agentapiservice/scratch_gce.go
+++ b/internal/api/agentapiservice/scratch_gce.go
@@ -185,12 +185,22 @@ func (g *computeGCE) StopInstance(ctx context.Context, zone, name string) error 
 	return g.waitZoneOp(ctx, zone, op)
 }
 
+// DeleteInstance is idempotent: deleting a missing instance succeeds, so
+// retried teardowns converge after a partially-observed earlier delete.
 func (g *computeGCE) DeleteInstance(ctx context.Context, zone, name string) error {
 	op, err := g.svc.Instances.Delete(g.project, zone, name).Context(ctx).Do()
+	if isNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "instances.delete")
 	}
 	return g.waitZoneOp(ctx, zone, op)
+}
+
+func isNotFound(err error) bool {
+	var gerr *googleapi.Error
+	return errors.As(err, &gerr) && gerr.Code == 404
 }
 
 func (g *computeGCE) waitZoneOp(ctx context.Context, zone string, op *compute.Operation) error {

--- a/internal/api/agentapiservice/scratch_reap.go
+++ b/internal/api/agentapiservice/scratch_reap.go
@@ -42,8 +42,8 @@ type ScratchReapDeps struct {
 	// we capture the worker's final status while it's still reachable.
 	// nil disables; affected ops get finalized blind instead.
 	Syncer Syncer
-	// IdleThreshold: ready scratches with no in-deadline pending exec
-	// and LastUsed older than this get torn down.
+	// IdleThreshold: non-deleted scratches with no in-deadline pending
+	// exec and LastUsed older than this get torn down.
 	IdleThreshold time.Duration // default: 30m
 }
 
@@ -61,14 +61,23 @@ func deadlineFor(exec schema.ScratchExec) time.Time {
 	return exec.StartedAt.Add(time.Duration(exec.TimeoutSeconds)*time.Second + opDeadlineGrace)
 }
 
-// ScratchReap deletes idle scratches and finalizes obsolete ops.
-// A pending op inside its deadline exempts its scratch from idle teardown,
-// so raising the exec timeout — not the idle threshold — is how longer
-// executions are accommodated. Ops bound to a no-longer-Ready scratch are
-// marked Lost and expired ops are pulled through the worker for their real
-// final status before falling back to a blind TimedOut. Best-effort: each
-// item's failure is logged and the loop continues so a single bad row
-// can't block the rest.
+// ScratchReap deletes stale scratches and finalizes obsolete ops.
+//
+// Scratch teardown:
+//   - Stale covers idle Ready scratches and Starting/Deleting records
+//     stranded by crashed creates or failed teardowns.
+//   - A scratch is never torn down while an op may still be running on
+//     it (pending, within deadline). The idle threshold only applies
+//     once all ops have completed.
+//   - Deletes converge across passes since records only reach Deleted
+//     once the VM is confirmed gone.
+//
+// Op finalization:
+//   - Ops on a non-Ready scratch are marked Lost.
+//   - Expired ops are synced and finalized, marking them TimedOut if
+//     still incomplete.
+//
+// Best-effort: per-item failures are logged and the pass continues.
 func ScratchReap(ctx context.Context, _ ScratchReapRequest, deps *ScratchReapDeps) (*ScratchReapResponse, error) {
 	now := time.Now().UTC()
 	idleCutoff := now.Add(-deps.idleThreshold())
@@ -92,32 +101,33 @@ func ScratchReap(ctx context.Context, _ ScratchReapRequest, deps *ScratchReapDep
 			busy[exec.ScratchID] = true
 		}
 	}
-	// Reap idle, non-busy scratches. Before tearing down each one, try
+	// Reap stale, non-busy scratches. Before tearing down a Ready one, try
 	// to sync any pending ops on it so we capture exit codes while the
-	// worker is still reachable.
-	idle, err := deps.Scratches.ListIdleSince(ctx, idleCutoff)
+	// worker is still reachable. Starting scratches never dispatched and
+	// Deleting ones already had their pre-teardown sync.
+	stale, err := deps.Scratches.ListIdleSince(ctx, idleCutoff)
 	if err != nil {
-		return nil, api.AsStatus(codes.Internal, pkgerrors.Wrap(err, "list idle scratches"))
+		return nil, api.AsStatus(codes.Internal, pkgerrors.Wrap(err, "list stale scratches"))
 	}
 	var scratchesReaped int
-	for _, scratch := range idle {
+	for _, scratch := range stale {
 		if busy[scratch.ID] {
 			continue
 		}
-		if deps.Syncer != nil {
+		if deps.Syncer != nil && scratch.State == schema.ScratchReady {
 			syncPendingFor(ctx, deps, scratch, pending)
 		}
 		// Re-check before the destructive step: an exec dispatched after
-		// the idle snapshot bumps LastUsed, and tearing down its scratch
-		// would orphan it.
+		// the stale snapshot bumps LastUsed, and a Starting scratch may
+		// have come Ready under a still-running create.
 		if cur, err := deps.Scratches.Get(ctx, scratch.ID); err != nil {
 			log.Printf("reap re-check scratch %s: %v", scratch.ID, err)
 			continue
-		} else if cur.State != schema.ScratchReady || !cur.LastUsed.Before(idleCutoff) {
+		} else if cur.State != scratch.State || !cur.LastUsed.Before(idleCutoff) {
 			continue
 		}
-		if err := teardownScratch(ctx, deps, scratch); err != nil {
-			log.Printf("reap teardown scratch %s: %v", scratch.ID, err)
+		if err := deleteScratch(ctx, deps.Scratches, deps.GCE, scratch); err != nil {
+			log.Printf("reap scratch %s: %v", scratch.ID, err)
 			continue
 		}
 		scratchesReaped++
@@ -211,21 +221,4 @@ func terminalStateFor(ctx context.Context, deps *ScratchReapDeps, exec schema.Sc
 		}
 	}
 	return schema.ScratchExecPending, nil
-}
-
-// teardownScratch mirrors ScratchDelete's GCE + state flow. Records
-// persist with state=Deleted for audit.
-func teardownScratch(ctx context.Context, deps *ScratchReapDeps, scratch schema.Scratch) error {
-	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleting); err != nil {
-		return pkgerrors.Wrap(err, "scratches update state deleting")
-	}
-	if scratch.VMName != "" {
-		if err := deps.GCE.DeleteInstance(ctx, scratch.Zone, scratch.VMName); err != nil {
-			log.Printf("reap DeleteInstance(%s): %v", scratch.VMName, err)
-		}
-	}
-	if err := deps.Scratches.UpdateState(ctx, scratch.ID, schema.ScratchDeleted); err != nil {
-		return pkgerrors.Wrap(err, "scratches update state deleted")
-	}
-	return nil
 }

--- a/internal/api/agentapiservice/scratch_reap_test.go
+++ b/internal/api/agentapiservice/scratch_reap_test.go
@@ -479,6 +479,88 @@ func (b *bumpingSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scrat
 	return exec, nil
 }
 
+// A Starting record stranded by a crashed create is reaped once stale,
+// while one inside a plausibly-live create window is spared.
+func TestScratchReap_StuckStartingReaped(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	gce := NewMemoryGCE()
+	now := time.Now().UTC()
+	zone := "us-central1-a"
+
+	_, _ = gce.InsertInstanceFromTemplate(ctx, zone, "scratch-stuck", "tmpl", nil)
+	for _, s := range []schema.Scratch{
+		{ID: "stuck", State: schema.ScratchStarting, Zone: zone, VMName: "scratch-stuck", LastUsed: now.Add(-time.Hour)},
+		{ID: "provisioning", State: schema.ScratchStarting, Zone: zone, VMName: "scratch-prov", LastUsed: now.Add(-time.Minute)},
+	} {
+		if err := scratches.Insert(ctx, s); err != nil {
+			t.Fatalf("seed %s: %v", s.ID, err)
+		}
+	}
+
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, reapDeps(t, scratches, db.NewMemoryScratchExecs(), gce))
+	if err != nil {
+		t.Fatalf("ScratchReap: %v", err)
+	}
+	if resp.ScratchesReaped != 1 {
+		t.Errorf("ScratchesReaped = %d; want 1", resp.ScratchesReaped)
+	}
+	if got, _ := scratches.Get(ctx, "stuck"); got.State != schema.ScratchDeleted {
+		t.Errorf("stuck.State = %q; want deleted", got.State)
+	}
+	if gce.InstanceExists(zone, "scratch-stuck") {
+		t.Errorf("stuck VM not torn down")
+	}
+	if got, _ := scratches.Get(ctx, "provisioning"); got.State != schema.ScratchStarting {
+		t.Errorf("provisioning.State = %q; want starting (spared)", got.State)
+	}
+}
+
+// A failed VM delete leaves the record Deleting, and the next pass picks
+// it up again and converges to Deleted.
+func TestScratchReap_DeletingRetriedUntilVMGone(t *testing.T) {
+	ctx := context.Background()
+	scratches := db.NewMemoryScratch()
+	gce := NewMemoryGCE()
+	now := time.Now().UTC()
+	zone := "us-central1-a"
+
+	_, _ = gce.InsertInstanceFromTemplate(ctx, zone, "scratch-d", "tmpl", nil)
+	if err := scratches.Insert(ctx, schema.Scratch{
+		ID: "d", State: schema.ScratchDeleting, Zone: zone, VMName: "scratch-d",
+		LastUsed: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	deps := reapDeps(t, scratches, db.NewMemoryScratchExecs(), gce)
+
+	gce.FailNext("DeleteInstance", errors.New("gce unavailable"))
+	resp, err := ScratchReap(ctx, ScratchReapRequest{}, deps)
+	if err != nil {
+		t.Fatalf("ScratchReap(1): %v", err)
+	}
+	if resp.ScratchesReaped != 0 {
+		t.Errorf("pass 1 ScratchesReaped = %d; want 0", resp.ScratchesReaped)
+	}
+	if got, _ := scratches.Get(ctx, "d"); got.State != schema.ScratchDeleting {
+		t.Errorf("State after failed pass = %q; want deleting", got.State)
+	}
+
+	resp, err = ScratchReap(ctx, ScratchReapRequest{}, deps)
+	if err != nil {
+		t.Fatalf("ScratchReap(2): %v", err)
+	}
+	if resp.ScratchesReaped != 1 {
+		t.Errorf("pass 2 ScratchesReaped = %d; want 1", resp.ScratchesReaped)
+	}
+	if got, _ := scratches.Get(ctx, "d"); got.State != schema.ScratchDeleted {
+		t.Errorf("State after retry = %q; want deleted", got.State)
+	}
+	if gce.InstanceExists(zone, "scratch-d") {
+		t.Errorf("VM not torn down after retry")
+	}
+}
+
 func TestScratchReap_TeardownRecheckSparesRevivedScratch(t *testing.T) {
 	ctx := context.Background()
 	scratches := db.NewMemoryScratch()

--- a/internal/api/agentapiservice/scratch_test.go
+++ b/internal/api/agentapiservice/scratch_test.go
@@ -478,6 +478,34 @@ func TestScratchDelete_NotFound(t *testing.T) {
 	}
 }
 
+// A failed VM delete must not advance the record to Deleted: it stays
+// Deleting so the reaper can retry, and the API surfaces the failure.
+func TestScratchDelete_GCEFailureStaysDeleting(t *testing.T) {
+	gce := NewMemoryGCE()
+	scratches := db.NewMemoryScratch()
+	zone := "us-central1-a"
+	_, _ = gce.InsertInstanceFromTemplate(context.Background(), zone, "scratch-s1", "tmpl", nil)
+	if err := scratches.Insert(context.Background(), schema.Scratch{
+		ID: "s1", State: schema.ScratchReady, Zone: zone, VMName: "scratch-s1",
+	}); err != nil {
+		t.Fatalf("seed scratch: %v", err)
+	}
+	gce.FailNext("DeleteInstance", errors.New("gce unavailable"))
+
+	_, err := ScratchDelete(context.Background(), schema.ScratchDeleteRequest{ScratchID: "s1"},
+		&ScratchDeleteDeps{Scratches: scratches, GCE: gce})
+	if status.Code(err) != codes.Internal {
+		t.Errorf("code = %s; want Internal. err=%v", status.Code(err), err)
+	}
+	rec, _ := scratches.Get(context.Background(), "s1")
+	if rec.State != schema.ScratchDeleting {
+		t.Errorf("State = %q; want deleting (retryable)", rec.State)
+	}
+	if !gce.InstanceExists(zone, "scratch-s1") {
+		t.Errorf("instance gone despite failed delete")
+	}
+}
+
 // MemoryGCE is an in-memory fake of GCE for tests. It records the operation
 // sequence and supports targeted failure injection.
 type MemoryGCE struct {
@@ -668,6 +696,8 @@ func (m *MemoryGCE) StopInstance(_ context.Context, zone, name string) error {
 	return nil
 }
 
+// DeleteInstance is idempotent (missing instance succeeds), matching the
+// 404-as-success semantics of the compute impl.
 func (m *MemoryGCE) DeleteInstance(_ context.Context, zone, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -675,10 +705,6 @@ func (m *MemoryGCE) DeleteInstance(_ context.Context, zone, name string) error {
 	if err := m.checkFail("DeleteInstance"); err != nil {
 		return err
 	}
-	key := zone + "/" + name
-	if _, ok := m.instances[key]; !ok {
-		return errors.New("instance not found")
-	}
-	delete(m.instances, key)
+	delete(m.instances, zone+"/"+name)
 	return nil
 }

--- a/internal/db/scratch.go
+++ b/internal/db/scratch.go
@@ -29,9 +29,10 @@ type Scratch interface {
 	UpdateState(ctx context.Context, scratchID string, s schema.ScratchState) error
 	// UpdateLastUsed sets the last_used field (and bumps `updated`).
 	UpdateLastUsed(ctx context.Context, scratchID string, t time.Time) error
-	// ListIdleSince returns scratches in state Ready whose LastUsed is
-	// strictly before t. Backed by a (state, last_used) composite index in
-	// Firestore.
+	// ListIdleSince returns non-deleted scratches whose LastUsed is strictly
+	// before t: idle Ready scratches plus Starting/Deleting records stranded
+	// by a crashed create or a failed teardown. Backed by a (state,
+	// last_used) composite index in Firestore.
 	ListIdleSince(ctx context.Context, t time.Time) ([]schema.Scratch, error)
 	Delete(ctx context.Context, scratchID string) error
 }
@@ -83,7 +84,11 @@ func (f *firestoreScratch) UpdateLastUsed(ctx context.Context, scratchID string,
 
 func (f *firestoreScratch) ListIdleSince(ctx context.Context, t time.Time) ([]schema.Scratch, error) {
 	q := f.client.Collection(scratchCollection).
-		Where("state", "==", string(schema.ScratchReady)).
+		Where("state", "in", []string{
+			string(schema.ScratchReady),
+			string(schema.ScratchStarting),
+			string(schema.ScratchDeleting),
+		}).
 		Where("last_used", "<", t.UTC())
 	iter := q.Documents(ctx)
 	defer iter.Stop()
@@ -167,7 +172,7 @@ func (m *memoryScratch) ListIdleSince(ctx context.Context, t time.Time) ([]schem
 	defer m.mu.Unlock()
 	var out []schema.Scratch
 	for _, e := range m.data {
-		if e.State == schema.ScratchReady && e.LastUsed.Before(t) {
+		if e.State != schema.ScratchDeleted && e.LastUsed.Before(t) {
 			out = append(out, e)
 		}
 	}

--- a/internal/db/scratch_test.go
+++ b/internal/db/scratch_test.go
@@ -94,9 +94,9 @@ func TestMemoryScratch_ListIdleSince(t *testing.T) {
 	for _, e := range []schema.Scratch{
 		sampleScratch("ready-old", schema.ScratchReady, old),                   // ✓ included
 		sampleScratch("ready-fresh", schema.ScratchReady, fresh),               // ✗ too fresh
-		sampleScratch("starting-old", schema.ScratchStarting, old),             // ✗ wrong state
-		sampleScratch("deleting-old", schema.ScratchDeleting, old),             // ✗ wrong state
-		sampleScratch("deleted-old", schema.ScratchDeleted, old),               // ✗ wrong state
+		sampleScratch("starting-old", schema.ScratchStarting, old),             // ✓ stuck create
+		sampleScratch("deleting-old", schema.ScratchDeleting, old),             // ✓ failed teardown
+		sampleScratch("deleted-old", schema.ScratchDeleted, old),               // ✗ already gone
 		sampleScratch("ready-old-2", schema.ScratchReady, old.Add(-time.Hour)), // ✓ included
 	} {
 		if err := s.Insert(ctx, e); err != nil {
@@ -113,7 +113,7 @@ func TestMemoryScratch_ListIdleSince(t *testing.T) {
 		ids = append(ids, e.ID)
 	}
 	sort.Strings(ids)
-	want := []string{"ready-old", "ready-old-2"}
+	want := []string{"deleting-old", "ready-old", "ready-old-2", "starting-old"}
 	if diff := cmp.Diff(want, ids); diff != "" {
 		t.Errorf("ListIdleSince ids mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
This ensures that scratch VMs are eventually reaped, even if failures
occur during insertion or deletion.

> Children: [#1324](https://redirect.github.com/google/oss-rebuild/pull/1324)