### PR TITLE
Preserve absent Cargo.lock in rebuilt crates

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -341,6 +341,8 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	if !hasMUSLBuild {
 		return nil, errors.New("rust version unsupported in MUSL builds")
 	}
+	// --exclude-lockfile was added in Cargo 1.87.
+	excludeLockfile := lockContent == nil && semver.Cmp(rustVersion, "1.87.0") >= 0
 
 	return &CratesIOCargoPackage{
 		Location: rebuild.Location{
@@ -348,9 +350,10 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			Ref:  ref,
 			Dir:  dir,
 		},
-		RustVersion:    rustVersion,
-		RegistryCommit: indexCommit,
-		PackageNames:   packageNames,
+		RustVersion:     rustVersion,
+		ExcludeLockfile: excludeLockfile,
+		RegistryCommit:  indexCommit,
+		PackageNames:    packageNames,
 	}, nil
 }
 

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -188,6 +188,32 @@ func TestInferStrategy(t *testing.T) {
 			},
 		},
 		{
+			name: "exclude lockfile when selected cargo supports it",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2025-05-22T00:00:00Z"}}`,
+			files: []archive.TarEntry{
+				{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+						Dir:  "",
+					},
+					RustVersion:     "1.87.0",
+					ExcludeLockfile: true,
+				}
+			},
+		},
+		{
 			name: "declared rust_version is a lower bound",
 			repo: `commits:
   - id: initial-commit

--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -22,6 +22,7 @@ type CratesIOCargoPackage struct {
 	rebuild.Location
 	RustVersion      string            `json:"rust_version" yaml:"rust_version,omitempty"`
 	ExplicitLockfile *ExplicitLockfile `json:"explicit_lockfile" yaml:"explicit_lockfile,omitempty"`
+	ExcludeLockfile  bool              `json:"exclude_lockfile,omitempty" yaml:"exclude_lockfile,omitempty"`
 	RegistryCommit   string            `json:"registry_commit,omitempty" yaml:"registry_commit,omitempty"`
 	PackageNames     []string          `json:"package_names,omitempty" yaml:"package_names,omitempty"`
 }
@@ -64,10 +65,11 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 		Build: []flow.Step{{
 			Uses: "cargo/build/package",
 			With: map[string]string{
-				"dir":            b.Location.Dir,
-				"rustVersion":    b.RustVersion,
-				"registryCommit": b.RegistryCommit,
-				"useGitIndex":    fmt.Sprintf("%t", len(b.PackageNames) > 0),
+				"dir":             b.Location.Dir,
+				"rustVersion":     b.RustVersion,
+				"excludeLockfile": fmt.Sprintf("%t", b.ExcludeLockfile),
+				"registryCommit":  b.RegistryCommit,
+				"useGitIndex":     fmt.Sprintf("%t", len(b.PackageNames) > 0),
 			},
 		}},
 		OutputDir: "target/package",
@@ -128,7 +130,7 @@ var toolkit = []*flow.Tool{
 			Runs: textwrap.Dedent(`
 				export CARGO_TARGET_DIR="$PWD/target"
 				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.dir}} && {{end -}}
-				/root/.cargo/bin/cargo package --no-verify
+				/root/.cargo/bin/cargo package --no-verify{{if eq .With.excludeLockfile "true"}} --exclude-lockfile{{end}}
 				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}`)[1:],
 			Needs: []string{"rustup"},
 		}},

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -44,6 +44,27 @@ func TestCratesIOCargoPackage(t *testing.T) {
 			},
 		},
 		{
+			"ExcludeLockfile",
+			&CratesIOCargoPackage{
+				Location:        defaultLocation,
+				RustVersion:     "1.87.0",
+				ExcludeLockfile: true,
+			},
+			rebuild.BuildEnv{HasRepo: true},
+			rebuild.Instructions{
+				Location: defaultLocation,
+				Source:   "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.87.0
+# NOTE: Using current crates.io registry`,
+				Build: `export CARGO_TARGET_DIR="$PWD/target"
+(cd the_dir && /root/.cargo/bin/cargo package --no-verify --exclude-lockfile)`,
+				Requires: rebuild.RequiredEnv{
+					SystemDeps: []string{"git", "rustup"},
+				},
+				OutputPath: "target/package/the_artifact",
+			},
+		},
+		{
 			"NoDir",
 			&CratesIOCargoPackage{
 				Location: rebuild.Location{


### PR DESCRIPTION
Cargo 1.84 and later include Cargo.lock in packaged libraries by default. When the published .crate has no root Cargo.lock, rebuilding with a newer Cargo can therefore add a file that was not published.

Record lockfile absence during inference and pass --exclude-lockfile when the selected Cargo supports it. Older Cargo versions retain the existing behavior.

Testing:
- go test ./...
- go vet ./...
- Rebuilt appwrite 0.10.0, pyo3-error 0.9.0, and cmd_lib_macros 1.9.6 from their Git revisions. Default packaging added only Cargo.lock; --exclude-lockfile matched all three published archives.
- Checked Cargo 1.83, 1.86, and 1.87: 1.83 omits the lockfile by default, 1.86 rejects --exclude-lockfile, and 1.87 honors it.