### PR TITLE
Use more efficient storers for inference

### DIFF
--- a/cmd/inference/main.go
+++ b/cmd/inference/main.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 
 	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/api/inferenceservice"
 	"github.com/google/oss-rebuild/internal/gitcache"
@@ -57,7 +56,7 @@ func InferInit(ctx context.Context) (*inferenceservice.InferDeps, error) {
 	d.RepoOptF = func() *gitx.RepositoryOptions {
 		return &gitx.RepositoryOptions{
 			Worktree: memfs.New(),
-			Storer:   memory.NewStorage(),
+			Storer:   gitx.NewInMemoryStorer(),
 		}
 	}
 	if *cratesRegistryURL != "" {

--- a/tools/benchmark/run/local.go
+++ b/tools/benchmark/run/local.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 
 	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/cache"
 	"github.com/google/oss-rebuild/internal/gitcache"
@@ -125,7 +124,7 @@ func (s *localExecutionService) infer(ctx context.Context, t rebuild.Target, mux
 	if err != nil {
 		return nil, err
 	}
-	rcfg, err := rebuilder.CloneRepo(ctx, t, repo, &gitx.RepositoryOptions{Worktree: memfs.New(), Storer: memory.NewStorage()})
+	rcfg, err := rebuilder.CloneRepo(ctx, t, repo, &gitx.RepositoryOptions{Worktree: memfs.New(), Storer: gitx.NewInMemoryStorer()})
 	if err != nil {
 		return nil, err
 	}

--- a/tools/ctl/command/infer/infer.go
+++ b/tools/ctl/command/infer/infer.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-billy/v5/osfs"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/api/inferenceservice"
 	"github.com/google/oss-rebuild/internal/gitcache"
@@ -187,7 +186,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 			RepoOptF: func() *gitx.RepositoryOptions {
 				return &gitx.RepositoryOptions{
 					Worktree: memfs.New(),
-					Storer:   memory.NewStorage(),
+					Storer:   gitx.NewInMemoryStorer(),
 				}
 			},
 			CratesRegistryStub: regstub,


### PR DESCRIPTION
This uses the more efficient hybrid filesystem-memfs storers which, for
the gitcache route, speed up clones by ~2.5x at no loss of efficiency
for uncached pathways.