### PR TITLE
Fix Rust version hint for single-element arrays

### DIFF
--- a/pkg/rebuild/cratesio/hints.go
+++ b/pkg/rebuild/cratesio/hints.go
@@ -19,8 +19,8 @@ var (
 	resolverTwoPattern = regexp.MustCompile(`(?m)^\s*resolver\s*=\s*["\']?2["\']?\s*$`)
 	// prettyArrayPattern detects pretty-printed arrays (Rust 1.60+)
 	prettyArrayPattern = regexp.MustCompile(`(?s)\[\s*\n\s+.*\n\s*\]`)
-	// cuddledArrayPattern detects cuddled/single-line arrays (Rust < 1.60)
-	cuddledArrayPattern = regexp.MustCompile(`(?m)^\s*\w+\s*=\s*\[[^\n\[\]]*\]`)
+	// inlineArrayLine matches array values that Cargo kept on one line.
+	inlineArrayLine = regexp.MustCompile(`(?m)^\s*[\w-]+\s*=\s*(\[[^\n\[\]]*\])\s*$`)
 	// modernHeaderPattern detects a change in the Cargo.toml header (Rust 1.55+)
 	modernHeaderPattern = regexp.MustCompile(`#.*to registry \(e\.g\., crates\.io\) dependencies\.`)
 	// docExamplesRegex detects the addition of the scrape indicator (Rust 1.67+)
@@ -36,6 +36,20 @@ func hasPackageEdition2024(cargoTomlText string) bool {
 	return toml.Unmarshal([]byte(cargoTomlText), &manifest) == nil && manifest.Package.Edition == "2024"
 }
 
+// hasInlineMultiElementArray reports whether Cargo.toml contains an inline
+// array with at least two top-level elements.
+func hasInlineMultiElementArray(cargoTomlText string) bool {
+	for _, m := range inlineArrayLine.FindAllStringSubmatch(cargoTomlText, -1) {
+		var value struct {
+			Array []any `toml:"array"`
+		}
+		if err := toml.Unmarshal([]byte("array = "+m[1]), &value); err == nil && len(value.Array) >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
 // detectRustVersionBounds analyzes Cargo.toml for structural patterns that indicate
 // minimum Rust version requirements based on tooling behavior changes.
 func detectRustVersionBounds(cargoTomlText string) (lo, hi string) {
@@ -49,8 +63,8 @@ func detectRustVersionBounds(cargoTomlText string) (lo, hi string) {
 	}
 	if prettyArrayPattern.MatchString(cargoTomlText) {
 		lo = max("1.60.0", lo) // Before which arrays were cuddled
-	} else if cuddledArrayPattern.MatchString(cargoTomlText) {
-		hi = min("1.59.0", hi) // After which arrays were pretty-printed
+	} else if hasInlineMultiElementArray(cargoTomlText) {
+		hi = min("1.59.0", hi) // After which multi-element arrays were pretty-printed
 	}
 	if modernHeaderPattern.MatchString(cargoTomlText) {
 		lo = max("1.55.0", lo)

--- a/pkg/rebuild/cratesio/hints_test.go
+++ b/pkg/rebuild/cratesio/hints_test.go
@@ -221,7 +221,7 @@ doc-scrape-examples = false
 			wantHi: "",
 		},
 		{
-			name: "async-native-tls 0.4.0 (cuddled categories)",
+			name: "async-native-tls 0.4.0 (inline categories)",
 			cargoToml: `
 # Before Rust 1.55, crates.io would automatically add this header to registry (e.g., crates.io) dependencies.
 [package]
@@ -230,8 +230,19 @@ name = "async-native-tls"
 version = "0.4.0"
 categories = ["asynchronous", "cryptography", "network-programming"]
 `,
-			wantLo: "1.55.0", // modernHeader=1.55, cuddledArray (hi=1.59) prevents bump to 1.64
-			wantHi: "1.59.0", // cuddledArray=1.59
+			wantLo: "1.55.0", // modernHeader=1.55, inline multi-element array (hi=1.59) prevents bump to 1.64
+			wantHi: "1.59.0", // inline multi-element array=1.59
+		},
+		{
+			name: "Single-element inline array (Modern Header)",
+			cargoToml: `
+# Before Rust 1.55, crates.io would automatically add this header to registry (e.g., crates.io) dependencies.
+[package]
+name = "my-crate"
+keywords = ["one"]
+`,
+			wantLo: "1.64.0", // modernHeader=1.55, no resolver=2 bumps to 1.64
+			wantHi: "",
 		},
 	}
 
@@ -243,6 +254,29 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 			}
 			if gotHi != tt.wantHi {
 				t.Errorf("detectRustVersionBounds() gotHi = %v, want %v", gotHi, tt.wantHi)
+			}
+		})
+	}
+}
+
+func TestHasInlineMultiElementArray(t *testing.T) {
+	tests := []struct {
+		name      string
+		cargoToml string
+		want      bool
+	}{
+		{name: "Empty", cargoToml: `keywords = []`, want: false},
+		{name: "Single element", cargoToml: `keywords = ["one"]`, want: false},
+		{name: "Comma in string", cargoToml: `authors = ["Example, Inc"]`, want: false},
+		{name: "Inline table", cargoToml: `assets = [{ source = "README.md", dest = "share/doc" }]`, want: false},
+		{name: "Multiple elements", cargoToml: `keywords = ["one", "two"]`, want: true},
+		{name: "Hyphenated key", cargoToml: `crate-type = ["cdylib", "rlib"]`, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasInlineMultiElementArray(tt.cargoToml); got != tt.want {
+				t.Errorf("hasInlineMultiElementArray() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The formatting change in Cargo 1.60 only moved multi-element arrays to multiple lines. Empty and single-element arrays remained inline. The current hint treats any inline array as evidence of Cargo 1.59 or earlier, so a modern normalized manifest containing only an array such as `keywords = ["one"]` gets an incorrect upper bound.

Only apply the upper bound when an inline array has at least two top-level elements. Parse the matched array with the existing TOML dependency so commas inside strings and inline tables are handled correctly.

Testing:
- `go test ./pkg/...`
- `go vet ./pkg/...`