### PR TITLE
Validate inherited Cargo workspace versions

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -242,8 +242,12 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	if ct.Name != name {
 		return nil, errors.Errorf("mismatched name [expected=%s,actual=%s,heuristic=%s]", name, ct.Name, rcfg.Dir)
 	}
-	if ct.Version() != version && ct.Version() != reg.WorkspaceVersion {
-		return nil, errors.Errorf("mismatched version [expected=%s,actual=%s]", version, ct.Version())
+	actualVersion, err := cargoPackageVersion(tree, path.Join(dir, "Cargo.toml"), &ct)
+	if err != nil {
+		return nil, errors.Wrap(err, "resolving Cargo.toml version")
+	}
+	if actualVersion != version {
+		return nil, errors.Errorf("mismatched version [expected=%s,actual=%s]", version, actualVersion)
 	}
 	// NOTE: Give a week's margin to allow for toolchain upgrades. Maybe raise.
 	rustVersion, err := reg.RustVersionAt(vmeta.Created.Add(-7 * 24 * time.Hour))
@@ -362,6 +366,52 @@ func getFileFromCrate(crate io.Reader, path string) ([]byte, error) {
 	return nil, fs.ErrNotExist
 }
 
+// cargoPackageVersion resolves package.version, including workspace inheritance.
+func cargoPackageVersion(tree *object.Tree, manifestPath string, cargoTOML *reg.CargoTOML) (string, error) {
+	version := cargoTOML.Version()
+	if version != reg.WorkspaceVersion {
+		return version, nil
+	}
+
+	if workspacePath := cargoTOML.WorkspacePath(); workspacePath != "" {
+		rootPath := path.Join(path.Dir(manifestPath), workspacePath, "Cargo.toml")
+		root, err := getCargoTOML(tree, rootPath)
+		if err != nil {
+			return "", errors.Wrapf(err, "reading workspace manifest [path=%s]", rootPath)
+		}
+		if root.Workspace == nil || root.Workspace.Package.Version == "" {
+			return "", errors.Errorf("workspace package version not found [path=%s]", rootPath)
+		}
+		return root.Workspace.Package.Version, nil
+	}
+
+	for dir := path.Dir(manifestPath); ; dir = path.Dir(dir) {
+		rootPath := path.Join(dir, "Cargo.toml")
+		root := cargoTOML
+		if rootPath != manifestPath {
+			candidate, err := getCargoTOML(tree, rootPath)
+			if err != nil && err != object.ErrFileNotFound {
+				return "", errors.Wrapf(err, "reading workspace manifest [path=%s]", rootPath)
+			}
+			if err == nil {
+				root = &candidate
+			} else {
+				root = nil
+			}
+		}
+		if root != nil && root.Workspace != nil {
+			if root.Workspace.Package.Version == "" {
+				return "", errors.Errorf("workspace package version not found [path=%s]", rootPath)
+			}
+			return root.Workspace.Package.Version, nil
+		}
+		if dir == "." {
+			break
+		}
+	}
+	return "", errors.Errorf("workspace manifest not found [path=%s]", manifestPath)
+}
+
 // findAndValidateCargoTOML ensures the package config has the expected name and version, or finds a new version if necessary.
 func findAndValidateCargoTOML(repo *git.Repository, c *object.Commit, name, version, guess string) (string, error) {
 	t, err := c.Tree()
@@ -371,8 +421,8 @@ func findAndValidateCargoTOML(repo *git.Repository, c *object.Commit, name, vers
 	path := path.Join(guess, "Cargo.toml")
 	orig, err := getCargoTOML(t, path)
 	cargoTOML := &orig
-	// TODO: Validate workspace version.
-	if err != nil || cargoTOML.Name != name || (cargoTOML.Version() != version && cargoTOML.Version() != reg.WorkspaceVersion) {
+	actualVersion, versionErr := cargoPackageVersion(t, path, cargoTOML)
+	if err != nil || cargoTOML.Name != name || versionErr != nil || actualVersion != version {
 		cargoTOML, path, err = findCargoTOML(repo, c, name)
 	}
 	if err == object.ErrFileNotFound {
@@ -383,8 +433,12 @@ func findAndValidateCargoTOML(repo *git.Repository, c *object.Commit, name, vers
 		return path, errors.Wrapf(err, "unknown Cargo.toml error")
 	} else if cargoTOML.Name != name {
 		return path, errors.Errorf("mismatched name [expected=%s,actual=%s,path=%s]", name, cargoTOML.Name, guess)
-	} else if cargoTOML.Version() != version && cargoTOML.Version() != reg.WorkspaceVersion {
-		return path, errors.Errorf("mismatched version [expected=%s,actual=%s]", version, cargoTOML.Version())
+	}
+	actualVersion, err = cargoPackageVersion(t, path, cargoTOML)
+	if err != nil {
+		return path, errors.Wrap(err, "resolving Cargo.toml version")
+	} else if actualVersion != version {
+		return path, errors.Errorf("mismatched version [expected=%s,actual=%s]", version, actualVersion)
 	}
 	return path, nil
 }

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -46,6 +46,8 @@ func getCargoTOML(tree *object.Tree, path string) (ct reg.CargoTOML, err error) 
 	if err != nil {
 		return ct, err
 	}
+	// Cargo tolerates a UTF-8 byte order mark in manifests; go-toml does not.
+	p = strings.TrimPrefix(p, "\uFEFF")
 	return ct, toml.Unmarshal([]byte(p), &ct)
 }
 

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"path"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -79,6 +81,7 @@ func TestInferStrategy(t *testing.T) {
 		metadata         string
 		files            []archive.TarEntry
 		filesFn          func(*gitxtest.Repository) []archive.TarEntry
+		hintFn           func(*gitxtest.Repository) rebuild.Strategy
 		wantFn           func(*gitxtest.Repository) rebuild.Strategy
 		wantErr          bool
 		registryResponse *cratesregistryservice.FindRegistryCommitResponse
@@ -396,6 +399,36 @@ edition = "2024"
 					RustVersion: "1.35.0",
 				}
 			},
+		},
+		{
+			name: "location hint rejects mismatched workspace version",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [workspace]
+        members = ["serde"]
+
+        [workspace.package]
+        version = "1.0.149"
+      serde/Cargo.toml: |
+        [package]
+        name = "serde"
+        version.workspace = true
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","rust_version": "1.35.0"}}`,
+			files: []archive.TarEntry{
+				{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(pre150CargoTOML)},
+			},
+			hintFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &rebuild.LocationHint{
+					Location: rebuild.Location{
+						Ref: repo.Commits["version-bump"].String(),
+						Dir: "serde",
+					},
+				}
+			},
+			wantErr: true,
 		},
 		{
 			name: "unreadable Cargo.toml",
@@ -756,6 +789,10 @@ version = 3
 			if tc.filesFn != nil {
 				files = tc.filesFn(repo)
 			}
+			var hint rebuild.Strategy
+			if tc.hintFn != nil {
+				hint = tc.hintFn(repo)
+			}
 			client := httpxtest.MockClient{
 				Calls: []httpxtest.Call{
 					{
@@ -783,7 +820,7 @@ version = 3
 				URLValidator: httpxtest.NewURLValidator(t),
 			}
 			mux := rebuild.RegistryMux{CratesIO: cratesio.HTTPRegistry{Client: &client}}
-			s, err := Rebuilder{}.InferStrategy(ctx, target, mux, &rcfg, nil)
+			s, err := Rebuilder{}.InferStrategy(ctx, target, mux, &rcfg, hint)
 			if tc.wantErr {
 				if err == nil {
 					t.Errorf("InferStrategy expected error, got %v", s)
@@ -839,6 +876,100 @@ func TestLockfileRustVersionFloor(t *testing.T) {
 		if got := lockfileRustVersionFloor(tc.formatVersion); got != tc.want {
 			t.Errorf("lockfileRustVersionFloor(%d) = %q, want %q", tc.formatVersion, got, tc.want)
 		}
+	}
+}
+
+func TestFindAndValidateCargoTOMLWorkspaceVersion(t *testing.T) {
+	repo := must(gitxtest.CreateRepoFromYAML(`commits:
+  - id: target
+    files:
+      Cargo.toml: |
+        [package]
+        name = "root-example"
+        version.workspace = true
+
+        [workspace]
+        members = ["crates/example", "nested/explicit"]
+
+        [workspace.package]
+        version = "1.2.3"
+      crates/example/Cargo.toml: |
+        [package]
+        name = "example"
+        version.workspace = true
+      nested/explicit/Cargo.toml: |
+        [package]
+        name = "explicit"
+        version.workspace = true
+        workspace = "../.."
+      incomplete/Cargo.toml: |
+        [package]
+        name = "incomplete"
+        version.workspace = true
+
+        [workspace]
+`, nil))
+	commit := must(repo.CommitObject(repo.Commits["target"]))
+	for _, tc := range []struct {
+		name    string
+		pkg     string
+		guess   string
+		version string
+		wantErr string
+	}{
+		{
+			name:    "matching inherited version",
+			pkg:     "example",
+			guess:   "crates/example",
+			version: "1.2.3",
+		},
+		{
+			name:    "mismatched inherited version",
+			pkg:     "example",
+			guess:   "crates/example",
+			version: "1.2.2",
+			wantErr: "mismatched version",
+		},
+		{
+			name:    "mismatched version with explicit workspace path",
+			pkg:     "explicit",
+			guess:   "nested/explicit",
+			version: "1.2.2",
+			wantErr: "mismatched version",
+		},
+		{
+			name:    "matching version with explicit workspace path",
+			pkg:     "explicit",
+			guess:   "nested/explicit",
+			version: "1.2.3",
+		},
+		{
+			name:    "package at workspace root",
+			pkg:     "root-example",
+			version: "1.2.3",
+		},
+		{
+			name:    "missing workspace package version",
+			pkg:     "incomplete",
+			guess:   "incomplete",
+			version: "1.2.3",
+			wantErr: "workspace package version not found",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := findAndValidateCargoTOML(repo.Repository, commit, tc.pkg, tc.version, tc.guess)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Errorf("findAndValidateCargoTOML(%q) = %q, want error", tc.version, got)
+				} else if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("findAndValidateCargoTOML(%q) error = %q, want substring %q", tc.version, err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("findAndValidateCargoTOML(%q): %v", tc.version, err)
+			} else if want := path.Join(tc.guess, "Cargo.toml"); got != want {
+				t.Errorf("findAndValidateCargoTOML(%q) = %q, want %q", tc.version, got, want)
+			}
+		})
 	}
 }
 

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -973,6 +973,26 @@ func TestFindAndValidateCargoTOMLWorkspaceVersion(t *testing.T) {
 	}
 }
 
+func TestFindAndValidateCargoTOMLStripsManifestBOM(t *testing.T) {
+	repo := must(gitxtest.CreateRepoFromYAML(`commits:
+  - id: target
+    files:
+      Cargo.toml: "\uFEFF[workspace]\nmembers = [\"member\"]\n\n[workspace.package]\nversion = \"1.2.3\"\n"
+      member/Cargo.toml: |
+        [package]
+        name = "member"
+        version.workspace = true
+`, nil))
+	commit := must(repo.CommitObject(repo.Commits["target"]))
+	got, err := findAndValidateCargoTOML(repo.Repository, commit, "member", "1.2.3", "member")
+	if err != nil {
+		t.Fatalf("findAndValidateCargoTOML with BOM workspace root: %v", err)
+	}
+	if want := "member/Cargo.toml"; got != want {
+		t.Errorf("findAndValidateCargoTOML = %q, want %q", got, want)
+	}
+}
+
 func must[T any](t T, err error) T {
 	if err != nil {
 		panic(err)

--- a/pkg/registry/cratesio/cargo.go
+++ b/pkg/registry/cratesio/cargo.go
@@ -21,6 +21,7 @@ type GitInfo struct {
 // Format: https://doc.rust-lang.org/cargo/reference/manifest.html
 type CargoTOML struct {
 	PackageManifest `toml:"package"`
+	Workspace       *WorkspaceManifest `toml:"workspace"`
 }
 
 // PackageManifest is the [package] section of the Cargo.toml file.
@@ -28,6 +29,16 @@ type PackageManifest struct {
 	Name         string `toml:"name"`
 	RawVersion   any    `toml:"version"`
 	RawWorkspace any    `toml:"workspace"`
+}
+
+// WorkspaceManifest is the [workspace] section of the Cargo.toml file.
+type WorkspaceManifest struct {
+	Package WorkspacePackageManifest `toml:"package"`
+}
+
+// WorkspacePackageManifest is the [workspace.package] section of the Cargo.toml file.
+type WorkspacePackageManifest struct {
+	Version string `toml:"version"`
 }
 
 // WorkspaceVersion is the special version string used for workspace crates.
@@ -42,4 +53,12 @@ func (pm PackageManifest) Version() string {
 	} else {
 		return ""
 	}
+}
+
+// WorkspacePath returns the explicit package.workspace path, if set.
+func (pm PackageManifest) WorkspacePath() string {
+	if p, ok := pm.RawWorkspace.(string); ok {
+		return p
+	}
+	return ""
 }


### PR DESCRIPTION
When a crate inherits its version from `workspace.package`, version validation currently treats it as a wildcard. This can allow a ref for a different workspace version to pass both ref selection and final strategy validation.

Resolve the workspace manifest using `package.workspace` when present, otherwise walk ancestor manifests, and compare `workspace.package.version` with the requested version. Also strip a leading UTF-8 BOM before parsing manifests, matching Cargo behavior.

Testing:
- `go test ./pkg/rebuild/cratesio`
- `go test ./...`