### PR TITLE
Add OCI ecosystem

### DIFF
--- a/cmd/oss-rebuild/main.go
+++ b/cmd/oss-rebuild/main.go
@@ -98,6 +98,8 @@ The ecosystem is one of npm, pypi, or cratesio. For npm the artifact is the <pac
 					artifact = fmt.Sprintf("%s-%s-py3-none-any.whl", strings.ReplaceAll(pkg, "-", "_"), version)
 				case rebuild.NPM:
 					artifact = fmt.Sprintf("%s-%s.tgz", pkg, version)
+				case rebuild.OCI:
+					return errors.Errorf("%s artifact inference not implemented", ecosystem)
 				default:
 					return errors.Errorf("Unsupported ecosystem: \"%s\"", ecosystem)
 				}

--- a/internal/agent/logic.go
+++ b/internal/agent/logic.go
@@ -320,6 +320,8 @@ func (a *defaultAgent) ecosystemExpertise() []string {
 		return []string{}
 	case rebuild.Debian:
 		return []string{}
+	case rebuild.OCI:
+		return []string{}
 	default:
 		return []string{}
 	}

--- a/pkg/analyzer/enqueue.go
+++ b/pkg/analyzer/enqueue.go
@@ -38,7 +38,7 @@ func GCSEventToTargetEvent(event schema.GCSObjectEvent) (*schema.TargetEvent, er
 			return nil, errors.Errorf("unexpected object path length: path=%s parts=%d", event.Name, len(parts))
 		}
 		fallthrough
-	case rebuild.CratesIO, rebuild.PyPI, rebuild.Maven:
+	case rebuild.CratesIO, rebuild.PyPI, rebuild.Maven, rebuild.OCI:
 		// Format: ecosystem/package/version/artifact/rebuild.intoto.jsonl
 		ecosystem, pkg, version, artifact, obj = parts[0], parts[1], parts[2], parts[3], parts[4]
 	default:

--- a/pkg/build/baseimage.go
+++ b/pkg/build/baseimage.go
@@ -23,6 +23,7 @@ func DefaultBaseImageConfig() BaseImageConfig {
 		Ecosystems: map[rebuild.Ecosystem]string{
 			rebuild.Debian:   "docker.io/library/debian:stable-20251103-slim",
 			rebuild.Maven:    "docker.io/library/debian:stable-20251103-slim",
+			rebuild.OCI:      "docker.io/library/docker:29.5-dind-rootless",
 			rebuild.RubyGems: "docker.io/library/debian:stable-20251103-slim",
 		},
 	}

--- a/pkg/rebuild/meta/meta.go
+++ b/pkg/rebuild/meta/meta.go
@@ -11,6 +11,7 @@ import (
 	debianrb "github.com/google/oss-rebuild/pkg/rebuild/debian"
 	mavenrb "github.com/google/oss-rebuild/pkg/rebuild/maven"
 	npmrb "github.com/google/oss-rebuild/pkg/rebuild/npm"
+	ocirb "github.com/google/oss-rebuild/pkg/rebuild/oci"
 	pypirb "github.com/google/oss-rebuild/pkg/rebuild/pypi"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	rubygemsrb "github.com/google/oss-rebuild/pkg/rebuild/rubygems"
@@ -41,6 +42,7 @@ var AllRebuilders = map[rebuild.Ecosystem]rebuild.Rebuilder{
 	rebuild.Debian:   &debianrb.Rebuilder{},
 	rebuild.Maven:    &mavenrb.Rebuilder{},
 	rebuild.RubyGems: &rubygemsrb.Rebuilder{},
+	rebuild.OCI:      &ocirb.Rebuilder{},
 }
 
 func GuessArtifact(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
@@ -69,6 +71,8 @@ func GuessArtifact(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMu
 		return "", errors.New("maven not implemented")
 	case rebuild.RubyGems:
 		guess = rubygemsrb.ArtifactName(t)
+	case rebuild.OCI:
+		guess = "image.tar"
 	default:
 		return "", errors.New("unknown ecosystem")
 	}

--- a/pkg/rebuild/oci/rebuild.go
+++ b/pkg/rebuild/oci/rebuild.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"context"
+	"io"
+
+	"github.com/google/oss-rebuild/internal/gitx"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+)
+
+// Rebuilder implements the Rebuilder interface for OCI registries.
+type Rebuilder struct{}
+
+var _ rebuild.Rebuilder = &Rebuilder{}
+
+// InferRepo identifies the repository for an OCI target.
+func (r *Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+// CloneRepo clones the repository for an OCI target.
+func (r *Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repo string, opts *gitx.RepositoryOptions) (rebuild.RepoConfig, error) {
+	return rebuild.RepoConfig{}, errors.New("not implemented")
+}
+
+// InferStrategy identifies the rebuild strategy for an OCI target.
+func (r *Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux, cfg *rebuild.RepoConfig, hint rebuild.Strategy) (rebuild.Strategy, error) {
+	return nil, errors.New("not implemented")
+}
+
+// UsesTimewarp returns true if the rebuilder uses timewarp.
+func (r *Rebuilder) UsesTimewarp(rebuild.Input) bool {
+	return false
+}
+
+// Upstream returns the upstream artifact for an OCI target.
+func (r *Rebuilder) Upstream(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+// UpstreamURL returns the URL of the upstream artifact for an OCI target.
+func (r *Rebuilder) UpstreamURL(ctx context.Context, t rebuild.Target, mux rebuild.RegistryMux) (string, error) {
+	return "", errors.New("not implemented")
+}

--- a/pkg/rebuild/rebuild/models.go
+++ b/pkg/rebuild/rebuild/models.go
@@ -21,6 +21,7 @@ const (
 	Maven    Ecosystem = "maven"
 	Debian   Ecosystem = "debian"
 	RubyGems Ecosystem = "rubygems"
+	OCI      Ecosystem = "oci"
 )
 
 // Target is a single target we might attempt to rebuild.
@@ -68,6 +69,8 @@ func (t Target) ArchiveType() archive.Format {
 		return archive.UnknownFormat
 	case RubyGems:
 		// Gem files are tar archives containing data.tar.gz, metadata.gz, and checksums.yaml.gz
+		return archive.TarFormat
+	case OCI:
 		return archive.TarFormat
 	default:
 		return archive.UnknownFormat

--- a/tools/benchmark/artifact_backfill/main.go
+++ b/tools/benchmark/artifact_backfill/main.go
@@ -76,6 +76,7 @@ func backfillArtifacts(dataPath string) error {
 		rebuild.NPM:      ratex.NewBackoffLimiter(200 * time.Millisecond),
 		rebuild.Maven:    ratex.NewBackoffLimiter(700 * time.Millisecond),
 		rebuild.CratesIO: ratex.NewBackoffLimiter(1500 * time.Millisecond),
+		rebuild.OCI:      ratex.NewBackoffLimiter(1000 * time.Millisecond),
 	}
 	// Count total work needed
 	totalWork := 0

--- a/tools/benchmark/run/run.go
+++ b/tools/benchmark/run/run.go
@@ -287,6 +287,7 @@ func defaultLimiters() map[string]*ratex.BackoffLimiter {
 		// constraint of 1QPS. At minimum, we expect to make 4 calls per test.
 		"cratesio": ratex.NewBackoffLimiter(8 * time.Second),
 		"rubygems": ratex.NewBackoffLimiter(time.Second),
+		"oci":      ratex.NewBackoffLimiter(time.Second),
 	}
 }
 


### PR DESCRIPTION
The OCI spec includes [annotations](https://specs.opencontainers.org/image-spec/annotations/) which in some cases provide enough provenance to attempt rebuilding images.

This is not always included, but some containers include enough information for our purposes. For example, a recent alpine container includes these annotations:

```json
"annotations": {
	"com.docker.official-images.bashbrew.arch": "amd64",
	"org.opencontainers.image.created": "2026-04-15T20:01:12Z",
	"org.opencontainers.image.base.name": "scratch",
	"org.opencontainers.image.revision": "c68e08480b8fb053591ade7dbaffa2ea67db2f56",
"org.opencontainers.image.source": "https://github.com/alpinelinux/docker-alpine.git#c68e08480b8fb053591ade7dbaffa2ea67db2f56:x86_64",
	"org.opencontainers.image.url": "https://hub.docker.com/_/alpine",
	"org.opencontainers.image.version": "3.23.4"
}
```

This PR only adds the ecosystem name. Followup PRs will add a strategy and sanitization support.