### PR TITLE
Isolate historical Cargo builds from repository config

### DIFF
--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -125,8 +125,24 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
 				{{if and (ne .TimewarpHost "") (ne .With.registryCommit "") -}}
-				manifest="$PWD{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}/{{.With.dir}}{{end}}/Cargo.toml"
-				(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)
+				package_dir="$PWD{{if and (ne .With.dir ".") (ne .With.dir "")}}/{{.With.dir}}{{end}}"
+				manifest="$package_dir/Cargo.toml"
+				if (cd "$package_dir" && /root/.cargo/bin/cargo --config 'net.offline=true' locate-project >/dev/null 2>&1); then
+				  (cd "$package_dir" && /root/.cargo/bin/cargo \
+				    {{if eq .With.useGitIndex "true" -}}
+				    --config 'source.crates-io.replace-with="timewarp-local"' \
+				    --config 'source.timewarp-local.registry="file:///cargo-index"' \
+				    {{- else -}}
+				    --config 'source.crates-io.replace-with="timewarp"' \
+				    --config 'source.timewarp.registry="{{.BuildEnv.TimewarpURLFromString "cargosparse" .With.registryCommit}}"' \
+				    {{- end}}
+				    package --no-verify)
+				else
+				active_toolchain="$(cd "$package_dir" && /root/.cargo/bin/rustup show active-toolchain)" || exit 1
+				active_toolchain="${active_toolchain%% *}"
+				[ -n "$active_toolchain" ] || exit 1
+				(cd / && RUSTUP_TOOLCHAIN="$active_toolchain" /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)
+				fi
 				{{- else -}}
 				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.dir}} && {{end -}}
 				/root/.cargo/bin/cargo package --no-verify

--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -124,9 +124,14 @@ var toolkit = []*flow.Tool{
 		Name: "cargo/build/package",
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
+				{{if and (ne .TimewarpHost "") (ne .With.registryCommit "") -}}
+				manifest="$PWD{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}/{{.With.dir}}{{end}}/Cargo.toml"
+				(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)
+				{{- else -}}
 				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.dir}} && {{end -}}
 				/root/.cargo/bin/cargo package --no-verify
-				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}`)[1:],
+				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}
+				{{- end -}}`)[1:],
 			Needs: []string{"rustup"},
 		}},
 	},

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -87,8 +87,19 @@ func TestCratesIOCargoPackage(t *testing.T) {
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "sparse+http://cargosparse:abc1234@localhost:8081/"\n' > /.cargo/config.toml`,
-				Build: `manifest="$PWD/Cargo.toml"
-(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)`,
+				Build: `package_dir="$PWD"
+manifest="$package_dir/Cargo.toml"
+if (cd "$package_dir" && /root/.cargo/bin/cargo --config 'net.offline=true' locate-project >/dev/null 2>&1); then
+  (cd "$package_dir" && /root/.cargo/bin/cargo \
+    --config 'source.crates-io.replace-with="timewarp"' \
+    --config 'source.timewarp.registry="sparse+http://cargosparse:abc1234@localhost:8081/"' \
+    package --no-verify)
+else
+active_toolchain="$(cd "$package_dir" && /root/.cargo/bin/rustup show active-toolchain)" || exit 1
+active_toolchain="${active_toolchain%% *}"
+[ -n "$active_toolchain" ] || exit 1
+(cd / && RUSTUP_TOOLCHAIN="$active_toolchain" /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)
+fi`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -200,8 +211,19 @@ mkdir -p /cargo-index
 wget -O - --header "X-Package-Names: serde,tokio" "http://cargogitarchive:abc1234@localhost:8081/index.git.tar" | tar -xf - -C /cargo-index
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config.toml`,
-				Build: `manifest="$PWD/the_dir/Cargo.toml"
-(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)`,
+				Build: `package_dir="$PWD/the_dir"
+manifest="$package_dir/Cargo.toml"
+if (cd "$package_dir" && /root/.cargo/bin/cargo --config 'net.offline=true' locate-project >/dev/null 2>&1); then
+  (cd "$package_dir" && /root/.cargo/bin/cargo \
+    --config 'source.crates-io.replace-with="timewarp-local"' \
+    --config 'source.timewarp-local.registry="file:///cargo-index"' \
+    package --no-verify)
+else
+active_toolchain="$(cd "$package_dir" && /root/.cargo/bin/rustup show active-toolchain)" || exit 1
+active_toolchain="${active_toolchain%% *}"
+[ -n "$active_toolchain" ] || exit 1
+(cd / && RUSTUP_TOOLCHAIN="$active_toolchain" /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)
+fi`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -222,8 +244,19 @@ printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-lo
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "sparse+http://cargosparse:abc1234@localhost:8081/"\n' > /.cargo/config.toml`,
-				Build: `manifest="$PWD/the_dir/Cargo.toml"
-(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)`,
+				Build: `package_dir="$PWD/the_dir"
+manifest="$package_dir/Cargo.toml"
+if (cd "$package_dir" && /root/.cargo/bin/cargo --config 'net.offline=true' locate-project >/dev/null 2>&1); then
+  (cd "$package_dir" && /root/.cargo/bin/cargo \
+    --config 'source.crates-io.replace-with="timewarp"' \
+    --config 'source.timewarp.registry="sparse+http://cargosparse:abc1234@localhost:8081/"' \
+    package --no-verify)
+else
+active_toolchain="$(cd "$package_dir" && /root/.cargo/bin/rustup show active-toolchain)" || exit 1
+active_toolchain="${active_toolchain%% *}"
+[ -n "$active_toolchain" ] || exit 1
+(cd / && RUSTUP_TOOLCHAIN="$active_toolchain" /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)
+fi`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -87,7 +87,8 @@ func TestCratesIOCargoPackage(t *testing.T) {
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "sparse+http://cargosparse:abc1234@localhost:8081/"\n' > /.cargo/config.toml`,
-				Build: `/root/.cargo/bin/cargo package --no-verify`,
+				Build: `manifest="$PWD/Cargo.toml"
+(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -199,7 +200,8 @@ mkdir -p /cargo-index
 wget -O - --header "X-Package-Names: serde,tokio" "http://cargogitarchive:abc1234@localhost:8081/index.git.tar" | tar -xf - -C /cargo-index
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config.toml`,
-				Build: `(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+				Build: `manifest="$PWD/the_dir/Cargo.toml"
+(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -220,7 +222,8 @@ printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-lo
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "sparse+http://cargosparse:abc1234@localhost:8081/"\n' > /.cargo/config.toml`,
-				Build: `(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+				Build: `manifest="$PWD/the_dir/Cargo.toml"
+(cd / && /root/.cargo/bin/cargo package --manifest-path "$manifest" --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},


### PR DESCRIPTION
Cargo loads `.cargo/config*` from the current working directory and its ancestors. During a historical rebuild, repository-local config can therefore override the timewarp registry configured at `/.cargo/config.toml`.

When supported, pass the timewarp crates.io replacement through Cargo's `--config` option. This gives the timewarp configuration command-line precedence while preserving repository settings needed for named registries and `rust-toolchain*` overrides. Older Cargo versions retain the isolated `/` fallback. Non-timewarp builds are unchanged.

Testing:
- `go test ./...`
- `go vet ./...`
- Checked Cargo 1.34-1.85 and 1.97 across root, subdirectory, and workspace layouts. The CLI-config path succeeded in all 72 supported cases; older Cargo versions selected the isolated fallback.
- Five published cases using `tuna` or `proton` registry aliases passed with CLI config and failed when repository config was hidden.
