### PR TITLE
Fix resolver version hint upper bound

### DIFF
--- a/pkg/rebuild/cratesio/hints.go
+++ b/pkg/rebuild/cratesio/hints.go
@@ -15,8 +15,8 @@ import (
 var (
 	// debugDenormalizedRegex detects debug = bool (Rust 1.71+ normalized boolean debug to integer)
 	debugDenormalizedRegex = regexp.MustCompile(`(?m)^\s*debug\s*=\s*(true|false)\s*$`)
-	// resolverTwoPattern detects resolver = "2" (became default and was removed in Rust 1.64+)
-	resolverTwoPattern = regexp.MustCompile(`(?m)^\s*resolver\s*=\s*["\']?2["\']?\s*$`)
+	// resolverTwoPattern detects candidate resolver = "2" lines before section-aware TOML parsing.
+	resolverTwoPattern = regexp.MustCompile(`(?m)^\s*resolver\s*=\s*["']2["']\s*$`)
 	// prettyArrayPattern detects pretty-printed arrays (Rust 1.60+)
 	prettyArrayPattern = regexp.MustCompile(`(?s)\[\s*\n\s+.*\n\s*\]`)
 	// inlineArrayLine matches array values that Cargo kept on one line.
@@ -50,6 +50,23 @@ func hasInlineMultiElementArray(cargoTomlText string) bool {
 	return false
 }
 
+// hasResolverTwo reports whether resolver 2 is set in a supported manifest section.
+func hasResolverTwo(cargoTomlText string) bool {
+	if !resolverTwoPattern.MatchString(cargoTomlText) {
+		return false
+	}
+	var manifest struct {
+		Package struct {
+			Resolver string `toml:"resolver"`
+		} `toml:"package"`
+		Workspace struct {
+			Resolver string `toml:"resolver"`
+		} `toml:"workspace"`
+	}
+	return toml.Unmarshal([]byte(cargoTomlText), &manifest) == nil &&
+		(manifest.Package.Resolver == "2" || manifest.Workspace.Resolver == "2")
+}
+
 // detectRustVersionBounds analyzes Cargo.toml for structural patterns that indicate
 // minimum Rust version requirements based on tooling behavior changes.
 func detectRustVersionBounds(cargoTomlText string) (lo, hi string) {
@@ -71,8 +88,7 @@ func detectRustVersionBounds(cargoTomlText string) (lo, hi string) {
 	} else {
 		hi = min("1.54.0", hi)
 	}
-	if resolverTwoPattern.MatchString(cargoTomlText) {
-		hi = min("1.63.0", hi) // After which resolver 2 became default and was omitted
+	if hasResolverTwo(cargoTomlText) {
 		lo = max("1.51.0", lo)
 	} else {
 		// If resolver pattern not found, we know the version lies outside the above range

--- a/pkg/rebuild/cratesio/hints.go
+++ b/pkg/rebuild/cratesio/hints.go
@@ -15,8 +15,6 @@ import (
 var (
 	// debugDenormalizedRegex detects debug = bool (Rust 1.71+ normalized boolean debug to integer)
 	debugDenormalizedRegex = regexp.MustCompile(`(?m)^\s*debug\s*=\s*(true|false)\s*$`)
-	// resolverTwoPattern detects candidate resolver = "2" lines before section-aware TOML parsing.
-	resolverTwoPattern = regexp.MustCompile(`(?m)^\s*resolver\s*=\s*["']2["']\s*$`)
 	// prettyArrayPattern detects pretty-printed arrays (Rust 1.60+)
 	prettyArrayPattern = regexp.MustCompile(`(?s)\[\s*\n\s+.*\n\s*\]`)
 	// inlineArrayLine matches array values that Cargo kept on one line.
@@ -52,9 +50,6 @@ func hasInlineMultiElementArray(cargoTomlText string) bool {
 
 // hasResolverTwo reports whether resolver 2 is set in a supported manifest section.
 func hasResolverTwo(cargoTomlText string) bool {
-	if !resolverTwoPattern.MatchString(cargoTomlText) {
-		return false
-	}
 	var manifest struct {
 		Package struct {
 			Resolver string `toml:"resolver"`

--- a/pkg/rebuild/cratesio/hints_test.go
+++ b/pkg/rebuild/cratesio/hints_test.go
@@ -60,7 +60,7 @@ name = "my-crate"
 resolver = "2"
 `,
 			wantLo: "1.51.0", // resolver=2 sets lo=1.51
-			wantHi: "1.54.0", // No modern header sets hi=1.54, resolver=2 sets hi=1.63. min(1.54, 1.63) = 1.54
+			wantHi: "1.54.0", // No modern header sets hi=1.54
 		},
 		{
 			name: "Resolver Two (Modern Header)",
@@ -72,8 +72,43 @@ name = "my-crate"
 [workspace]
 resolver = '2'
 `,
-			wantLo: "1.55.0", // modernHeader sets lo=1.55, resolver=2 sets lo=1.51. max(1.55, 1.51) = 1.55
-			wantHi: "1.63.0", // resolver=2 sets hi=1.63
+			wantLo: "1.55.0", // modernHeader=1.55, resolver=2=1.51. Max is 1.55
+			wantHi: "",
+		},
+		{
+			name: "Package Resolver Two Has No Upper Bound",
+			cargoToml: `
+# Before Rust 1.55, crates.io would automatically add this header to registry (e.g., crates.io) dependencies.
+[package]
+name = "my-crate"
+resolver = "2"
+`,
+			wantLo: "1.55.0", // modernHeader=1.55, resolver=2=1.51. Max is 1.55
+			wantHi: "",       // resolver=2 is still retained after Cargo 1.63
+		},
+		{
+			name: "Resolver in Metadata Is Not Evidence",
+			cargoToml: `
+[package]
+name = "my-crate"
+
+[package.metadata.commands]
+resolver = "2"
+`,
+			wantLo: "",
+			wantHi: "1.50.0", // Existing no-resolver rule still applies
+		},
+		{
+			name: "Resolver in Multiline String Is Not Evidence",
+			cargoToml: `
+[package]
+name = "my-crate"
+description = """
+resolver = "2"
+"""
+`,
+			wantLo: "",
+			wantHi: "1.50.0", // Existing no-resolver rule still applies
 		},
 		{
 			name: "Pretty Array (Modern Header)",
@@ -137,7 +172,7 @@ resolver = "2"
 debug = false
 `,
 			wantLo: "1.51.0", // resolver=2 sets lo=1.51
-			wantHi: "1.54.0", // debugDenormalized=1.70, no modernHeader=1.54, resolver=2=1.63. Min is 1.54
+			wantHi: "1.54.0", // No modern header sets hi=1.54
 		},
 		{
 			name: "All Hi Bounds (Modern Header)",
@@ -153,7 +188,7 @@ resolver = "2"
 debug = false
 `,
 			wantLo: "1.55.0", // modernHeader=1.55, resolver=2=1.51. Max is 1.55
-			wantHi: "1.63.0", // debugDenormalized=1.70, resolver=2=1.63. Min is 1.63
+			wantHi: "1.70.0", // debugDenormalized=1.70
 		},
 		{
 			name: "All Bounds (Modern Header)",
@@ -173,7 +208,7 @@ resolver = "2"
 debug = false
 `,
 			wantLo: "1.67.0", // docExamples=1.67, prettyArray=1.60, modernHeader=1.55, resolver=2=1.51. Max is 1.67
-			wantHi: "1.63.0", // debugDenormalized=1.70, resolver=2=1.63. Min is 1.63
+			wantHi: "1.70.0", // debugDenormalized=1.70
 		},
 		{
 			name: "aho-corasick 1.0.4 (debug = 2, pretty arrays)",

--- a/pkg/rebuild/cratesio/hints_test.go
+++ b/pkg/rebuild/cratesio/hints_test.go
@@ -87,6 +87,17 @@ resolver = "2"
 			wantHi: "",       // resolver=2 is still retained after Cargo 1.63
 		},
 		{
+			name: "Package Resolver Two With Trailing Comment",
+			cargoToml: `
+# Before Rust 1.55, crates.io would automatically add this header to registry (e.g., crates.io) dependencies.
+[package]
+name = "my-crate"
+resolver = "2" # Explicitly retain resolver 2.
+`,
+			wantLo: "1.55.0",
+			wantHi: "",
+		},
+		{
 			name: "Resolver in Metadata Is Not Evidence",
 			cargoToml: `
 [package]


### PR DESCRIPTION
## What

Treat an explicit `resolver = "2"` as a lower-bound hint only, and parse the manifest before accepting it as evidence.

## Why

The current hint caps the Cargo version at 1.63, but an explicitly written resolver setting is retained by later Cargo versions. The line-based match can also fire on unrelated metadata or multiline string contents.

The updated check accepts `resolver = "2"` only from the package or workspace tables, keeps the Cargo 1.51 lower bound, and removes the incorrect upper bound.

## Testing

- Verified with Cargo 1.50, 1.51, 1.55, 1.56, 1.60, 1.63, 1.64, and current stable: 1.50 rejects resolver 2; every tested version from 1.51 onward accepts and retains it
- `go test ./...`
- `go vet ./...`
