### PR TITLE
Fix invalidated git object accesses

### DIFF
--- a/internal/gitcache/client.go
+++ b/internal/gitcache/client.go
@@ -10,15 +10,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/filesystem"
@@ -96,19 +93,16 @@ func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem
 		return nil, errors.New("Unsupported opt")
 	}
 	// Determine extraction target: use the filesystem directly for
-	// filesystem.Storage, otherwise stage via a temp directory.
+	// filesystem.Storage, otherwise stage via an in-memory storer.
+	// NOTE: The staging storer must not be cleaned up as CopyStorer is only a
+	// shallow-copy and retains indirect references to the staging storer.
 	var extractFS billy.Filesystem
-	var needsStaging bool
+	var stagingStorer *filesystem.Storage
 	if sf, ok := s.(*filesystem.Storage); ok {
 		extractFS = sf.Filesystem()
 	} else {
-		needsStaging = true
-		tmpDir, err := os.MkdirTemp("", "gitcache-clone-*")
-		if err != nil {
-			return nil, errors.Wrap(err, "creating staging directory")
-		}
-		defer os.RemoveAll(tmpDir)
-		extractFS = osfs.New(tmpDir)
+		stagingStorer = gitx.NewInMemoryStorer()
+		extractFS = stagingStorer.Filesystem()
 	}
 	// Use ref if specified in CloneOptions
 	var ref string
@@ -137,8 +131,7 @@ func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem
 		return nil, errors.Wrap(err, "tar extract error")
 	}
 	// Copy staged data into the target storer if needed.
-	if needsStaging {
-		stagingStorer := filesystem.NewStorage(extractFS, cache.NewObjectLRUDefault())
+	if stagingStorer != nil {
 		if err := gitx.CopyStorer(s, stagingStorer); err != nil {
 			return nil, errors.Wrap(err, "copying from staging to storage")
 		}

--- a/internal/gitcache/client_test.go
+++ b/internal/gitcache/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-billy/v5"
@@ -24,13 +25,18 @@ import (
 	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
 )
 
-const testRepoYAML = `
+// bigContent exceeds go-git's 16KiB small-object threshold, so packfile reads
+// will access it lazily via the backed storer.
+var bigContent = strings.Repeat("x", 64*1024)
+
+var testRepoYAML = `
 commits:
   - id: initial
     branch: master
     message: "Initial commit"
     files:
       README.md: "hello world"
+      big.bin: "` + bigContent + `"
 `
 
 // setupCloneTestServer creates a test HTTP server that mimics the gitcache
@@ -45,11 +51,17 @@ func setupCloneTestServer(t *testing.T, yamlSpec string) Client {
 	if err := os.MkdirAll(gitDir, 0o755); err != nil {
 		t.Fatalf("failed to create .git dir: %v", err)
 	}
-	if _, err := gitxtest.CreateRepoFromYAML(yamlSpec, &gitxtest.RepositoryOptions{
+	repo, err := gitxtest.CreateRepoFromYAML(yamlSpec, &gitxtest.RepositoryOptions{
 		Storer:   filesystem.NewStorage(osfs.New(gitDir), cache.NewObjectLRUDefault()),
 		Worktree: osfs.New(repoDir),
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("failed to create test repo: %v", err)
+	}
+	// Repack loose objects into a packfile to match production tarballs
+	// (cached repos are packed, and only packed objects are read lazily).
+	if err := repo.RepackObjects(&git.RepackConfig{}); err != nil {
+		t.Fatalf("failed to repack test repo: %v", err)
 	}
 	// Remove the index to match production behavior (bare clone has no index).
 	os.Remove(filepath.Join(gitDir, "index"))
@@ -143,6 +155,19 @@ func TestClientClone(t *testing.T) {
 			}
 			if commit.Message != "Initial commit" {
 				t.Errorf("commit message = %q, want %q", commit.Message, "Initial commit")
+			}
+			// Verify a blob above go-git's small-object threshold is readable
+			// after Clone returns to ensure staged storer remains accessible.
+			f, err := commit.File("big.bin")
+			if err != nil {
+				t.Fatalf("File(big.bin) error = %v", err)
+			}
+			contents, err := f.Contents()
+			if err != nil {
+				t.Fatalf("Contents() error = %v", err)
+			}
+			if len(contents) != len(bigContent) {
+				t.Errorf("big.bin length = %d, want %d", len(contents), len(bigContent))
 			}
 			// For checkout case, verify worktree file exists.
 			if !tc.noCheckout {

--- a/internal/gitx/clone.go
+++ b/internal/gitx/clone.go
@@ -20,7 +20,6 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/filesystem"
@@ -267,13 +266,19 @@ func NativeClone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt
 	// Copy staging to target storage if needed
 	if needsStaging {
 		stagingFS := osfs.New(targetDir)
-		stagingStorer := filesystem.NewStorage(stagingFS, cache.NewObjectLRUDefault())
 		if sf, ok := s.(*filesystem.Storage); ok {
 			if err := billyx.CopyFS(sf.Filesystem(), stagingFS); err != nil {
 				return nil, errors.Wrap(err, "copying from staging to storage filesystem")
 			}
 		} else {
-			if err := CopyStorer(s, stagingStorer); err != nil {
+			// CopyStorer populates the target storer with lazily-read objects
+			// still backed by the staged packfile, so first move the staged
+			// bytes into an in-memory storer that can outlive targetDir.
+			retained := NewInMemoryStorer()
+			if err := billyx.CopyFS(retained.Filesystem(), stagingFS); err != nil {
+				return nil, errors.Wrap(err, "copying staging to retained storer")
+			}
+			if err := CopyStorer(s, retained); err != nil {
 				return nil, errors.Wrap(err, "copying from staging to memory storage")
 			}
 		}

--- a/internal/gitx/clone_test.go
+++ b/internal/gitx/clone_test.go
@@ -198,6 +198,53 @@ commits:
 	}
 }
 
+func TestNativeClone_MemoryStorageLargeObject(t *testing.T) {
+	if !NativeGitAvailable() {
+		t.Skip("native git not available")
+	}
+	ctx := context.Background()
+	// A blob above go-git's 16KiB small-object threshold is read lazily from
+	// the packfile rather than materialized, so reading it after NativeClone
+	// returns catches the staged objects not outliving the temp clone dir.
+	bigContent := strings.Repeat("x", 64*1024)
+	yamlRepo := `
+commits:
+  - id: initial
+    branch: master
+    message: "Initial commit"
+    files:
+      README.md: "hello"
+      big.bin: "` + bigContent + `"
+`
+	upstreamURL := setupLocalRepo(t, yamlRepo)
+	repo, err := NativeClone(ctx, memory.NewStorage(), nil, &git.CloneOptions{
+		URL:        upstreamURL,
+		NoCheckout: true,
+	})
+	if err != nil {
+		t.Fatalf("NativeClone failed: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("failed to get HEAD: %v", err)
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("failed to get commit: %v", err)
+	}
+	f, err := commit.File("big.bin")
+	if err != nil {
+		t.Fatalf("failed to get big.bin: %v", err)
+	}
+	contents, err := f.Contents()
+	if err != nil {
+		t.Fatalf("failed to read big.bin: %v", err)
+	}
+	if len(contents) != len(bigContent) {
+		t.Errorf("big.bin length = %d, want %d", len(contents), len(bigContent))
+	}
+}
+
 func TestNativeClone_RemoteTrackingRefs(t *testing.T) {
 	if !NativeGitAvailable() {
 		t.Skip("native git not available")

--- a/internal/gitx/storage.go
+++ b/internal/gitx/storage.go
@@ -4,8 +4,21 @@
 package gitx
 
 import (
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/storage"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 )
+
+// NewInMemoryStorer returns git storage backed by an in-memory filesystem,
+// tuned for per-request, single-write-then-read-only use: KeepDescriptors
+// retains the parsed packfile across object reads and ExclusiveAccess elides
+// redundant packfile re-scans, which is safe when using read-only.
+// NOTE: KeepDescriptors normally requires calling Close to cleanup but this is
+// not required for memfs.
+func NewInMemoryStorer() *filesystem.Storage {
+	return filesystem.NewStorageWithOptions(memfs.New(), cache.NewObjectLRUDefault(), filesystem.Options{KeepDescriptors: true, ExclusiveAccess: true})
+}
 
 // Storer augments go-git's Storer to provide the capability to re-initialize the underlying state.
 type Storer struct {

--- a/internal/gitx/storer.go
+++ b/internal/gitx/storer.go
@@ -11,6 +11,10 @@ import (
 
 // CopyStorer copies all git data from src to dst storage.
 // This includes objects, references, config, and shallow commits.
+// NOTE: dst may end up holding lazily-read objects still backed by src's
+// underlying storage (e.g. memory.Storage retains packfile-backed object
+// references), so src's backing store must remain live and unmodified for
+// the lifetime of dst.
 // NOTE: This is very slow for large repos. If possible, prefer
 // copying the underlying metadata content to the underlying destination.
 func CopyStorer(dst, src storage.Storer) error {


### PR DESCRIPTION
The previous approach to using gitcache and the native git cli via an
intermediate filesystem-based Storer didn't always work: go-git only
eagerly copies objects below a certain size threshold and will leave a
pointer back to the underlying storage for larger ones. Given we cleaned
up the intermediate Storer's filesystem after copying it out, that left
the large-object pointers invalid causing a crash.

This change addresses that error case by using in-memory storer for
intermediate use. While we now need to leak the storer beyond the
return, using an in-memory storer means we tie the GC lifetime to that
of the Clone instead of it leaking past even the process exit as would
be the case using the os filesystem.

Fixes #1343