### PR TITLE
Set Cargo 1.85 floor for Edition 2024 crates

### DIFF
--- a/pkg/rebuild/cratesio/hints.go
+++ b/pkg/rebuild/cratesio/hints.go
@@ -5,6 +5,9 @@ package cratesio
 
 import (
 	"regexp"
+
+	"github.com/google/oss-rebuild/internal/semver"
+	"github.com/pelletier/go-toml/v2"
 )
 
 // Compiled regex patterns for detecting Rust version requirements
@@ -23,6 +26,15 @@ var (
 	// docExamplesRegex detects the addition of the scrape indicator (Rust 1.67+)
 	docExamplesRegex = regexp.MustCompile(`(?m)^\s*doc-scrape-examples\s*=\s*(true|false)\s*$`)
 )
+
+func hasPackageEdition2024(cargoTomlText string) bool {
+	var manifest struct {
+		Package struct {
+			Edition string `toml:"edition"`
+		} `toml:"package"`
+	}
+	return toml.Unmarshal([]byte(cargoTomlText), &manifest) == nil && manifest.Package.Edition == "2024"
+}
 
 // detectRustVersionBounds analyzes Cargo.toml for structural patterns that indicate
 // minimum Rust version requirements based on tooling behavior changes.
@@ -60,6 +72,12 @@ func detectRustVersionBounds(cargoTomlText string) (lo, hi string) {
 	}
 	if hi == "999" {
 		hi = ""
+	}
+	if hasPackageEdition2024(cargoTomlText) {
+		lo = max("1.85.0", lo)
+		if hi != "" && semver.Cmp(hi, lo) < 0 {
+			hi = ""
+		}
 	}
 	return
 }

--- a/pkg/rebuild/cratesio/hints_test.go
+++ b/pkg/rebuild/cratesio/hints_test.go
@@ -42,6 +42,15 @@ name = "my-crate"
 			wantHi: "1.50.0", // No modern header sets hi=1.54, no resolver=2 bumps to 1.50
 		},
 		{
+			name: "Edition 2024 overrides older upper bounds",
+			cargoToml: `[package]
+name = "my-crate"
+edition = "2024"
+`,
+			wantLo: "1.85.0",
+			wantHi: "",
+		},
+		{
 			name: "Resolver Two (Old Header)",
 			cargoToml: `
 [package]

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -27,6 +27,51 @@ const (
 	pre150CargoTOML  = `# to registry (e.g., crates.io) dependencies`
 )
 
+func TestHasPackageEdition2024(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		manifest string
+		want     bool
+	}{
+		{
+			name: "package edition",
+			manifest: `[package]
+edition = "2024" # supported since Cargo 1.85
+`,
+			want: true,
+		},
+		{
+			name: "metadata is not package edition",
+			manifest: `[package]
+name = "example"
+
+[package.metadata.example]
+edition = "2024"
+`,
+		},
+		{
+			name: "multiline string is not package edition",
+			manifest: `[package]
+description = """
+edition = "2024"
+"""
+`,
+		},
+		{
+			name: "older package edition",
+			manifest: `[package]
+edition = "2021"
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasPackageEdition2024(tc.manifest); got != tc.want {
+				t.Errorf("hasPackageEdition2024() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestInferStrategy(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
@@ -102,6 +147,44 @@ func TestInferStrategy(t *testing.T) {
 						Dir:  "",
 					},
 					RustVersion: "1.65.0",
+				}
+			},
+		},
+		{
+			name: "edition 2024 raises rust_version floor",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+        edition = "2024"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2025-02-26T00:00:00Z","updated_at":"2025-02-26T00:00:00Z"}}`,
+			files: []archive.TarEntry{
+				{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML + `
+[package]
+name = "serde"
+version = "1.0.150"
+edition = "2024"
+`)},
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+						Dir:  "",
+					},
+					RustVersion: "1.85.0",
 				}
 			},
 		},


### PR DESCRIPTION
Stable Cargo versions before 1.85 reject package manifests with `edition = "2024"`. If such a crate omits `rust_version`, the publication-date heuristic can select Cargo 1.82–1.84 for releases published before or shortly after Cargo 1.85's release.

This change reads the package edition and applies Cargo 1.85 as a hard lower bound after the existing heuristic bounds. Edition-like values in metadata or multiline strings are ignored.

Testing:
- `go test ./...`
- Repackaged 985 affected releases: Cargo 1.82–1.84 rejected all of them with `feature edition2024 is required`, while Cargo 1.85.0 matched the upstream `Cargo.toml`, `Cargo.lock`, and packaged file set (excluding `.cargo_vcs_info.json`).