### PR TITLE
Handle multiple versions sharing an index path

### DIFF
--- a/pkg/registry/cratesio/index/find.go
+++ b/pkg/registry/cratesio/index/find.go
@@ -115,19 +115,23 @@ var errNoMatches = errors.New("no packages found at publish time")
 
 func findCommitWithVersions(repo *git.Repository, packages []internalPackage, published time.Time, cfg *FindConfig) (*searchResult, error) {
 	blobHashes := make(map[string]plumbing.Hash)
-	present := make(map[string]bool)
+	present := make(map[string]map[string]bool)
+	packagesByPath := make(map[string][]internalPackage)
+	for _, pkg := range packages {
+		packagesByPath[pkg.Path] = append(packagesByPath[pkg.Path], pkg)
+	}
 	matchesFor := func(commit *object.Commit) int {
 		tree, err := commit.Tree()
 		if err != nil {
 			return 0
 		}
 		var found int
-		for _, pkg := range packages {
-			entry, err := tree.FindEntry(pkg.Path)
+		for path, pathPackages := range packagesByPath {
+			entry, err := tree.FindEntry(path)
 			if err != nil {
 				continue
 			}
-			if entry.Hash != blobHashes[pkg.Path] {
+			if entry.Hash != blobHashes[path] {
 				blob, err := repo.BlobObject(entry.Hash)
 				if err != nil {
 					continue
@@ -141,11 +145,16 @@ func findCommitWithVersions(repo *git.Repository, packages []internalPackage, pu
 				if err != nil {
 					continue
 				}
-				blobHashes[pkg.Path] = entry.Hash
-				present[pkg.Path] = bytes.Contains(content, []byte(`"vers":"`+pkg.Version+`"`))
+				blobHashes[path] = entry.Hash
+				present[path] = make(map[string]bool, len(pathPackages))
+				for _, pkg := range pathPackages {
+					present[path][pkg.Version] = bytes.Contains(content, []byte(`"vers":"`+pkg.Version+`"`))
+				}
 			}
-			if present[pkg.Path] {
-				found++
+			for _, pkg := range pathPackages {
+				if present[path][pkg.Version] {
+					found++
+				}
 			}
 		}
 		if cfg != nil && cfg.VerboseLogging {

--- a/pkg/registry/cratesio/index/find_test.go
+++ b/pkg/registry/cratesio/index/find_test.go
@@ -148,6 +148,31 @@ func TestFindRegistryResolution(t *testing.T) {
 			wantCommit:     "initial-commit",
 		},
 		{
+			name: "distinguish versions sharing an index path across repos",
+			repoYAMLs: []string{
+				`commits:
+  - id: current-commit
+    files:
+      se/rd/serde: |
+        {"name":"serde","vers":"1.0.0","deps":[],"cksum":"abc123","features":{},"yanked":false}
+        {"name":"serde","vers":"1.0.193","deps":[],"cksum":"new123","features":{},"yanked":false}
+`,
+				`commits:
+  - id: snapshot-commit
+    files:
+      se/rd/serde: |
+        {"name":"serde","vers":"1.0.0","deps":[],"cksum":"abc123","features":{},"yanked":false}
+`,
+			},
+			packages: []cargolock.Package{
+				{Name: "serde", Version: "1.0.0"},
+				{Name: "serde", Version: "1.0.193"},
+			},
+			cratePublished: time.Now(),
+			wantRepoIndex:  0,
+			wantCommit:     "current-commit",
+		},
+		{
 			name: "find in second repo when first not found",
 			repoYAMLs: []string{
 				// Current repo without the packages


### PR DESCRIPTION
A Cargo.lock can contain multiple versions of the same crate. These entries share one crates.io index path, but `findCommitWithVersions` caches presence only by path. The result for the first version is then reused for the others, which can overcount matches and select an older snapshot that does not contain every requested version.

Group lockfile entries by index path so each blob is still read once, while tracking presence separately for each version. The regression test covers two versions in the current index and only one in the older snapshot.

Testing:
- `go test ./pkg/registry/cratesio/index`
- `go test ./...`
- `go vet ./...`