### PR TITLE
Exclude non-crates.io packages from registry resolution

### DIFF
--- a/internal/api/cratesregistryservice/findcommit.go
+++ b/internal/api/cratesregistryservice/findcommit.go
@@ -69,6 +69,10 @@ func FindRegistryCommit(ctx context.Context, req FindRegistryCommitRequest, deps
 	if err != nil {
 		return nil, api.AsStatus(codes.InvalidArgument, errors.Wrap(err, "failed to parse Cargo.lock"))
 	}
+	packages = cargolock.CratesIOPackages(packages)
+	if len(packages) == 0 {
+		return &FindRegistryCommitResponse{}, nil
+	}
 	// Determine which snapshots should be searched based on publish date
 	snapshots, err := index.ListAvailableSnapshots(ctx)
 	if err != nil {

--- a/internal/api/cratesregistryservice/findcommit_test.go
+++ b/internal/api/cratesregistryservice/findcommit_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cratesregistryservice
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+)
+
+func TestFindRegistryCommitWithoutRegistryPackages(t *testing.T) {
+	lockfile := `version = 3
+
+[[package]]
+name = "example"
+version = "1.0.0"
+`
+	response, err := FindRegistryCommit(context.Background(), FindRegistryCommitRequest{
+		LockfileBase64: base64.StdEncoding.EncodeToString([]byte(lockfile)),
+		PublishedTime:  "2026-01-01T00:00:00Z",
+	}, &FindRegistryCommitDeps{})
+	if err != nil {
+		t.Fatalf("FindRegistryCommit() error = %v", err)
+	}
+	if response.CommitHash != "" {
+		t.Errorf("FindRegistryCommit() commit = %q, want empty", response.CommitHash)
+	}
+}

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -291,28 +291,31 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 		if lockfileLo != "" && semver.Cmp(rustVersion, lockfileLo) < 0 {
 			rustVersion = lockfileLo
 		}
-		// Registry search is only usable in builds that support the local or sparse registry protocols.
-		// Sparse support: http://releases.rs/docs/1.68.0/#cargo
-		// Local support: http://releases.rs/docs/1.34.0/#cargo
-		stub, err := getRegistryStub(ctx)
-		if err != nil {
-			return nil, errors.Wrapf(err, "[INTERNAL] Failed to access registry query stub")
+		registryPackages := cargolock.CratesIOPackages(lf.Packages)
+		if len(registryPackages) > 0 {
+			// Registry search is only usable in builds that support the local or sparse registry protocols.
+			// Sparse support: http://releases.rs/docs/1.68.0/#cargo
+			// Local support: http://releases.rs/docs/1.34.0/#cargo
+			stub, err := getRegistryStub(ctx)
+			if err != nil {
+				return nil, errors.Wrapf(err, "[INTERNAL] Failed to access registry query stub")
+			}
+			resp, err := stub(ctx, cratesregistryservice.FindRegistryCommitRequest{
+				LockfileBase64: base64.StdEncoding.EncodeToString(lockContent),
+				PublishedTime:  vmeta.Created.Format(time.RFC3339),
+			})
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to call registry service")
+			}
+			if resp.CommitHash == "" {
+				return nil, errors.New("no suitable registry commit found")
+			}
+			indexCommit = resp.CommitHash
 		}
-		resp, err := stub(ctx, cratesregistryservice.FindRegistryCommitRequest{
-			LockfileBase64: base64.StdEncoding.EncodeToString(lockContent),
-			PublishedTime:  vmeta.Created.Format(time.RFC3339),
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to call registry service")
-		}
-		if resp.CommitHash == "" {
-			return nil, errors.New("no suitable registry commit found")
-		}
-		indexCommit = resp.CommitHash
 		// TODO: If we want to default to sparse registry, we can predicate this on `if semver.Cmp(rustVersion, "1.68.0") < 0`
-		// If only local registry supported, parse package names from Cargo.lock.
+		// If only local registry is supported, collect crates.io package names from Cargo.lock.
 		packageSet := make(map[string]bool)
-		for _, pkg := range lf.Packages {
+		for _, pkg := range registryPackages {
 			packageSet[pkg.Name] = true
 		}
 		for pkgName := range packageSet {

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -491,6 +491,16 @@ version = 3
 [[package]]
 name = "serde"
 version = "1.0.150"
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "git+https://github.com/example/tracing#0123456789abcdef"
 `)},
 				}
 			},
@@ -507,7 +517,7 @@ version = "1.0.150"
 					},
 					RustVersion:    "1.68.0",
 					RegistryCommit: "abcd1234567890abcdef1234567890abcdef1234",
-					PackageNames:   []string{"serde"}, // NOTE: This will be emptied if/when cargosparse timewarp mode is used
+					PackageNames:   []string{"syn"}, // NOTE: This will be emptied if/when cargosparse timewarp mode is used
 				}
 			},
 		},
@@ -540,6 +550,11 @@ version = 4
 [[package]]
 name = "serde"
 version = "1.0.150"
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 `)},
 				}
 			},
@@ -555,7 +570,7 @@ version = "1.0.150"
 					},
 					RustVersion:    "1.78.0",
 					RegistryCommit: "abcd1234567890abcdef1234567890abcdef1234",
-					PackageNames:   []string{"serde"}, // NOTE: This will be emptied if/when cargosparse timewarp mode is used
+					PackageNames:   []string{"syn"}, // NOTE: This will be emptied if/when cargosparse timewarp mode is used
 				}
 			},
 		},
@@ -587,6 +602,11 @@ version = 3
 [[package]]
 name = "serde"
 version = "1.0.150"
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 `)},
 				}
 			},
@@ -661,10 +681,12 @@ version = "1.0.150"
 [[package]]
 name = "clap"
 version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "criterion"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -673,6 +695,7 @@ version = "1.0.150"
 [[package]]
 name = "tokio"
 version = "1.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 `)},
 				}
 			},
@@ -685,7 +708,7 @@ version = "1.21.2"
 					},
 					RustVersion:    "1.35.0",
 					RegistryCommit: "abcd1234567890abcdef1234567890abcdef1234",
-					PackageNames:   []string{"clap", "criterion", "serde", "tokio"},
+					PackageNames:   []string{"clap", "criterion", "tokio"},
 				}
 			},
 		},
@@ -717,9 +740,6 @@ version = 3
 `)},
 				}
 			},
-			registryResponse: &cratesregistryservice.FindRegistryCommitResponse{
-				CommitHash: "abcd1234567890abcdef1234567890abcdef1234",
-			},
 			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
 				return &CratesIOCargoPackage{
 					Location: rebuild.Location{
@@ -727,8 +747,7 @@ version = 3
 						Ref:  repo.Commits["version-bump"].String(),
 						Dir:  "",
 					},
-					RustVersion:    "1.67.0",
-					RegistryCommit: "abcd1234567890abcdef1234567890abcdef1234",
+					RustVersion: "1.67.0",
 				}
 			},
 		},

--- a/pkg/registry/cratesio/cargolock/cargolock.go
+++ b/pkg/registry/cratesio/cargolock/cargolock.go
@@ -6,13 +6,18 @@ package cargolock
 import (
 	"bufio"
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 )
 
-// Package represents a crate dependency from a Cargo.lock file.
+const cratesIOIndexSource = "registry+https://github.com/rust-lang/crates.io-index"
+
+// Package represents a package entry from a Cargo.lock file.
 type Package struct {
 	Name    string
 	Version string
+	Source  string
 }
 
 // Lockfile represents a parsed Cargo.lock file.
@@ -23,33 +28,67 @@ type Lockfile struct {
 	Packages      []Package
 }
 
+// CratesIOPackages returns packages resolved from the crates.io registry.
+// The input slice is modified in place.
+func CratesIOPackages(packages []Package) []Package {
+	return slices.DeleteFunc(packages, func(pkg Package) bool {
+		return pkg.Source != cratesIOIndexSource
+	})
+}
+
 // ParseLockfile parses a Cargo.lock file, returning the format version and packages.
 func ParseLockfile(content string) (Lockfile, error) {
 	var lf Lockfile
+	var current *Package
+	flushPackage := func() {
+		if current != nil && current.Name != "" && current.Version != "" {
+			lf.Packages = append(lf.Packages, *current)
+		}
+		current = nil
+	}
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
+		if line == "[[package]]" || line == "[root]" {
+			flushPackage()
+			current = &Package{}
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			flushPackage()
+			continue
+		}
 		// Top-level format version: `version = N` (unquoted integer, unlike package versions).
-		if strings.HasPrefix(line, "version = ") && !strings.Contains(line, "\"") {
+		if current == nil && strings.HasPrefix(line, "version = ") && !strings.Contains(line, "\"") {
 			fmt.Sscanf(strings.TrimPrefix(line, "version = "), "%d", &lf.FormatVersion)
 			continue
 		}
-		// Package entry: `name = "foo"` immediately followed by `version = "x.y.z"`.
-		if strings.HasPrefix(line, "name = ") {
-			name := strings.Trim(strings.TrimPrefix(line, "name = "), "\"")
-			if scanner.Scan() {
-				versionLine := scanner.Text()
-				if strings.HasPrefix(versionLine, "version = ") {
-					version := strings.Trim(strings.TrimPrefix(versionLine, "version = "), "\"")
-					lf.Packages = append(lf.Packages, Package{Name: name, Version: version})
-				}
-			}
+		if current == nil {
+			continue
+		}
+		if value, ok := quotedValue(line, "name"); ok {
+			current.Name = value
+		} else if value, ok := quotedValue(line, "version"); ok {
+			current.Version = value
+		} else if value, ok := quotedValue(line, "source"); ok {
+			current.Source = value
 		}
 	}
+	flushPackage()
 	if err := scanner.Err(); err != nil {
 		return Lockfile{}, fmt.Errorf("error parsing lockfile: %w", err)
 	}
 	return lf, nil
+}
+
+func quotedValue(line, key string) (string, bool) {
+	value, ok := strings.CutPrefix(line, key+" = ")
+	if !ok {
+		return "", false
+	}
+	value = strings.TrimSpace(value)
+	unquoted, err := strconv.Unquote(value)
+	return unquoted, err == nil
 }
 
 // Parse extracts package information from Cargo.lock content.

--- a/pkg/registry/cratesio/cargolock/cargolock.go
+++ b/pkg/registry/cratesio/cargolock/cargolock.go
@@ -29,8 +29,8 @@ type Lockfile struct {
 }
 
 // CratesIOPackages returns packages resolved from the crates.io registry.
-// The input slice is modified in place.
 func CratesIOPackages(packages []Package) []Package {
+	packages = slices.Clone(packages)
 	return slices.DeleteFunc(packages, func(pkg Package) bool {
 		return pkg.Source != cratesIOIndexSource
 	})

--- a/pkg/registry/cratesio/cargolock/cargolock_test.go
+++ b/pkg/registry/cratesio/cargolock/cargolock_test.go
@@ -49,7 +49,11 @@ checksum = "abc123"
 `,
 			want: Lockfile{
 				FormatVersion: 2,
-				Packages:      []Package{{Name: "serde", Version: "1.0.100"}},
+				Packages: []Package{{
+					Name:    "serde",
+					Version: "1.0.100",
+					Source:  "registry+https://github.com/rust-lang/crates.io-index",
+				}},
 			},
 		},
 		{
@@ -73,8 +77,8 @@ checksum = "c89b4efa943cdcb42a541ed5fafe108b0a0be4c16e8fe0c57e2b5b7a46b002d"
 			want: Lockfile{
 				FormatVersion: 3,
 				Packages: []Package{
-					{Name: "serde", Version: "1.0.193"},
-					{Name: "tokio", Version: "1.35.1"},
+					{Name: "serde", Version: "1.0.193", Source: "registry+https://github.com/rust-lang/crates.io-index"},
+					{Name: "tokio", Version: "1.35.1", Source: "registry+https://github.com/rust-lang/crates.io-index"},
 				},
 			},
 		},
@@ -92,7 +96,11 @@ checksum = "def456"
 `,
 			want: Lockfile{
 				FormatVersion: 4,
-				Packages:      []Package{{Name: "serde", Version: "1.0.210"}},
+				Packages: []Package{{
+					Name:    "serde",
+					Version: "1.0.210",
+					Source:  "registry+https://github.com/rust-lang/crates.io-index",
+				}},
 			},
 		},
 	}
@@ -107,6 +115,42 @@ checksum = "def456"
 				t.Errorf("ParseLockfile() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestCratesIOPackages(t *testing.T) {
+	content := `version = 3
+
+[[package]]
+name = "example"
+version = "1.0.0"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "git+https://github.com/example/tracing#0123456789abcdef"
+
+[[package]]
+name = "private"
+version = "2.0.0"
+source = "registry+https://example.com/index"
+`
+	lf, err := ParseLockfile(content)
+	if err != nil {
+		t.Fatalf("ParseLockfile() error = %v", err)
+	}
+	want := []Package{{
+		Name:    "serde",
+		Version: "1.0.193",
+		Source:  "registry+https://github.com/rust-lang/crates.io-index",
+	}}
+	if diff := cmp.Diff(want, CratesIOPackages(lf.Packages)); diff != "" {
+		t.Errorf("CratesIOPackages() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -135,7 +179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 `,
 			want: []Package{
-				{Name: "serde", Version: "1.0.193"},
+				{Name: "serde", Version: "1.0.193", Source: "registry+https://github.com/rust-lang/crates.io-index"},
 			},
 		},
 		{
@@ -157,8 +201,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89b4efa943cdcb42a541ed5fafe108b0a0be4c16e8fe0c57e2b5b7a46b002d"
 `,
 			want: []Package{
-				{Name: "serde", Version: "1.0.193"},
-				{Name: "tokio", Version: "1.35.1"},
+				{Name: "serde", Version: "1.0.193", Source: "registry+https://github.com/rust-lang/crates.io-index"},
+				{Name: "tokio", Version: "1.35.1", Source: "registry+https://github.com/rust-lang/crates.io-index"},
 			},
 		},
 	}

--- a/pkg/registry/cratesio/cargolock/cargolock_test.go
+++ b/pkg/registry/cratesio/cargolock/cargolock_test.go
@@ -144,6 +144,7 @@ source = "registry+https://example.com/index"
 	if err != nil {
 		t.Fatalf("ParseLockfile() error = %v", err)
 	}
+	original := append([]Package(nil), lf.Packages...)
 	want := []Package{{
 		Name:    "serde",
 		Version: "1.0.193",
@@ -151,6 +152,9 @@ source = "registry+https://example.com/index"
 	}}
 	if diff := cmp.Diff(want, CratesIOPackages(lf.Packages)); diff != "" {
 		t.Errorf("CratesIOPackages() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(original, lf.Packages); diff != "" {
+		t.Errorf("CratesIOPackages() modified input (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/registry/cratesio/index/README.md
+++ b/pkg/registry/cratesio/index/README.md
@@ -272,8 +272,9 @@ for _, h := range handles {
     repos = append(repos, h.Repository)
 }
 
-// Parse Cargo.lock to get packages
+// Parse Cargo.lock to get crates.io packages
 packages, err := cargolock.Parse(lockfileContent)
+packages = cargolock.CratesIOPackages(packages)
 
 // Find resolution
 resolution, err := index.FindRegistryResolution(repos, packages, publishTime, nil)

--- a/pkg/registry/cratesio/index/find_test.go
+++ b/pkg/registry/cratesio/index/find_test.go
@@ -237,3 +237,73 @@ func TestFindRegistryResolution(t *testing.T) {
 		})
 	}
 }
+
+func TestFindRegistryResolutionExcludesPathPackage(t *testing.T) {
+	current := mustCreateRepo(t, `commits:
+  - id: current
+    files:
+      pr/iv/private: |
+        {"name":"private","vers":"2.0.0","deps":[],"cksum":"path","features":{},"yanked":false}
+      se/rd/serde: |
+        {"name":"serde","vers":"1.0.193","deps":[],"cksum":"dependency","features":{},"yanked":false}
+`)
+	snapshot := mustCreateRepo(t, `commits:
+  - id: snapshot
+    files:
+      se/rd/serde: |
+        {"name":"serde","vers":"1.0.193","deps":[],"cksum":"dependency","features":{},"yanked":false}
+`)
+	lockfile, err := cargolock.ParseLockfile(`version = 3
+
+[[package]]
+name = "example"
+version = "1.0.0"
+
+[[package]]
+name = "private"
+version = "2.0.0"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+`)
+	if err != nil {
+		t.Fatalf("ParseLockfile() error = %v", err)
+	}
+
+	unfiltered, err := FindRegistryResolution(
+		[]*git.Repository{current.Repository, snapshot.Repository},
+		lockfile.Packages,
+		time.Now(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("FindRegistryResolution() with all packages error = %v", err)
+	}
+	if unfiltered.CommitHash != current.Commits["current"] {
+		t.Fatalf("unfiltered resolution = %v, want current index", unfiltered.CommitHash)
+	}
+
+	filtered, err := FindRegistryResolution(
+		[]*git.Repository{current.Repository, snapshot.Repository},
+		cargolock.CratesIOPackages(lockfile.Packages),
+		time.Now(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("FindRegistryResolution() with crates.io packages error = %v", err)
+	}
+	if filtered.CommitHash != snapshot.Commits["snapshot"] {
+		t.Errorf("filtered resolution = %v, want snapshot index", filtered.CommitHash)
+	}
+}
+
+func mustCreateRepo(t *testing.T, history string) *gitxtest.Repository {
+	t.Helper()
+	repo, err := gitxtest.CreateRepoFromYAML(history, nil)
+	if err != nil {
+		t.Fatalf("CreateRepoFromYAML() error = %v", err)
+	}
+	return repo
+}

--- a/tools/registryscan/main.go
+++ b/tools/registryscan/main.go
@@ -64,7 +64,12 @@ func main() {
 	}
 	packages, err := cargolock.Parse(lockfile)
 	if err != nil {
-		fmt.Printf("Error parsing packages: %v\n", err)
+		fmt.Printf("Error parsing Cargo.lock: %v\n", err)
+		os.Exit(1)
+	}
+	packages = cargolock.CratesIOPackages(packages)
+	if len(packages) == 0 {
+		fmt.Println("Cargo.lock contains no crates.io packages")
 		os.Exit(1)
 	}
 	manager, err := setupIndexManager(cacheDir)


### PR DESCRIPTION
Cargo.lock records root, path, Git, and alternate-registry packages alongside crates.io packages. The registry resolver currently treats every entry as if it came from crates.io. When a non-registry package has the same name and version as a published crate, it can move the selected index commit; its name is also included in git-index timewarp requests.

`agent-doc 0.31.9` reproduces this with its path package `tmux-router 0.3.9`: including that entry moves the selected registry commit.

Record each package's source and use only crates.io entries for registry resolution and `PackageNames`. Lockfiles with no crates.io packages now skip registry lookup.

Testing:
- `go test ./...`
- `go vet ./...`