### PR TITLE
Ensure native clone disables reftable storage

### DIFF
--- a/internal/gitx/clone.go
+++ b/internal/gitx/clone.go
@@ -256,6 +256,10 @@ func NativeClone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt
 	args = append(args, opt.URL, targetDir)
 	// Execute the git command
 	cmd := exec.CommandContext(ctx, "git", args...)
+	// NOTE: go-git cannot read the reftable refstorage format so force "files".
+	// See https://github.com/go-git/go-git/issues/1827
+	// Unlike --ref-format, this var is a no-op on git versions predating reftable.
+	cmd.Env = append(os.Environ(), "GIT_DEFAULT_REF_FORMAT=files")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, classifyCloneError(output, err)

--- a/internal/gitx/clone_test.go
+++ b/internal/gitx/clone_test.go
@@ -216,6 +216,39 @@ commits:
 	}
 }
 
+func TestNativeClone_ReftableDefaultHost(t *testing.T) {
+	if !NativeGitAvailable() {
+		t.Skip("native git not available")
+	}
+	// Hosts may default new repos to the reftable format which go-git cannot
+	// read. NativeClone must override it for the cloned repo to be usable.
+	t.Setenv("GIT_DEFAULT_REF_FORMAT", "reftable")
+	ctx := context.Background()
+	upstreamURL := setupLocalRepo(t, `
+commits:
+  - id: initial
+    branch: master
+    message: "Initial commit"
+    files:
+      README.md: "Test content"
+`)
+	storer := filesystem.NewStorage(osfs.New(t.TempDir()), cache.NewObjectLRUDefault())
+	repo, err := NativeClone(ctx, storer, nil, &git.CloneOptions{
+		URL:        upstreamURL,
+		NoCheckout: true,
+	})
+	if err != nil {
+		t.Fatalf("NativeClone failed: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("failed to get HEAD: %v", err)
+	}
+	if _, err := repo.CommitObject(head.Hash()); err != nil {
+		t.Fatalf("failed to get commit: %v", err)
+	}
+}
+
 func TestNativeClone_MemoryStorageLargeObject(t *testing.T) {
 	if !NativeGitAvailable() {
 		t.Skip("native git not available")


### PR DESCRIPTION
This mode is not yet available in a go-git release.