### PR TITLE
Record strategy provenance on rebuild attempts

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -190,12 +190,12 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing inference URL")
 	}
-	u = u.JoinPath("infer")
 	runclient, err := idtoken.NewClient(ctx, *inferenceURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing inference client")
 	}
-	d.InferStub = api.StubFromHandler(runclient, u, inferenceservice.Infer)
+	d.InferStub = api.StubFromHandler(runclient, u.JoinPath("infer"), inferenceservice.Infer)
+	d.InferVersionStub = api.StubFromHandler(runclient, u.JoinPath("version"), inferenceservice.Version)
 	return &d, nil
 }
 

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -57,6 +57,7 @@ type RebuildPackageDeps struct {
 	RemoteMetadataStoreBuilder func(ctx context.Context, uuid string) (rebuild.LocatableAssetStore, error)
 	OverwriteAttestations      bool // TODO: Remove in favor of req.OverwriteMode
 	InferStub                  api.StubFn[schema.InferenceRequest, schema.StrategyOneOf]
+	InferVersionStub           api.StubFn[schema.VersionRequest, schema.VersionResponse] // resolves inference /version for provenance
 }
 
 type repoEntry struct {
@@ -66,10 +67,33 @@ type repoEntry struct {
 	BuildDefLoc rebuild.Location
 }
 
+// resolution is getStrategy's result.
+type resolution struct {
+	Strategy  rebuild.Strategy
+	Entry     *repoEntry           // consulted build def entry, nil when no repo was used
+	Inference *schema.InferenceRun // set iff inference ran
+}
+
+// Provenance derives the strategy provenance from the resolution's inputs.
+// - Definition when the entry contributed a strategy or hint
+// - Inference when inference ran.
+func (r *resolution) Provenance() *schema.StrategyProvenance {
+	p := &schema.StrategyProvenance{Inference: r.Inference}
+	if r.Entry != nil && r.Entry.BuildDefinition.StrategyOneOf != nil {
+		p.Definition = &schema.SourceLocation{
+			Repository: r.Entry.BuildDefLoc.Repo,
+			Ref:        r.Entry.BuildDefLoc.Ref,
+			Path:       r.Entry.BuildDefLoc.Dir,
+		}
+	}
+	return p
+}
+
 // getStrategy determines which strategy we should execute. If a build def repo was used, that data will be included as repoEntry.
-func getStrategy(ctx context.Context, deps *RebuildPackageDeps, t rebuild.Target, fromRepo bool) (rebuild.Strategy, *repoEntry, error) {
+func getStrategy(ctx context.Context, deps *RebuildPackageDeps, t rebuild.Target, fromRepo bool) (*resolution, error) {
 	var strategy rebuild.Strategy
 	var entry *repoEntry
+	var inference *schema.InferenceRun
 	ireq := schema.InferenceRequest{
 		Ecosystem: t.Ecosystem,
 		Package:   t.Package,
@@ -90,7 +114,7 @@ func getStrategy(ctx context.Context, deps *RebuildPackageDeps, t rebuild.Target
 		if gitx.IsSSMURL(cloneOpts.URL) {
 			auth, err := gitx.GCPBasicAuth(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "getting GCP auth for SSM repo")
+				return nil, errors.Wrap(err, "getting GCP auth for SSM repo")
 			}
 			cloneOpts.Auth = auth
 		}
@@ -101,7 +125,7 @@ func getStrategy(ctx context.Context, deps *RebuildPackageDeps, t rebuild.Target
 			SparseCheckoutDirs: sparseDirs,
 		})
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "creating build definition repo reader")
+			return nil, errors.Wrap(err, "creating build definition repo reader")
 		}
 		pth, _ := defs.Path(ctx, t)
 		entry = &repoEntry{
@@ -113,12 +137,12 @@ func getStrategy(ctx context.Context, deps *RebuildPackageDeps, t rebuild.Target
 		}
 		entry.BuildDefinition, err = defs.Get(ctx, t)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "accessing build definition")
+			return nil, errors.Wrap(err, "accessing build definition")
 		}
 		if entry.BuildDefinition.StrategyOneOf != nil {
 			defnStrategy, err := entry.BuildDefinition.Strategy()
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "accessing strategy")
+				return nil, errors.Wrap(err, "accessing strategy")
 			}
 			if hint, ok := defnStrategy.(*rebuild.LocationHint); ok && hint != nil {
 				ireq.StrategyHint = &schema.StrategyOneOf{LocationHint: hint}
@@ -128,17 +152,25 @@ func getStrategy(ctx context.Context, deps *RebuildPackageDeps, t rebuild.Target
 		}
 	}
 	if strategy == nil {
+		// Resolve the inference service's version out-of-band before the call.
+		// A rollout landing between the two calls can misattribute the
+		// version. Rollouts are rare and the window is narrow.
+		vr, err := deps.InferVersionStub(ctx, schema.VersionRequest{})
+		if err != nil {
+			return nil, errors.Wrap(err, "fetching inference version")
+		}
 		s, err := deps.InferStub(ctx, ireq)
 		if err != nil {
 			// TODO: Surface better error than Internal.
-			return nil, nil, errors.Wrap(err, "fetching inference")
+			return nil, errors.Wrap(err, "fetching inference")
 		}
 		strategy, err = s.Strategy()
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "reading strategy")
+			return nil, errors.Wrap(err, "reading strategy")
 		}
+		inference = &schema.InferenceRun{Version: vr.Version}
 	}
-	return strategy, entry, nil
+	return &resolution{Strategy: strategy, Entry: entry, Inference: inference}, nil
 }
 
 func buildAndAttest(ctx context.Context, deps *RebuildPackageDeps, mux rebuild.RegistryMux, a verifier.Attestor, t rebuild.Target, strategy rebuild.Strategy, entry *repoEntry, sizeHint schema.SizeHint, useProxy bool, useSyscallMonitor bool, timeout time.Duration, mode schema.OverwriteMode) (err error) {
@@ -332,15 +364,16 @@ func rebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 		// NOTE: This ensures racing rebuilds won't result in multiple attestations being written.
 		a.AllowOverwrite = false
 	}
-	strategy, entry, err := getStrategy(ctx, deps, t, req.UseRepoDefinition)
+	res, err := getStrategy(ctx, deps, t, req.UseRepoDefinition)
 	if err != nil {
 		v.Message = errors.Wrap(err, "getting strategy").Error()
 		return &v, nil
 	}
-	if strategy != nil {
-		v.StrategyOneof = schema.NewStrategyOneOf(strategy)
+	v.Provenance = res.Provenance()
+	if res.Strategy != nil {
+		v.StrategyOneof = schema.NewStrategyOneOf(res.Strategy)
 	}
-	err = buildAndAttest(ctx, deps, mux, a, t, strategy, entry, req.SizeHint, req.UseNetworkProxy, req.UseSyscallMonitor, req.BuildTimeout, req.OverwriteMode)
+	err = buildAndAttest(ctx, deps, mux, a, t, res.Strategy, res.Entry, req.SizeHint, req.UseNetworkProxy, req.UseSyscallMonitor, req.BuildTimeout, req.OverwriteMode)
 	if err != nil {
 		v.Message = errors.Wrap(err, "executing rebuild").Error()
 		return &v, nil
@@ -380,6 +413,10 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 	}
 
 	v, err := rebuildPackage(ctx, req, deps)
+	if v != nil {
+		// Attempts that exited before strategy resolution keep nil provenance.
+		attempt.Provenance = v.Provenance
+	}
 	if err != nil {
 		attempt.Message = errors.Wrap(err, "executing rebuild").Error()
 		finish(schema.RebuildStatusError)

--- a/internal/api/apiservice/rebuild_deps.go
+++ b/internal/api/apiservice/rebuild_deps.go
@@ -128,11 +128,11 @@ func MakeRebuildPackageDeps(ctx context.Context, cfg *schema.RebuildDepsConfig) 
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing inference URL")
 	}
-	u = u.JoinPath("infer")
 	runclient, err := idtoken.NewClient(ctx, cfg.InferenceURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing inference client")
 	}
-	d.InferStub = api.StubFromHandler(runclient, u, inferenceservice.Infer)
+	d.InferStub = api.StubFromHandler(runclient, u.JoinPath("infer"), inferenceservice.Infer)
+	d.InferVersionStub = api.StubFromHandler(runclient, u.JoinPath("version"), inferenceservice.Version)
 	return &d, nil
 }

--- a/internal/api/apiservice/rebuild_lro.go
+++ b/internal/api/apiservice/rebuild_lro.go
@@ -38,6 +38,7 @@ func ProjectRebuildAttempt(a schema.RebuildAttempt) longrunning.Operation[schema
 			Target:        a.Target(),
 			Message:       a.Message,
 			StrategyOneof: a.Strategy,
+			Provenance:    a.Provenance,
 			Timings:       a.Timings,
 		},
 	}

--- a/internal/api/apiservice/rebuild_lro_test.go
+++ b/internal/api/apiservice/rebuild_lro_test.go
@@ -144,6 +144,9 @@ func TestRebuildPackageDuplicateInsert(t *testing.T) {
 	d.InferStub = func(context.Context, schema.InferenceRequest) (*schema.StrategyOneOf, error) {
 		return nil, io.EOF // arbitrary error
 	}
+	d.InferVersionStub = func(context.Context, schema.VersionRequest) (*schema.VersionResponse, error) {
+		return &schema.VersionResponse{Version: "test-infer-v1"}, nil
+	}
 
 	// RebuildPackage should not fail on the initial write.
 	// It will return a verdict with an error message later due to InferStub returning EOF.
@@ -282,6 +285,9 @@ func TestCreateRebuildOpFast(t *testing.T) {
 	d.InferStub = func(context.Context, schema.InferenceRequest) (*schema.StrategyOneOf, error) {
 		oneof := schema.NewStrategyOneOf(strategy)
 		return &oneof, nil
+	}
+	d.InferVersionStub = func(context.Context, schema.VersionRequest) (*schema.VersionResponse, error) {
+		return &schema.VersionResponse{Version: "test-infer-v1"}, nil
 	}
 
 	lroDeps := &CreateRebuildOpDeps{

--- a/internal/api/apiservice/rebuild_test.go
+++ b/internal/api/apiservice/rebuild_test.go
@@ -636,6 +636,9 @@ RLpmHHG1JOVdOA==
 				must(oneof.Strategy())
 				return &oneof, nil
 			}
+			d.InferVersionStub = func(context.Context, schema.VersionRequest) (*schema.VersionResponse, error) {
+				return &schema.VersionResponse{Version: "test-infer-v1"}, nil
+			}
 			if tc.buildDef != nil {
 				path := must(builddef.NewFilesystemBuildDefinitionSet(memfs.New()).Path(ctx, tc.target))
 				relpath := path[1:]
@@ -669,6 +672,33 @@ RLpmHHG1JOVdOA==
 			}
 			if got.Started.IsZero() || got.Created.IsZero() {
 				t.Errorf("timestamps not set: started=%v created=%v", got.Started, got.Created)
+			}
+			// Provenance expectations derive from the build def input: an entry
+			// with a strategy contributes a Definition, and inference runs (and
+			// records its version) unless that strategy was full (non-hint).
+			wantDef := tc.buildDef != nil && tc.buildDef.StrategyOneOf != nil
+			wantInfer := true
+			if wantDef {
+				if s, err := tc.buildDef.Strategy(); err == nil {
+					if _, isHint := s.(*rebuild.LocationHint); !isHint {
+						wantInfer = false
+					}
+				}
+			}
+			if got.Provenance == nil {
+				t.Error("Provenance not set")
+			} else {
+				if gotDef := got.Provenance.Definition != nil; gotDef != wantDef {
+					t.Errorf("Provenance.Definition set = %v, want %v", gotDef, wantDef)
+				}
+				if wantDef && got.Provenance.Definition.Ref == "" {
+					t.Error("Provenance.Definition.Ref is empty")
+				}
+				if gotInfer := got.Provenance.Inference != nil; gotInfer != wantInfer {
+					t.Errorf("Provenance.Inference set = %v, want %v", gotInfer, wantInfer)
+				} else if wantInfer && got.Provenance.Inference.Version != "test-infer-v1" {
+					t.Errorf("Provenance.Inference.Version = %q, want %q", got.Provenance.Inference.Version, "test-infer-v1")
+				}
 			}
 
 			if tc.expectedMsg != "" {

--- a/pkg/rebuild/schema/provenance.go
+++ b/pkg/rebuild/schema/provenance.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+// SourceLocation identifies a file within a git repository at a specific
+// ref. It mirrors attestation.SourceLocation, which lacks the firestore
+// tags needed for persistence. Keep the two in sync.
+type SourceLocation struct {
+	Repository string `json:"repository" firestore:"repository"`         // source repository URI
+	Ref        string `json:"ref" firestore:"ref"`                       // resolved commit hash
+	Path       string `json:"path,omitempty" firestore:"path,omitempty"` // repo-relative file path
+}
+
+// InferenceRun records an execution of the inference service.
+type InferenceRun struct {
+	Version string `json:"version" firestore:"version"` // service-reported version, possibly empty
+}
+
+// StrategyProvenance describes the inputs that produced an executed
+// strategy: a build definition, an inference run, or both when a
+// LocationHint seeded inference. Interpretations of these inputs (e.g.
+// manual vs inferred) are left to consumers. Nil indicates strategy
+// resolution never completed or predated provenance capture.
+type StrategyProvenance struct {
+	Definition *SourceLocation `json:"definition,omitempty" firestore:"definition,omitempty"` // build def entry, pinned at the serving ref
+	Inference  *InferenceRun   `json:"inference,omitempty" firestore:"inference,omitempty"`   // set iff inference ran
+}

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -213,6 +213,7 @@ type Verdict struct {
 	Target        rebuild.Target
 	Message       string
 	StrategyOneof StrategyOneOf
+	Provenance    *StrategyProvenance // strategy inputs, nil when unresolved or unrecorded by the producer
 	Timings       rebuild.Timings
 }
 
@@ -361,23 +362,24 @@ const (
 
 // RebuildAttempt stores rebuild and execution metadata on a single smoketest run.
 type RebuildAttempt struct {
-	Ecosystem       string          `firestore:"ecosystem,omitempty"`
-	Package         string          `firestore:"package,omitempty"`
-	Version         string          `firestore:"version,omitempty"`
-	Artifact        string          `firestore:"artifact,omitempty"`
-	Status          RebuildStatus   `firestore:"status,omitempty"`
-	Success         bool            `firestore:"success,omitempty"`
-	Message         string          `firestore:"message,omitempty"`
-	Strategy        StrategyOneOf   `firestore:"strategyoneof,omitempty"`
-	Dockerfile      string          `firestore:"dockerfile,omitempty"`
-	Timings         rebuild.Timings `firestore:"timings,omitempty"`
-	ExecutorVersion string          `firestore:"executor_version,omitempty"`
-	RunID           string          `firestore:"run_id,omitempty"`
-	BuildID         string          `firestore:"build_id,omitempty"`
-	ObliviousID     string          `firestore:"oblivious_id,omitempty"`
-	Started         time.Time       `firestore:"started,omitempty"`  // The time rebuild started
-	Finished        time.Time       `firestore:"finished,omitempty"` // The time rebuild finished
-	Created         time.Time       `firestore:"created,omitempty"`  // The time this record was created
+	Ecosystem       string              `firestore:"ecosystem,omitempty"`
+	Package         string              `firestore:"package,omitempty"`
+	Version         string              `firestore:"version,omitempty"`
+	Artifact        string              `firestore:"artifact,omitempty"`
+	Status          RebuildStatus       `firestore:"status,omitempty"`
+	Success         bool                `firestore:"success,omitempty"`
+	Message         string              `firestore:"message,omitempty"`
+	Strategy        StrategyOneOf       `firestore:"strategyoneof,omitempty"`
+	Dockerfile      string              `firestore:"dockerfile,omitempty"`
+	Timings         rebuild.Timings     `firestore:"timings,omitempty"`
+	ExecutorVersion string              `firestore:"executor_version,omitempty"`
+	RunID           string              `firestore:"run_id,omitempty"`
+	BuildID         string              `firestore:"build_id,omitempty"`
+	ObliviousID     string              `firestore:"oblivious_id,omitempty"`
+	Provenance      *StrategyProvenance `firestore:"provenance,omitempty"` // strategy inputs, nil for legacy records or pre-resolution failures
+	Started         time.Time           `firestore:"started,omitempty"`    // The time rebuild started
+	Finished        time.Time           `firestore:"finished,omitempty"`   // The time rebuild finished
+	Created         time.Time           `firestore:"created,omitempty"`    // The time this record was created
 }
 
 func (a RebuildAttempt) Target() rebuild.Target {

--- a/tools/benchmark/run/local.go
+++ b/tools/benchmark/run/local.go
@@ -76,6 +76,8 @@ func (s *localExecutionService) RebuildPackage(ctx context.Context, req schema.R
 		return verdict, nil
 	}
 	verdict.StrategyOneof = schema.NewStrategyOneOf(strategy)
+	// In-process inference ran. There is no service version to report.
+	verdict.Provenance = &schema.StrategyProvenance{Inference: &schema.InferenceRun{}}
 	if err := executeBuild(ctx, t, strategy, s.store, buildOpts{PrebuildURL: s.prebuildURL, LogSink: s.logsink}, s.dockerConfig); err != nil {
 		verdict.Message = err.Error()
 	} else if err := compare(ctx, t, s.store, mux); err != nil {

--- a/tools/benchmark/run/run.go
+++ b/tools/benchmark/run/run.go
@@ -271,7 +271,9 @@ func (w *inferenceWorker) ProcessOne(ctx context.Context, p benchmark.Package, o
 					Artifact:  artifact,
 				},
 				StrategyOneof: *strat,
-				Message:       "inference success",
+				// Remote inference ran. Its version is not resolved here.
+				Provenance: &schema.StrategyProvenance{Inference: &schema.InferenceRun{}},
+				Message:    "inference success",
 			}
 		}
 	}


### PR DESCRIPTION
Adds provenance i.e. the origin of the produced strategy. Definition is
a SourceLocation (a schema mirror of attestation.SourceLocation) pinning
the build-def entry consulted at the ref that served the attempt.
Inference records that the inference service ran and its reported
version, resolved by an out-of-band /version call. Notably, a
hint-guided inference sets both fields.