### PR TITLE
Distinguish crates.io prereleases from build metadata

### DIFF
--- a/pkg/rebuild/cratesio/rebuild.go
+++ b/pkg/rebuild/cratesio/rebuild.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strings"
 
+	"github.com/google/oss-rebuild/internal/semver"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	reg "github.com/google/oss-rebuild/pkg/registry/cratesio"
 	"github.com/pkg/errors"
@@ -23,9 +23,13 @@ func GetVersions(ctx context.Context, pkg string, mux rebuild.RegistryMux) (vers
 	}
 	var vs []reg.Version
 	for _, v := range p.Versions {
+		parsedVersion, err := semver.New(v.Version)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing crate version %q", v.Version)
+		}
 		// Omit pre-release versions.
 		// TODO: Support rebuilding pre-release versions.
-		if strings.ContainsRune(v.Version, '-') {
+		if parsedVersion.Prerelease != "" {
 			continue
 		}
 		vs = append(vs, v)

--- a/pkg/rebuild/cratesio/rebuild_test.go
+++ b/pkg/rebuild/cratesio/rebuild_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cratesio
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	reg "github.com/google/oss-rebuild/pkg/registry/cratesio"
+)
+
+type staticRegistry struct {
+	crate *reg.Crate
+}
+
+func (r staticRegistry) Crate(context.Context, string) (*reg.Crate, error) {
+	return r.crate, nil
+}
+
+func (staticRegistry) Version(context.Context, string, string) (*reg.CrateVersion, error) {
+	panic("unexpected Version call")
+}
+
+func (staticRegistry) Artifact(context.Context, string, string) (io.ReadCloser, error) {
+	panic("unexpected Artifact call")
+}
+
+func TestGetVersionsOmitsOnlyPrereleases(t *testing.T) {
+	date := func(day int) time.Time {
+		return time.Date(2026, time.January, day, 0, 0, 0, 0, time.UTC)
+	}
+	mux := rebuild.RegistryMux{CratesIO: staticRegistry{crate: &reg.Crate{
+		Versions: []reg.Version{
+			{Version: "1.0.0-alpha.1", Created: date(4)},
+			{Version: "0.14.7+wasi-0.2.4", Created: date(3)},
+			{Version: "1.0.0+build-1", Created: date(2)},
+			{Version: "0.9.0", Created: date(1)},
+		},
+	}}}
+
+	got, err := GetVersions(context.Background(), "example", mux)
+	if err != nil {
+		t.Fatalf("GetVersions() error = %v", err)
+	}
+	want := []string{"0.14.7+wasi-0.2.4", "1.0.0+build-1", "0.9.0"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("GetVersions() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/tools/benchmark/generate/main.go
+++ b/tools/benchmark/generate/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/google/oss-rebuild/internal/semver"
 	"github.com/google/oss-rebuild/internal/urlx"
 	"github.com/google/oss-rebuild/pkg/registry/cratesio"
 	"github.com/google/oss-rebuild/pkg/registry/debian"
@@ -112,9 +113,11 @@ var cratesioTop2000 = RebuildBenchmark{
 					break
 				}
 				isTooOld := v.Created.Before(ageThreshold)
-				// NOTE: Assuming versions are valid SemVer, hyphen detects prerelease.
-				isPrerelease := strings.ContainsRune(v.Version, '-')
-				if v.Yanked || isPrerelease || isTooOld {
+				parsedVersion, err := semver.New(v.Version)
+				if err != nil {
+					log.Fatalf("invalid crates.io version %q for package %s: %v", v.Version, m.Name, err)
+				}
+				if v.Yanked || parsedVersion.Prerelease != "" || isTooOld {
 					continue
 				}
 				versions = append(versions, v.Version)


### PR DESCRIPTION
Use the existing SemVer parser to distinguish prerelease identifiers from build metadata in the benchmark generator and GetVersions. This keeps stable versions such as `0.14.7+wasi-0.2.4` while continuing to omit true prereleases.

Invalid registry versions now fail explicitly.

Testing:
- `go run ./ci -v test`
- `go run ./ci -v lint`
- `go run ./ci -v fmt-check`

Related to #1362