### PR TITLE
Use crate publish time for crates.io inference

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -226,7 +226,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	rustVersion := vmeta.RustVersion
 	if rustVersion == "" {
 		// NOTE: Give a week's margin to allow for toolchain upgrades. Maybe raise.
-		rustVersion, err = reg.RustVersionAt(vmeta.Updated.Add(-7 * 24 * time.Hour))
+		rustVersion, err = reg.RustVersionAt(vmeta.Created.Add(-7 * 24 * time.Hour))
 		if err != nil {
 			return nil, errors.New("rust version heuristic failed")
 		}
@@ -275,7 +275,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 		}
 		resp, err := stub(ctx, cratesregistryservice.FindRegistryCommitRequest{
 			LockfileBase64: base64.StdEncoding.EncodeToString(lockContent),
-			PublishedTime:  vmeta.Updated.Format(time.RFC3339),
+			PublishedTime:  vmeta.Created.Format(time.RFC3339),
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to call registry service")

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -37,6 +37,7 @@ func TestInferStrategy(t *testing.T) {
 		wantFn           func(*gitxtest.Repository) rebuild.Strategy
 		wantErr          bool
 		registryResponse *cratesregistryservice.FindRegistryCommitResponse
+		wantPublishTime  string
 	}{
 		{
 			name: "ref from cargo_vcs_info",
@@ -74,7 +75,7 @@ func TestInferStrategy(t *testing.T) {
 			},
 		},
 		{
-			name: "rust_version from updated_at",
+			name: "rust_version from created_at",
 			repo: `commits:
   - id: initial-commit
     files:
@@ -90,7 +91,7 @@ func TestInferStrategy(t *testing.T) {
         name = "serde"
         version = "1.0.150"
 `,
-			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","updated_at":"2022-12-12T00:25:28.357Z"}}`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-12-12T00:25:28.357Z","updated_at":"2024-06-01T00:00:00Z"}}`,
 			files: []archive.TarEntry{
 				{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
 			},
@@ -363,7 +364,7 @@ func TestInferStrategy(t *testing.T) {
         name = "serde"
         version = "1.0.150"
 `,
-			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","rust_version": "1.68.0", "updated_at":"2023-01-01T00:00:00Z"}}`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","rust_version": "1.68.0", "created_at":"2023-01-01T00:00:00Z","updated_at":"2024-06-01T00:00:00Z"}}`,
 			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
 				return []archive.TarEntry{
 					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
@@ -381,6 +382,7 @@ version = "1.0.150"
 			registryResponse: &cratesregistryservice.FindRegistryCommitResponse{
 				CommitHash: "abcd1234567890abcdef1234567890abcdef1234",
 			},
+			wantPublishTime: "2023-01-01T00:00:00Z",
 			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
 				return &CratesIOCargoPackage{
 					Location: rebuild.Location{
@@ -572,6 +574,9 @@ version = 3
 			ctx := context.Background()
 			if tc.registryResponse != nil {
 				mockStub := func(ctx context.Context, req cratesregistryservice.FindRegistryCommitRequest) (*cratesregistryservice.FindRegistryCommitResponse, error) {
+					if tc.wantPublishTime != "" && req.PublishedTime != tc.wantPublishTime {
+						t.Errorf("PublishedTime = %q, want %q", req.PublishedTime, tc.wantPublishTime)
+					}
 					return tc.registryResponse, nil
 				}
 				ctx = context.WithValue(ctx, rebuild.CratesRegistryStubID, api.StubFn[cratesregistryservice.FindRegistryCommitRequest, cratesregistryservice.FindRegistryCommitResponse](mockStub))


### PR DESCRIPTION
Crates.io updates `updated_at` when version metadata changes, including yank and unyank operations. Inference currently uses this mutable value both to choose the fallback Rust version and to anchor registry index resolution, so later updates can change the inferred strategy for an existing artifact.

Use `created_at`, the version publish timestamp, for both decisions. The regression tests keep the timestamps distinct and verify the selected Rust version and registry request time.

Testing:
- `go run ./ci -v test`
- `go run ./ci -v lint`
- `go run ./ci -v fmt-check`