### PR TITLE
Write explicit lockfile to Cargo workspace root

### DIFF
--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -40,15 +40,16 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 		}},
 		Deps: []flow.Step{
 			{
-				Uses: "cargo/create-lockfile",
-				With: map[string]string{
-					"lockfile": lockfile,
-				},
-			},
-			{
 				Uses: "cargo/deps/toolchain",
 				With: map[string]string{
 					"rustVersion": b.RustVersion,
+				},
+			},
+			{
+				Uses: "cargo/create-lockfile",
+				With: map[string]string{
+					"dir":      b.Location.Dir,
+					"lockfile": lockfile,
 				},
 			},
 			{
@@ -91,8 +92,14 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
 				{{if ne .With.lockfile "" -}}
-				echo '{{.With.lockfile}}' | base64 -d > Cargo.lock
+				metadata="$({{if and (ne .With.dir ".") (ne .With.dir "")}}cd {{.With.dir}} && {{end}}/root/.cargo/bin/cargo metadata --no-deps --format-version 1)" || exit 1
+				workspace_root="$(printf '%s\n' "$metadata" | sed -n 's/.*"workspace_root":"\([^"]*\)".*/\1/p')"
+				if [ -z "$workspace_root" ]; then
+				  workspace_root="$PWD"
+				fi
+				echo '{{.With.lockfile}}' | base64 -d > "$workspace_root/Cargo.lock"
 				{{- end -}}`)[1:],
+			Needs: []string{"rustup"},
 		}},
 	},
 	{

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -107,8 +107,13 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 			rebuild.Instructions{
 				Location: defaultLocation,
 				Source:   "git checkout --force 'the_ref'",
-				Deps: `echo 'lock_base64' | base64 -d > Cargo.lock
-/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
+metadata="$(cd the_dir && /root/.cargo/bin/cargo metadata --no-deps --format-version 1)" || exit 1
+workspace_root="$(printf '%s\n' "$metadata" | sed -n 's/.*"workspace_root":"\([^"]*\)".*/\1/p')"
+if [ -z "$workspace_root" ]; then
+  workspace_root="$PWD"
+fi
+echo 'lock_base64' | base64 -d > "$workspace_root/Cargo.lock"
 # NOTE: Using current crates.io registry`,
 				Build: `(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
@@ -153,8 +158,13 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 			rebuild.Instructions{
 				Location: defaultLocation,
 				Source:   "git checkout --force 'the_ref'",
-				Deps: `echo 'lock_base64' | base64 -d > Cargo.lock
-/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
+metadata="$(cd the_dir && /root/.cargo/bin/cargo metadata --no-deps --format-version 1)" || exit 1
+workspace_root="$(printf '%s\n' "$metadata" | sed -n 's/.*"workspace_root":"\([^"]*\)".*/\1/p')"
+if [ -z "$workspace_root" ]; then
+  workspace_root="$PWD"
+fi
+echo 'lock_base64' | base64 -d > "$workspace_root/Cargo.lock"
 # NOTE: Using current crates.io registry`,
 				Build: `(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{


### PR DESCRIPTION
Explicit lockfiles are currently written at the checkout root. For packages in a subdirectory or nested workspace, Cargo reads the workspace-root lock instead, so the supplied lockfile can be ignored.

Install the selected toolchain before lockfile creation and use `cargo metadata` from the package directory to locate the workspace root. If the metadata does not expose one, preserve the existing checkout-root behavior.

Testing:
- `go test ./...`
- `go vet ./...`
- Verified root packages, standalone subdirectories, root workspace members, and nested workspace members across eight Rust versions: correct placement increased from 16/32 to 32/32. Rust 1.13 and 1.23 toolchains preserve the checkout-root fallback.