### PR TITLE
Refine registry search after coarse scan

### DIFF
--- a/pkg/registry/cratesio/index/find.go
+++ b/pkg/registry/cratesio/index/find.go
@@ -177,28 +177,21 @@ func findCommitWithVersions(repo *git.Repository, packages []internalPackage, pu
 	// until we find a drop in the number of matches.
 	day := 24 * time.Hour
 	nextCheckTime := firstCommit.Committer.When.Add(-day)
-	foundDrop := false
 	for c, err := range iterx.ToSeq2(commitIter, io.EOF) {
 		if err != nil {
 			return nil, errors.Wrap(err, "iterating over daily commits")
 		}
 		if c.Committer.When.Before(nextCheckTime) {
 			if matchesFor(c) < maxFound {
-				foundDrop = true
 				break
 			}
 			upperBoundCommit = c
 			nextCheckTime = c.Committer.When.Add(-day)
 		}
 	}
-	if !foundDrop {
-		return &searchResult{
-			ResolutionCommit: upperBoundCommit,
-			ResolvableCrates: maxFound,
-			PriorCommit:      nil,
-		}, nil
-	}
-	// Scan backwards through that day's commits again to find the exact drop
+	// Scan backwards through the remaining commits to find the exact drop.
+	// This is also required when the coarse scan reaches the repository root:
+	// the unexamined tail may be shorter than one day.
 	commitIter, err = repo.Log(&git.LogOptions{From: upperBoundCommit.Hash})
 	if err != nil {
 		return nil, fmt.Errorf("failed to iterate commits: %w", err)

--- a/pkg/registry/cratesio/index/find.go
+++ b/pkg/registry/cratesio/index/find.go
@@ -177,17 +177,30 @@ func findCommitWithVersions(repo *git.Repository, packages []internalPackage, pu
 	// until we find a drop in the number of matches.
 	day := 24 * time.Hour
 	nextCheckTime := firstCommit.Committer.When.Add(-day)
+	oldestCommit := firstCommit
+	foundDrop := false
 	for c, err := range iterx.ToSeq2(commitIter, io.EOF) {
 		if err != nil {
 			return nil, errors.Wrap(err, "iterating over daily commits")
 		}
+		oldestCommit = c
 		if c.Committer.When.Before(nextCheckTime) {
 			if matchesFor(c) < maxFound {
+				foundDrop = true
 				break
 			}
 			upperBoundCommit = c
 			nextCheckTime = c.Committer.When.Add(-day)
 		}
+	}
+	// The coarse scan leaves up to a day of commits above the root unexamined;
+	// probing the root directly settles the all-matches case without a rescan.
+	if !foundDrop && matchesFor(oldestCommit) == maxFound {
+		return &searchResult{
+			ResolutionCommit: oldestCommit,
+			ResolvableCrates: maxFound,
+			PriorCommit:      nil,
+		}, nil
 	}
 	// Scan backwards through the remaining commits to find the exact drop.
 	// This is also required when the coarse scan reaches the repository root:

--- a/pkg/registry/cratesio/index/find.go
+++ b/pkg/registry/cratesio/index/find.go
@@ -202,9 +202,7 @@ func findCommitWithVersions(repo *git.Repository, packages []internalPackage, pu
 			PriorCommit:      nil,
 		}, nil
 	}
-	// Scan backwards through the remaining commits to find the exact drop.
-	// This is also required when the coarse scan reaches the repository root:
-	// the unexamined tail may be shorter than one day.
+	// Scan backwards through that day's commits again to find the exact drop
 	commitIter, err = repo.Log(&git.LogOptions{From: upperBoundCommit.Hash})
 	if err != nil {
 		return nil, fmt.Errorf("failed to iterate commits: %w", err)

--- a/pkg/registry/cratesio/index/find_test.go
+++ b/pkg/registry/cratesio/index/find_test.go
@@ -181,6 +181,27 @@ func TestFindRegistryResolution(t *testing.T) {
 			wantCommit:     "snapshot-commit",
 		},
 		{
+			name: "refine tail when coarse scan finds no drop",
+			repoYAMLs: []string{
+				`commits:
+  - id: initial-commit
+    files:
+      se/rd/serde: |
+        {"name":"serde","vers":"1.0.193","deps":[],"cksum":"abc123","features":{},"yanked":false}
+  - id: second-commit
+    parent: initial-commit
+  - id: third-commit
+    parent: second-commit
+`,
+			},
+			packages: []cargolock.Package{
+				{Name: "serde", Version: "1.0.193"},
+			},
+			cratePublished: time.Now(),
+			wantRepoIndex:  0,
+			wantCommit:     "initial-commit",
+		},
+		{
 			name: "empty packages is an error",
 			repoYAMLs: []string{
 				`commits:


### PR DESCRIPTION
When the coarse scan reaches the repository root without observing a drop in the match count, `FindRegistryResolution` returns the last sampled commit. Commits between that sample and the root are never checked, so the result can be later than the earliest matching state.

Track the oldest commit reached by the coarse scan and probe it before deciding whether a fine-grained scan is needed. If the root has the same match count as the baseline, return it directly; otherwise refine from the last complete coarse sample. The regression case covers multiple matching commits within one coarse interval.

Testing:
- `go test ./pkg/registry/cratesio/index`
- `go test ./...`
- `go vet ./...`