### PR TITLE
Require a complete registry search upper bound

### DIFF
--- a/internal/api/cratesregistryservice/findcommit.go
+++ b/internal/api/cratesregistryservice/findcommit.go
@@ -6,6 +6,7 @@ package cratesregistryservice
 import (
 	"context"
 	"encoding/base64"
+	"sort"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -26,6 +27,8 @@ import (
 type FindRegistryCommitRequest struct {
 	LockfileBase64 string `form:"lockfile_base64"`
 	PublishedTime  string `form:"published_time"`
+	Package        string `form:"package"`
+	Version        string `form:"version"`
 }
 
 func (r FindRegistryCommitRequest) Validate() error {
@@ -34,6 +37,9 @@ func (r FindRegistryCommitRequest) Validate() error {
 	}
 	if r.PublishedTime == "" {
 		return errors.New("published_time is required")
+	}
+	if (r.Package == "") != (r.Version == "") {
+		return errors.New("package and version must be provided together")
 	}
 	if _, err := time.Parse(time.RFC3339, r.PublishedTime); err != nil {
 		return errors.Wrap(err, "invalid published_time format, must be RFC3339")
@@ -79,22 +85,8 @@ func FindRegistryCommit(ctx context.Context, req FindRegistryCommitRequest, deps
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "failed to get available snapshots"))
 	}
 	relevantSnapshots := getRelevantSnapshots(snapshots, publishedTime)
-	// Determine if we need the current repository
-	var needsCurrent bool
-	if len(relevantSnapshots) == 0 {
-		needsCurrent = true
-	} else {
-		mostRecentSnapshotDate := relevantSnapshots[0]
-		needsCurrent = req.PublishedTime > mostRecentSnapshotDate
-	}
 	// Build list of repositories in newest-to-oldest order
-	var keys []index.RepositoryKey
-	if needsCurrent {
-		keys = append(keys, index.RepositoryKey{Type: index.CurrentIndex})
-	}
-	for _, snapshotDate := range relevantSnapshots {
-		keys = append(keys, index.RepositoryKey{Type: index.SnapshotIndex, Name: snapshotDate})
-	}
+	keys := repositoryKeysForPublication(relevantSnapshots, publishedTime, req.Package != "")
 	if len(keys) == 0 {
 		return &FindRegistryCommitResponse{}, nil
 	}
@@ -127,8 +119,32 @@ func FindRegistryCommit(ctx context.Context, req FindRegistryCommitRequest, deps
 	for _, handle := range handles {
 		repos = append(repos, handle.Repository)
 	}
-	// Find the registry resolution
-	resolution, err := index.FindRegistryResolution(repos, packages, publishedTime, nil)
+	var resolution *index.RegistryResolution
+	if req.Package == "" {
+		// Preserve compatibility with clients deployed before target anchoring.
+		resolution, err = index.FindRegistryResolution(repos, packages, publishedTime, nil)
+	} else {
+		// API publication timestamps can precede the corresponding index updates.
+		// Anchor the lock search at the target's own first index-visible commit.
+		target := cargolock.Package{Name: req.Package, Version: req.Version}
+		resolution, err = index.FindRegistryResolutionAtPackage(repos, packages, target, nil)
+		if errors.Is(err, index.ErrTargetPackageNotFound) {
+			newerKey, ok := nextNewerRepositoryKey(keys[0], snapshots)
+			if !ok {
+				return nil, api.AsStatus(codes.Unavailable, errors.New("target package version is not yet indexed"))
+			}
+			newerHandle, acquireErr := deps.IndexManager.GetRepository(ctx, newerKey)
+			if acquireErr != nil {
+				return nil, api.AsStatus(codes.Internal, errors.Wrap(acquireErr, "failed to get newer registry repository"))
+			}
+			handles = append(handles, newerHandle)
+			repos = append([]*git.Repository{newerHandle.Repository}, repos...)
+			resolution, err = index.FindRegistryResolutionAtPackage(repos, packages, target, nil)
+			if errors.Is(err, index.ErrTargetPackageNotFound) {
+				return nil, api.AsStatus(codes.Unavailable, errors.New("target package version is not yet indexed"))
+			}
+		}
+	}
 	if err != nil {
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "failed to find registry resolution"))
 	}
@@ -138,6 +154,35 @@ func FindRegistryCommit(ctx context.Context, req FindRegistryCommitRequest, deps
 	return &FindRegistryCommitResponse{
 		CommitHash: resolution.CommitHash.String(),
 	}, nil
+}
+
+func repositoryKeysForPublication(relevantSnapshots []string, published time.Time, targetAware bool) []index.RepositoryKey {
+	var keys []index.RepositoryKey
+	publishedValue := published.Format(time.RFC3339)
+	if targetAware {
+		publishedValue = published.Format(time.DateOnly)
+	}
+	if len(relevantSnapshots) == 0 || publishedValue > relevantSnapshots[0] {
+		keys = append(keys, index.RepositoryKey{Type: index.CurrentIndex})
+	}
+	for _, snapshotDate := range relevantSnapshots {
+		keys = append(keys, index.RepositoryKey{Type: index.SnapshotIndex, Name: snapshotDate})
+	}
+	return keys
+}
+
+func nextNewerRepositoryKey(key index.RepositoryKey, snapshots []string) (index.RepositoryKey, bool) {
+	if key.Type == index.CurrentIndex {
+		return index.RepositoryKey{}, false
+	}
+	position := sort.SearchStrings(snapshots, key.Name)
+	if position >= len(snapshots) || snapshots[position] != key.Name {
+		return index.RepositoryKey{}, false
+	}
+	if position+1 < len(snapshots) {
+		return index.RepositoryKey{Type: index.SnapshotIndex, Name: snapshots[position+1]}, true
+	}
+	return index.RepositoryKey{Type: index.CurrentIndex}, true
 }
 
 // getRelevantSnapshots determines which snapshots are relevant based on publish date

--- a/internal/api/cratesregistryservice/findcommit_test.go
+++ b/internal/api/cratesregistryservice/findcommit_test.go
@@ -6,7 +6,11 @@ package cratesregistryservice
 import (
 	"context"
 	"encoding/base64"
+	"slices"
 	"testing"
+	"time"
+
+	"github.com/google/oss-rebuild/pkg/registry/cratesio/index"
 )
 
 func TestFindRegistryCommitWithoutRegistryPackages(t *testing.T) {
@@ -25,5 +29,92 @@ version = "1.0.0"
 	}
 	if response.CommitHash != "" {
 		t.Errorf("FindRegistryCommit() commit = %q, want empty", response.CommitHash)
+	}
+}
+
+func TestFindRegistryCommitRequestTargetPair(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		pkg     string
+		version string
+		wantErr bool
+	}{
+		{name: "both omitted"},
+		{name: "both provided", pkg: "serde", version: "1.0.228"},
+		{name: "package only", pkg: "serde", wantErr: true},
+		{name: "version only", version: "1.0.228", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := FindRegistryCommitRequest{
+				LockfileBase64: "Cg==",
+				PublishedTime:  "2025-01-01T00:00:00Z",
+				Package:        test.pkg,
+				Version:        test.version,
+			}
+			if err := req.Validate(); (err != nil) != test.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestRepositoryKeysForPublication(t *testing.T) {
+	published := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	snapshots := []string{"2026-05-25"}
+	for _, test := range []struct {
+		name        string
+		targetAware bool
+		want        []index.RepositoryKey
+	}{
+		{
+			name:        "target anchored",
+			targetAware: true,
+			want:        []index.RepositoryKey{{Type: index.SnapshotIndex, Name: "2026-05-25"}},
+		},
+		{
+			name: "legacy request",
+			want: []index.RepositoryKey{
+				{Type: index.CurrentIndex},
+				{Type: index.SnapshotIndex, Name: "2026-05-25"},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := repositoryKeysForPublication(snapshots, published, test.targetAware)
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("repositoryKeysForPublication() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNextNewerRepositoryKey(t *testing.T) {
+	snapshots := []string{"2026-04-19", "2026-04-28", "2026-05-25"}
+	for _, test := range []struct {
+		name string
+		key  index.RepositoryKey
+		want index.RepositoryKey
+		ok   bool
+	}{
+		{
+			name: "next snapshot",
+			key:  index.RepositoryKey{Type: index.SnapshotIndex, Name: "2026-04-28"},
+			want: index.RepositoryKey{Type: index.SnapshotIndex, Name: "2026-05-25"},
+			ok:   true,
+		},
+		{
+			name: "current after latest snapshot",
+			key:  index.RepositoryKey{Type: index.SnapshotIndex, Name: "2026-05-25"},
+			want: index.RepositoryKey{Type: index.CurrentIndex},
+			ok:   true,
+		},
+		{name: "already current", key: index.RepositoryKey{Type: index.CurrentIndex}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := nextNewerRepositoryKey(test.key, snapshots)
+			if ok != test.ok || got != test.want {
+				t.Fatalf("nextNewerRepositoryKey() = (%v, %t), want (%v, %t)", got, ok, test.want, test.ok)
+			}
+		})
 	}
 }

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -313,6 +313,8 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			resp, err := stub(ctx, cratesregistryservice.FindRegistryCommitRequest{
 				LockfileBase64: base64.StdEncoding.EncodeToString(lockContent),
 				PublishedTime:  vmeta.Created.Format(time.RFC3339),
+				Package:        t.Package,
+				Version:        t.Version,
 			})
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to call registry service")

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -825,6 +825,12 @@ version = 3
 					if tc.wantPublishTime != "" && req.PublishedTime != tc.wantPublishTime {
 						t.Errorf("PublishedTime = %q, want %q", req.PublishedTime, tc.wantPublishTime)
 					}
+					if req.Package != "serde" {
+						t.Errorf("Package = %q, want %q", req.Package, "serde")
+					}
+					if req.Version != "1.0.150" {
+						t.Errorf("Version = %q, want %q", req.Version, "1.0.150")
+					}
 					return tc.registryResponse, nil
 				}
 				ctx = context.WithValue(ctx, rebuild.CratesRegistryStubID, api.StubFn[cratesregistryservice.FindRegistryCommitRequest, cratesregistryservice.FindRegistryCommitResponse](mockStub))

--- a/pkg/registry/cratesio/index/find.go
+++ b/pkg/registry/cratesio/index/find.go
@@ -90,6 +90,9 @@ func findRegistryResolution(indices []*git.Repository, lockfileCrates []cargoloc
 			}
 			return nil, errors.Wrap(err, "searching index")
 		}
+		if i == 0 && result.ResolvableCrates != len(internalPackages) {
+			return nil, errors.Errorf("registry search upper bound contains %d of %d packages", result.ResolvableCrates, len(internalPackages))
+		}
 		if lastResult != nil {
 			// Edge case: If the previous repo didn't find a boundary and this one
 			// has fewer crates, we've found our transition point:

--- a/pkg/registry/cratesio/index/find.go
+++ b/pkg/registry/cratesio/index/find.go
@@ -38,6 +38,31 @@ type FindConfig struct {
 // Indices should be ordered from newest to oldest (e.g., current index first, then previous snapshot(s)).
 // An optional config parameter can be provided to control logging and other behaviors.
 func FindRegistryResolution(indices []*git.Repository, lockfileCrates []cargolock.Package, cratePublished time.Time, cfg *FindConfig) (*RegistryResolution, error) {
+	return findRegistryResolution(indices, lockfileCrates, nil, &cratePublished, cfg)
+}
+
+// FindRegistryResolutionAtPackage anchors the lock search at the target
+// package's first index-visible commit in the newest supplied index.
+func FindRegistryResolutionAtPackage(indices []*git.Repository, lockfileCrates []cargolock.Package, target cargolock.Package, cfg *FindConfig) (*RegistryResolution, error) {
+	if len(indices) == 0 {
+		return nil, errors.New("no registry indices to search")
+	}
+	head, err := indices[0].Head()
+	if err != nil {
+		return nil, errors.Wrap(err, "reading registry HEAD")
+	}
+	headHash := head.Hash()
+	targetResolution, err := findRegistryResolution(indices[:1], []cargolock.Package{target}, &headHash, nil, cfg)
+	if err != nil {
+		if errors.Is(err, errNoMatches) {
+			return nil, ErrTargetPackageNotFound
+		}
+		return nil, errors.Wrap(err, "finding target in registry")
+	}
+	return findRegistryResolution(indices, lockfileCrates, &targetResolution.CommitHash, nil, cfg)
+}
+
+func findRegistryResolution(indices []*git.Repository, lockfileCrates []cargolock.Package, upperCommit *plumbing.Hash, upperTime *time.Time, cfg *FindConfig) (*RegistryResolution, error) {
 	if len(lockfileCrates) == 0 {
 		return nil, errors.New("no crates to resolve")
 	}
@@ -52,7 +77,11 @@ func FindRegistryResolution(indices []*git.Repository, lockfileCrates []cargoloc
 	var lastResult, bestResult *searchResult
 	// Search each index in order until found
 	for i, index := range indices {
-		result, err := findCommitWithVersions(index, internalPackages, cratePublished, cfg)
+		var from *plumbing.Hash
+		if i == 0 {
+			from = upperCommit
+		}
+		result, err := findCommitWithVersions(index, internalPackages, from, upperTime, cfg)
 		if err != nil {
 			if i > 0 && err == errNoMatches {
 				// Edge case: For multi-index searches, subsequent indices may lack matches:
@@ -111,9 +140,13 @@ func EntryPath(name string) string {
 	}
 }
 
-var errNoMatches = errors.New("no packages found at publish time")
+var errNoMatches = errors.New("no packages found at search upper bound")
 
-func findCommitWithVersions(repo *git.Repository, packages []internalPackage, published time.Time, cfg *FindConfig) (*searchResult, error) {
+// ErrTargetPackageNotFound indicates that the target package version is not
+// present in the newest supplied registry segment.
+var ErrTargetPackageNotFound = errors.New("target package version not found")
+
+func findCommitWithVersions(repo *git.Repository, packages []internalPackage, upperCommit *plumbing.Hash, upperTime *time.Time, cfg *FindConfig) (*searchResult, error) {
 	blobHashes := make(map[string]plumbing.Hash)
 	present := make(map[string]map[string]bool)
 	packagesByPath := make(map[string][]internalPackage)
@@ -162,9 +195,15 @@ func findCommitWithVersions(repo *git.Repository, packages []internalPackage, pu
 		}
 		return found
 	}
-	// Get a single iterator for the entire history up to the publish time.
+	// Get a single iterator for the available history up to the requested bound.
 	// The default order is reverse chronological, which is what we want.
-	commitIter, err := repo.Log(&git.LogOptions{Until: &published})
+	logOpts := &git.LogOptions{}
+	if upperCommit != nil {
+		logOpts.From = *upperCommit
+	} else if upperTime != nil {
+		logOpts.Until = upperTime
+	}
+	commitIter, err := repo.Log(logOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +211,7 @@ func findCommitWithVersions(repo *git.Repository, packages []internalPackage, pu
 	// Analyze the very first commit to establish the baseline number of matches.
 	firstCommit, err := commitIter.Next()
 	if err == io.EOF {
-		return nil, errors.New("no commits found before publish time")
+		return nil, errors.New("no commits found before search upper bound")
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/cratesio/index/find_test.go
+++ b/pkg/registry/cratesio/index/find_test.go
@@ -284,6 +284,80 @@ func TestFindRegistryResolution(t *testing.T) {
 	}
 }
 
+func TestFindRegistryResolutionAtPackage(t *testing.T) {
+	repo := mustCreateRepo(t, `commits:
+  - id: initial
+    files:
+      de/pe/dependency: |
+        {"name":"dependency","vers":"1.0.0"}
+  - id: target
+    parent: initial
+    files:
+      de/pe/dependency: |
+        {"name":"dependency","vers":"1.0.0"}
+        {"name":"dependency","vers":"2.0.0"}
+  - id: later
+    parent: target
+    files:
+      de/pe/dependency: |
+        {"name":"dependency","vers":"1.0.0"}
+        {"name":"dependency","vers":"2.0.0"}
+        {"name":"dependency","vers":"3.0.0"}
+`)
+	target := cargolock.Package{Name: "dependency", Version: "2.0.0"}
+
+	if _, err := FindRegistryResolution(
+		[]*git.Repository{repo.Repository},
+		[]cargolock.Package{target},
+		time.Time{}.Add(-time.Second),
+		nil,
+	); err == nil {
+		t.Fatal("FindRegistryResolution() succeeded before the target was indexed")
+	}
+
+	resolution, err := FindRegistryResolutionAtPackage(
+		[]*git.Repository{repo.Repository},
+		[]cargolock.Package{target},
+		target,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolution.CommitHash != repo.Commits["target"] {
+		t.Fatalf("FindRegistryResolutionAtPackage() = %s, want %s", resolution.CommitHash, repo.Commits["target"])
+	}
+
+	targetCommit, err := repo.CommitObject(repo.Commits["target"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	laterCommit, err := repo.CommitObject(repo.Commits["later"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !targetCommit.Committer.When.Equal(laterCommit.Committer.When) {
+		t.Fatal("fixture commits must share a timestamp")
+	}
+	if _, err := FindRegistryResolutionAtPackage(
+		[]*git.Repository{repo.Repository},
+		[]cargolock.Package{{Name: "dependency", Version: "3.0.0"}},
+		target,
+		nil,
+	); err == nil {
+		t.Fatal("FindRegistryResolutionAtPackage() included a later commit with the same timestamp")
+	}
+
+	if _, err := FindRegistryResolutionAtPackage(
+		[]*git.Repository{repo.Repository},
+		[]cargolock.Package{target},
+		cargolock.Package{Name: "dependency", Version: "4.0.0"},
+		nil,
+	); err != ErrTargetPackageNotFound {
+		t.Fatalf("FindRegistryResolutionAtPackage() error = %v, want %v", err, ErrTargetPackageNotFound)
+	}
+}
+
 func TestFindRegistryResolutionExcludesPathPackage(t *testing.T) {
 	current := mustCreateRepo(t, `commits:
   - id: current

--- a/pkg/registry/cratesio/index/find_test.go
+++ b/pkg/registry/cratesio/index/find_test.go
@@ -347,6 +347,17 @@ func TestFindRegistryResolutionAtPackage(t *testing.T) {
 	); err == nil {
 		t.Fatal("FindRegistryResolutionAtPackage() included a later commit with the same timestamp")
 	}
+	if _, err := FindRegistryResolutionAtPackage(
+		[]*git.Repository{repo.Repository},
+		[]cargolock.Package{
+			{Name: "dependency", Version: "1.0.0"},
+			{Name: "dependency", Version: "3.0.0"},
+		},
+		target,
+		nil,
+	); err == nil {
+		t.Fatal("FindRegistryResolutionAtPackage() accepted an incomplete upper bound")
+	}
 
 	if _, err := FindRegistryResolutionAtPackage(
 		[]*git.Repository{repo.Repository},
@@ -392,17 +403,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 		t.Fatalf("ParseLockfile() error = %v", err)
 	}
 
-	unfiltered, err := FindRegistryResolution(
+	if _, err := FindRegistryResolution(
 		[]*git.Repository{current.Repository, snapshot.Repository},
 		lockfile.Packages,
 		time.Now(),
 		nil,
-	)
-	if err != nil {
-		t.Fatalf("FindRegistryResolution() with all packages error = %v", err)
-	}
-	if unfiltered.CommitHash != current.Commits["current"] {
-		t.Fatalf("unfiltered resolution = %v, want current index", unfiltered.CommitHash)
+	); err == nil {
+		t.Fatal("FindRegistryResolution() with all packages succeeded")
 	}
 
 	filtered, err := FindRegistryResolution(


### PR DESCRIPTION
Parents: #1375

The registry search currently accepts any non-zero number of pins at its newest upper bound. If that bound is incomplete, it can return a `RegistryCommit` that never contained the full lockfile view.

Require the first search segment to contain every requested pin before walking older history. Older segments may still contain fewer pins; that decrease remains the boundary signal.

Testing:
- `go test ./...`
- `go vet ./...`
- Replayed 441 target-anchored cases: all upper bounds were complete, with no probe errors or missing pins.