### PR TITLE
Record repo size metrics on inference clone

### DIFF
--- a/cmd/inference/main.go
+++ b/cmd/inference/main.go
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"net/url"
 
+	"cloud.google.com/go/firestore"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/api/inferenceservice"
+	"github.com/google/oss-rebuild/internal/db"
 	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/httpegress"
@@ -26,6 +28,7 @@ import (
 var (
 	gitCacheURL       = flag.String("git-cache-url", "", "if provided, the git-cache service to use to fetch repos")
 	cratesRegistryURL = flag.String("crates-registry-service-url", "", "if provided, the crates registry service to use for Rust crate index resolution")
+	project           = flag.String("project", "", "if provided, the GCP project whose Firestore holds repo_metrics records")
 	port              = flag.Int("port", 8080, "port on which to serve")
 )
 
@@ -34,6 +37,13 @@ var httpcfg = httpegress.Config{}
 func InferInit(ctx context.Context) (*inferenceservice.InferDeps, error) {
 	var d inferenceservice.InferDeps
 	var err error
+	if *project != "" {
+		fs, err := firestore.NewClient(ctx, *project)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating firestore client")
+		}
+		d.RepoMetrics = db.NewFirestoreRepoMetrics(fs)
+	}
 	d.HTTPClient, err = httpegress.MakeClient(ctx, httpcfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "making http client")

--- a/deployments/iam.tf
+++ b/deployments/iam.tf
@@ -88,7 +88,11 @@ resource "google_storage_bucket_iam_member" "git-cache-views-git-cache" {
 resource "google_storage_bucket_iam_member" "cachers-read-git-cache" {
   bucket = google_storage_bucket.git-cache.name
   role   = "roles/storage.objectViewer"
-  member = google_service_account.crates-registry.member
+  for_each = toset([
+    google_service_account.crates-registry.member,
+    google_service_account.inference.member,
+  ])
+  member = each.key
 }
 resource "google_storage_bucket_iam_member" "orchestrator-writes-attestations" {
   bucket = google_storage_bucket.attestations.name
@@ -164,6 +168,11 @@ resource "google_project_iam_member" "orchestrator-uses-datastore" {
   role    = "roles/datastore.user"
   member  = google_service_account.orchestrator.member
 }
+resource "google_project_iam_member" "inference-uses-datastore" {
+  project = var.project
+  role    = "roles/datastore.user"
+  member  = google_service_account.inference.member
+}
 resource "google_storage_bucket_iam_member" "builders-view-bootstrap-bucket" {
   bucket = google_storage_bucket.bootstrap-tools.name
   role   = "roles/storage.objectViewer"
@@ -236,7 +245,11 @@ resource "google_cloud_run_v2_service_iam_member" "cachers-call-git-cache" {
   project  = google_cloud_run_v2_service.git-cache.project
   name     = google_cloud_run_v2_service.git-cache.name
   role     = "roles/run.invoker"
-  member   = google_service_account.crates-registry.member
+  for_each = toset([
+    google_service_account.crates-registry.member,
+    google_service_account.inference.member,
+  ])
+  member = each.key
 }
 resource "google_cloud_run_v2_service_iam_member" "api-and-inference-call-gateway" {
   location = google_cloud_run_v2_service.gateway.location

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -161,6 +161,7 @@ resource "google_cloud_run_v2_service" "inference" {
     containers {
       image = data.google_artifact_registry_docker_image.inference.self_link
       args = [
+        "--project=${var.project}",
         "--gateway-url=${google_cloud_run_v2_service.gateway.uri}",
         "--host=${var.host}",
         "--git-cache-url=${google_cloud_run_v2_service.git-cache.uri}",

--- a/internal/api/inferenceservice/infer.go
+++ b/internal/api/inferenceservice/infer.go
@@ -6,8 +6,10 @@ package inferenceservice
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
+	"github.com/google/oss-rebuild/internal/db"
 	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/httpx"
@@ -20,30 +22,30 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func doInfer(ctx context.Context, rebuilder rebuild.Rebuilder, t rebuild.Target, mux rebuild.RegistryMux, hint rebuild.Strategy, ropt *gitx.RepositoryOptions) (rebuild.Strategy, error) {
+func doInfer(ctx context.Context, rebuilder rebuild.Rebuilder, t rebuild.Target, mux rebuild.RegistryMux, hint rebuild.Strategy, ropt *gitx.RepositoryOptions) (rebuild.Strategy, rebuild.RepoConfig, error) {
 	var repo string
 	if lh, ok := hint.(*rebuild.LocationHint); ok && lh != nil {
 		var err error
 		repo, err = uri.CanonicalizeRepoURI(lh.Location.Repo)
 		if err != nil {
-			return nil, errors.Wrap(err, "canonicalizing repo hint")
+			return nil, rebuild.RepoConfig{}, errors.Wrap(err, "canonicalizing repo hint")
 		}
 	} else {
 		var err error
 		repo, err = rebuilder.InferRepo(ctx, t, mux)
 		if err != nil {
-			return nil, err
+			return nil, rebuild.RepoConfig{}, err
 		}
 	}
 	rcfg, err := rebuilder.CloneRepo(ctx, t, repo, ropt)
 	if err != nil {
-		return nil, err
+		return nil, rebuild.RepoConfig{}, err
 	}
 	strategy, err := rebuilder.InferStrategy(ctx, t, mux, &rcfg, hint)
 	if err != nil {
-		return nil, err
+		return nil, rcfg, err
 	}
-	return strategy, nil
+	return strategy, rcfg, nil
 }
 
 type InferDeps struct {
@@ -51,6 +53,39 @@ type InferDeps struct {
 	GitCache           *gitcache.Client
 	RepoOptF           func() *gitx.RepositoryOptions
 	CratesRegistryStub api.StubFn[cratesregistryservice.FindRegistryCommitRequest, cratesregistryservice.FindRegistryCommitResponse]
+	RepoMetrics        db.RepoMetrics // optional. when nil, repos are not measured on clone
+}
+
+// recordRepoMetrics measures rcfg and upserts its repo_metrics record keyed
+// by canonical repo URI.
+func recordRepoMetrics(ctx context.Context, store db.RepoMetrics, rcfg rebuild.RepoConfig) error {
+	canonical, err := uri.CanonicalizeRepoURI(rcfg.URI)
+	if err != nil {
+		return errors.Wrapf(err, "canonicalizing %q", rcfg.URI)
+	}
+	if rcfg.Repository == nil {
+		return errors.New("nil repository")
+	}
+	ref, err := rcfg.Head()
+	if err != nil {
+		return errors.Wrap(err, "resolving head")
+	}
+	bytes, err := gitx.ObjectStoreSize(rcfg.Storer)
+	if err != nil {
+		return errors.Wrap(err, "sizing object store")
+	}
+	commits, err := gitx.CommitCount(rcfg.Storer)
+	if err != nil {
+		return errors.Wrap(err, "counting commits")
+	}
+	m := schema.RepoMetrics{
+		URI:        canonical,
+		Bytes:      bytes,
+		Commits:    commits,
+		Head:       ref.Hash().String(),
+		MeasuredAt: time.Now().UTC(),
+	}
+	return errors.Wrap(store.Upsert(ctx, m), "upserting")
 }
 
 func Infer(ctx context.Context, req schema.InferenceRequest, deps *InferDeps) (*schema.StrategyOneOf, error) {
@@ -86,7 +121,13 @@ func Infer(ctx context.Context, req schema.InferenceRequest, deps *InferDeps) (*
 	if !ok {
 		return nil, api.AsStatus(codes.InvalidArgument, errors.New("unsupported ecosystem"))
 	}
-	s, err := doInfer(ctx, rebuilder, t, mux, req.LocationHint(), repoOpt)
+	s, rcfg, err := doInfer(ctx, rebuilder, t, mux, req.LocationHint(), repoOpt)
+	// TODO: Move before doInfer so we record metrics even when inference fails.
+	if deps.RepoMetrics != nil && rcfg.Repository != nil {
+		if err := recordRepoMetrics(ctx, deps.RepoMetrics, rcfg); err != nil {
+			log.Printf("repo_metrics: %s: %v", rcfg.URI, err)
+		}
+	}
 	if err != nil {
 		log.Printf("No inference for [pkg=%s, version=%v]: %v\n", req.Package, req.Version, err)
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "failed to infer strategy"))

--- a/internal/api/inferenceservice/infer_test.go
+++ b/internal/api/inferenceservice/infer_test.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package inferenceservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/internal/db"
+	"github.com/google/oss-rebuild/internal/gitx"
+	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+const twoCommitRepo = `
+commits:
+  - id: first
+    branch: master
+    message: "first"
+    files:
+      README.md: "hello"
+  - id: second
+    parent: first
+    branch: master
+    message: "second"
+    files:
+      README.md: "world"
+`
+
+func newTestRepo(t *testing.T) *gitxtest.Repository {
+	t.Helper()
+	// The filesystem-backed storer matches production and is required by
+	// gitx.ObjectStoreSize.
+	repo, err := gitxtest.CreateRepoFromYAML(twoCommitRepo, &gitxtest.RepositoryOptions{Storer: gitx.NewInMemoryStorer(), Worktree: memfs.New()})
+	if err != nil {
+		t.Fatalf("CreateRepoFromYAML: %v", err)
+	}
+	return repo
+}
+
+func TestRecordRepoMetrics(t *testing.T) {
+	repo := newTestRepo(t)
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	store := db.NewMemoryRepoMetrics()
+	// The non-canonical ssh alias exercises canonicalization on write.
+	rcfg := rebuild.RepoConfig{Repository: repo.Repository, URI: "git@github.com:Org/Repo.git"}
+	if err := recordRepoMetrics(context.Background(), store, rcfg); err != nil {
+		t.Fatalf("recordRepoMetrics: %v", err)
+	}
+	got, err := store.Get(context.Background(), "https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.URI != "https://github.com/org/repo" {
+		t.Errorf("URI = %q; want canonical https form", got.URI)
+	}
+	if got.Commits != 2 {
+		t.Errorf("Commits = %d; want 2", got.Commits)
+	}
+	if got.Head != head.Hash().String() {
+		t.Errorf("Head = %q; want %q", got.Head, head.Hash().String())
+	}
+	if got.Bytes <= 0 {
+		t.Errorf("Bytes = %d; want > 0", got.Bytes)
+	}
+	if got.MeasuredAt.IsZero() {
+		t.Error("MeasuredAt is zero; want a timestamp")
+	}
+}
+
+func TestRecordRepoMetricsBadURI(t *testing.T) {
+	repo := newTestRepo(t)
+	store := db.NewMemoryRepoMetrics()
+	if err := recordRepoMetrics(context.Background(), store, rebuild.RepoConfig{Repository: repo.Repository, URI: ""}); err == nil {
+		t.Error("recordRepoMetrics(empty URI) = nil error; want error")
+	}
+}
+
+func TestRecordRepoMetricsNilRepository(t *testing.T) {
+	store := db.NewMemoryRepoMetrics()
+	if err := recordRepoMetrics(context.Background(), store, rebuild.RepoConfig{URI: "https://github.com/org/repo"}); err == nil {
+		t.Error("recordRepoMetrics(nil repository) = nil error; want error")
+	}
+}

--- a/internal/billyx/size.go
+++ b/internal/billyx/size.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package billyx
+
+import (
+	"io/fs"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/util"
+)
+
+// DirSize returns the total size in bytes of all files under dir, recursively.
+func DirSize(bfs billy.Filesystem, dir string) (int64, error) {
+	var total int64
+	err := util.Walk(bfs, dir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total, err
+}

--- a/internal/billyx/size_test.go
+++ b/internal/billyx/size_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package billyx
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v5/util"
+)
+
+func TestDirSize(t *testing.T) {
+	bfs := memfs.New()
+	files := map[string]string{
+		"root/a":       "12345",
+		"root/sub/b":   "1234567890",
+		"root/sub/c/d": "1",
+		"outside":      "ignored",
+	}
+	for path, content := range files {
+		if err := util.WriteFile(bfs, path, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+	got, err := DirSize(bfs, "root")
+	if err != nil {
+		t.Fatalf("DirSize: %v", err)
+	}
+	if want := int64(16); got != want {
+		t.Errorf("DirSize = %d; want %d", got, want)
+	}
+	if _, err := DirSize(bfs, "missing"); err == nil {
+		t.Error("DirSize(missing) = nil error; want error")
+	}
+}

--- a/internal/db/repometrics.go
+++ b/internal/db/repometrics.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"net/url"
+
+	"cloud.google.com/go/firestore"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+// RepoMetrics persists per-repository size/history measurements.
+//
+// The document ID is the url.PathEscape of the canonical repo URI:
+// reversible, legible in the console, and free of the "/" Firestore forbids.
+type RepoMetrics = Resource[schema.RepoMetrics, string]
+
+const repoMetricsCollection = "repo_metrics"
+
+func repoMetricsPath(m schema.RepoMetrics) []string { return repoMetricsKey(m.URI) }
+
+func repoMetricsKey(canonicalURI string) []string {
+	return []string{repoMetricsCollection, url.PathEscape(canonicalURI)}
+}
+
+// NewFirestoreRepoMetrics returns a Firestore-backed RepoMetrics store.
+func NewFirestoreRepoMetrics(c *firestore.Client) RepoMetrics {
+	return &firestoreResource[schema.RepoMetrics, string]{client: c, pathFor: repoMetricsPath, pathForKey: repoMetricsKey}
+}
+
+// NewMemoryRepoMetrics returns an in-memory RepoMetrics store for tests.
+func NewMemoryRepoMetrics() RepoMetrics {
+	return &memoryResource[schema.RepoMetrics, string]{data: map[string]schema.RepoMetrics{}, pathFor: repoMetricsPath, pathForKey: repoMetricsKey}
+}

--- a/internal/db/repometrics_test.go
+++ b/internal/db/repometrics_test.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/uri"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+func TestMemoryRepoMetrics_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryRepoMetrics()
+	canonical, err := uri.CanonicalizeRepoURI("git@github.com:Org/Repo.git")
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	want := schema.RepoMetrics{
+		URI:        canonical,
+		Bytes:      4096,
+		Commits:    12,
+		Head:       "deadbeef",
+		MeasuredAt: time.Unix(1700000000, 0).UTC(),
+	}
+	if err := s.Upsert(ctx, want); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	// The ssh and https aliases canonicalize to the same key and document.
+	key, err := uri.CanonicalizeRepoURI("https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("canonicalize alias: %v", err)
+	}
+	got, err := s.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != want {
+		t.Errorf("Get = %+v; want %+v", got, want)
+	}
+	updated := want
+	updated.Bytes = 8192
+	if err := s.Upsert(ctx, updated); err != nil {
+		t.Fatalf("Upsert (update): %v", err)
+	}
+	got, err = s.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+	if got.Bytes != 8192 {
+		t.Errorf("after re-Upsert Get = %+v; want Bytes=8192", got)
+	}
+}
+
+func TestRepoMetricsKey(t *testing.T) {
+	got := repoMetricsKey("https://github.com/org/repo")
+	want := []string{"repo_metrics", "https:%2F%2Fgithub.com%2Forg%2Frepo"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("repoMetricsKey = %v; want %v", got, want)
+	}
+}
+
+func TestMemoryRepoMetrics_NotFound(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryRepoMetrics()
+	if _, err := s.Get(ctx, "https://github.com/missing/repo"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(missing) = %v; want ErrNotFound", err)
+	}
+}

--- a/internal/gitx/measure.go
+++ b/internal/gitx/measure.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gitx
+
+import (
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/google/oss-rebuild/internal/billyx"
+	"github.com/pkg/errors"
+)
+
+// ObjectStoreSize returns the size in bytes of s's object store, the packed
+// clone plus any loose objects, as held by the storer's filesystem. Only
+// filesystem-backed storage is supported, unwrapping Storer as needed.
+// Uncompressed size is deliberately not offered since summing it requires
+// inflating every object, which costs seconds of CPU on large repos where
+// the filesystem stat is near-free.
+func ObjectStoreSize(s storage.Storer) (int64, error) {
+	if ws, ok := s.(*Storer); ok {
+		s = ws.Storer
+	}
+	fss, ok := s.(*filesystem.Storage)
+	if !ok {
+		return 0, errors.Errorf("unsupported storer %T", s)
+	}
+	return billyx.DirSize(fss.Filesystem(), "objects")
+}
+
+// CommitCount returns the number of commit objects in s, reachable from a
+// ref or not. The typed iteration reads only object headers, never inflating
+// payloads.
+func CommitCount(s storage.Storer) (commits int64, err error) {
+	iter, err := s.IterEncodedObjects(plumbing.CommitObject)
+	if err != nil {
+		return 0, errors.Wrap(err, "iterating commits")
+	}
+	err = iter.ForEach(func(plumbing.EncodedObject) error { commits++; return nil })
+	iter.Close()
+	if err != nil {
+		return 0, errors.Wrap(err, "counting commits")
+	}
+	return commits, nil
+}

--- a/internal/gitx/measure_test.go
+++ b/internal/gitx/measure_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gitx
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5/storage"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
+)
+
+const twoCommitRepo = `
+commits:
+  - id: first
+    branch: master
+    message: "first"
+    files:
+      README.md: "hello"
+  - id: second
+    parent: first
+    branch: master
+    message: "second"
+    files:
+      README.md: "world"
+`
+
+func TestObjectStoreSize(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		storer  storage.Storer
+		wantErr bool
+	}{
+		{name: "Filesystem", storer: NewInMemoryStorer()},
+		{name: "WrappedFilesystem", storer: NewStorer(func() storage.Storer { return NewInMemoryStorer() })},
+		{name: "UnsupportedMemory", storer: memory.NewStorage(), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, err := gitxtest.CreateRepoFromYAML(twoCommitRepo, &gitxtest.RepositoryOptions{Storer: tc.storer, Worktree: memfs.New()})
+			if err != nil {
+				t.Fatalf("CreateRepoFromYAML: %v", err)
+			}
+			got, err := ObjectStoreSize(repo.Storer)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("ObjectStoreSize() error = %v; want error %t", err, tc.wantErr)
+			}
+			if !tc.wantErr && got <= 0 {
+				t.Errorf("ObjectStoreSize = %d; want > 0", got)
+			}
+		})
+	}
+}
+
+func TestCommitCount(t *testing.T) {
+	// The memory-backed default storer shows CommitCount is storer-agnostic.
+	repo, err := gitxtest.CreateRepoFromYAML(twoCommitRepo, nil)
+	if err != nil {
+		t.Fatalf("CreateRepoFromYAML: %v", err)
+	}
+	got, err := CommitCount(repo.Storer)
+	if err != nil {
+		t.Fatalf("CommitCount: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("CommitCount = %d; want 2", got)
+	}
+}

--- a/pkg/rebuild/schema/costs.go
+++ b/pkg/rebuild/schema/costs.go
@@ -1,0 +1,17 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import "time"
+
+// RepoMetrics records size measurements of a source repository, taken on
+// clone by the inference service. Keyed by repo rather than target since
+// many packages share a repository.
+type RepoMetrics struct {
+	URI        string    `json:"uri,omitempty" firestore:"uri,omitempty"`         // canonical repo URI
+	Bytes      int64     `json:"bytes,omitempty" firestore:"bytes,omitempty"`     // packed object store bytes at clone
+	Commits    int64     `json:"commits,omitempty" firestore:"commits,omitempty"` // commit objects in the clone
+	Head       string    `json:"head,omitempty" firestore:"head,omitempty"`       // head commit hash at measurement
+	MeasuredAt time.Time `json:"measured_at,omitzero" firestore:"measured_at,omitempty"`
+}


### PR DESCRIPTION
Persist per-repository size measurements to a repo_metrics Firestore
collection keyed by canonical repo URI. The inference service measures
each successful clone (packed object store bytes, commit count, head)
in a detached goroutine, including when strategy inference itself fails
since oversized repos are the ones sizing decisions most need measured.