### PR TITLE
Update local bootstrap tools example

### DIFF
--- a/docs/content/development.md
+++ b/docs/content/development.md
@@ -44,7 +44,7 @@ To execute a benchmark on your local machine, use the `run-bench` command with t
 > Some strategies depend on timewarp, which is served in production using a "bootstrap tools" bucket.
 > When running locally, a bucket can be specified using `--bootstrap-bucket` and `--bootstrap-version`.
 >
-> Some example values would be `--bootstrap-bucket=google-rebuild-bootstrap-tools --bootstrap-version=v0.0.0-20250428204534-b35098b3c7b7`
+> Some example values would be `--bootstrap-bucket=google-rebuild-bootstrap-tools --bootstrap-version=v0.0.0-20251211001310-499b5fb97512`
 
 ```bash
 cat <<EOF > /tmp/my-benchmark.json
@@ -62,10 +62,13 @@ cat <<EOF > /tmp/my-benchmark.json
   ]
 }
 EOF
-go run ./tools/ctl run-bench attest --local --max-concurrency 1 /tmp/my-benchmark.json
+go run ./tools/ctl run-bench attest --local --max-concurrency 1 \
+  --bootstrap-bucket=google-rebuild-bootstrap-tools \
+  --bootstrap-version=v0.0.0-20251211001310-499b5fb97512 \
+  /tmp/my-benchmark.json
 ```
 
-This will run the pypi_absl_micro.json benchmark locally (as opposed to the hosted execution platform). The local runner spins up a separate Docker container for each build in the benchmark. This guarantees that every build runs in a clean, isolated environment.
+This will run the benchmark locally (as opposed to the hosted execution platform). The local runner spins up a separate Docker container for each build in the benchmark. This guarantees that every build runs in a clean, isolated environment.
 
 If you have a large machine, you might want to increase the `--max-concurrency` beyond 1. One of the benefits of hosted (non-local) infrastructure is that extremely high concurrency is possible.
 

--- a/tools/ctl/command/infer/infer.go
+++ b/tools/ctl/command/infer/infer.go
@@ -243,7 +243,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 	}, Strategy: s}
 	resources := build.Resources{
 		ToolURLs: map[build.ToolType]string{
-			// Ex: https://storage.googleapis.com/google-rebuild-bootstrap-tools/v0.0.0-20250428204534-b35098b3c7b7/timewarp
+			// Ex: https://storage.googleapis.com/google-rebuild-bootstrap-tools/v0.0.0-20251211001310-499b5fb97512/timewarp
 			build.TimewarpTool: fmt.Sprintf("https://storage.googleapis.com/%s/%s/timewarp", cfg.BootstrapBucket, cfg.BootstrapVersion),
 		},
 		BaseImageConfig: build.DefaultBaseImageConfig(),


### PR DESCRIPTION
## Summary
- update the local `run-bench` bootstrap tools example to a version with current timewarp route support
- include the required bootstrap flags in the sample command

The previous example version predates the `cargogitarchive` timewarp route used by current crates.io strategy generation.
Following the old example, crates.io local builds can fail inside the build container with HTTP 400 `unsupported platform` from timewarp, which is hard to diagnose from the logs.

## Testing
- Ran the updated example command as written (`pypi`, `absl_py` 2.0.0): 1/1, stabilized match
- Confirmed `v0.0.0-20251211001310-499b5fb97512` is the only published bootstrap version containing the `cargogitarchive` route (bucket listing and git history; added in #833)
