### PR TITLE
Inject crates registry stub into run-one local execution

### DIFF
--- a/tools/ctl/command/runone/runone.go
+++ b/tools/ctl/command/runone/runone.go
@@ -12,8 +12,11 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/pkg/act"
 	"github.com/google/oss-rebuild/pkg/act/api"
@@ -23,6 +26,7 @@ import (
 	"github.com/google/oss-rebuild/pkg/oauth"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/google/oss-rebuild/pkg/registry/cratesio/index"
 	benchrun "github.com/google/oss-rebuild/tools/benchmark/run"
 	"github.com/google/oss-rebuild/tools/ctl/localfiles"
 	"github.com/pkg/errors"
@@ -200,6 +204,25 @@ func handleLocal(ctx context.Context, cfg Config, deps *Deps, enc *json.Encoder,
 			apiClient = http.DefaultClient
 		}
 		localCfg.GitCache = &gitcache.Client{IDClient: idClient, APIClient: apiClient, URL: u}
+	}
+	if rebuild.Ecosystem(cfg.Ecosystem) == rebuild.CratesIO {
+		mgrInit := sync.OnceValues(func() (*index.IndexManager, error) {
+			if err := os.MkdirAll("/tmp/crates-registry-cache", 0o755); err != nil {
+				return nil, errors.Wrap(err, "initializing crates registry cache")
+			}
+			return index.NewIndexManagerFromFS(index.IndexManagerConfig{
+				Filesystem:            osfs.New("/tmp/crates-registry-cache"),
+				CurrentUpdateInterval: 6 * time.Hour,
+				MaxSnapshots:          3,
+			})
+		})
+		localCfg.CratesRegistryStub = func(ctx context.Context, req cratesregistryservice.FindRegistryCommitRequest) (*cratesregistryservice.FindRegistryCommitResponse, error) {
+			mgr, err := mgrInit()
+			if err != nil {
+				return nil, errors.Wrap(err, "creating crates index manager")
+			}
+			return cratesregistryservice.FindRegistryCommit(ctx, req, &cratesregistryservice.FindRegistryCommitDeps{IndexManager: mgr})
+		}
 	}
 	executor := benchrun.NewLocalExecutionService(localCfg)
 	t := rebuild.Target{


### PR DESCRIPTION
When running `run-one attest --local`, it fails for CratesIO packages with "_crates registry stub not found in context_". This seems to be similar to the issue fixed for `run-bench` in #1158; the `run-one` local execution config was missing the CratesRegistryStub initialization.

Initialize a local IndexManager when the target ecosystem is `cratesio`.
