### PR TITLE
Add default User-Agent to outbound HTTP requests

### DIFF
--- a/pkg/rebuild/meta/meta.go
+++ b/pkg/rebuild/meta/meta.go
@@ -24,6 +24,11 @@ import (
 )
 
 func NewRegistryMux(c httpx.BasicClient) rebuild.RegistryMux {
+	// Ensure requests have a User-Agent header. Some registries (e.g.,
+	// crates.io) reject requests without one.
+	if _, ok := c.(*httpx.WithUserAgent); !ok {
+		c = &httpx.WithUserAgent{BasicClient: c, UserAgent: rebuild.DefaultUserAgent}
+	}
 	return rebuild.RegistryMux{
 		Debian:   debianreg.HTTPRegistry{Client: c},
 		CratesIO: cratesreg.HTTPRegistry{Client: c},

--- a/pkg/rebuild/rebuild/http.go
+++ b/pkg/rebuild/rebuild/http.go
@@ -10,10 +10,17 @@ import (
 	"github.com/google/oss-rebuild/internal/httpx"
 )
 
+// DefaultUserAgent is used for outbound HTTP requests when no client is configured.
+// Some registries (e.g., crates.io) reject requests without a User-Agent header.
+const DefaultUserAgent = "oss-rebuild"
+
 // DoContext attempts to make an external HTTP request using the gateway client, if configured.
 func DoContext(ctx context.Context, req *http.Request) (*http.Response, error) {
 	if c, ok := ctx.Value(HTTPBasicClientID).(httpx.BasicClient); ok && c != nil {
 		return c.Do(req)
+	}
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", DefaultUserAgent)
 	}
 	return http.DefaultClient.Do(req)
 }


### PR DESCRIPTION
Some registries (e.g., crates.io) reject HTTP requests that lack a `User-Agent` header with `403 Forbidden`. This causes local execution (`run-one --local`, `run-bench --local`) to fail for CratesIO packages at two stages: Registry metadata fetch and Upstream artifact download

This PR adds a default `User-Agent` header; see issue #1327