### PR TITLE
Move GCS object access wrappers to gcsx

### DIFF
--- a/internal/gcsx/copy.go
+++ b/internal/gcsx/copy.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gcsx extends the GCS client library.
+package gcsx
+
+import (
+	"context"
+
+	gcs "cloud.google.com/go/storage"
+)
+
+// ObjectReader streams an object's content.
+type ObjectReader struct {
+	*gcs.Reader
+	obj *gcs.ObjectHandle
+}
+
+// NewObjectReader opens obj for reading.
+func NewObjectReader(ctx context.Context, obj *gcs.ObjectHandle) (*ObjectReader, error) {
+	r, err := obj.NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &ObjectReader{Reader: r, obj: obj}, nil
+}
+
+// ObjectWriter commits content to its object.
+type ObjectWriter struct {
+	*gcs.Writer
+	ctx context.Context
+	obj *gcs.ObjectHandle
+}
+
+// NewObjectWriter opens obj for writing.
+func NewObjectWriter(ctx context.Context, obj *gcs.ObjectHandle) *ObjectWriter {
+	return &ObjectWriter{Writer: obj.NewWriter(ctx), ctx: ctx, obj: obj}
+}

--- a/pkg/gcb/gcb.go
+++ b/pkg/gcb/gcb.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	gcs "cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/pkg/errors"
 	"google.golang.org/api/cloudbuild/v1"
 	"google.golang.org/grpc/codes"
@@ -63,8 +64,7 @@ func NewGCSLogsClient(gcsClient *gcs.Client, bucket string) LogsClient {
 
 // ReadBuildLogs reads the complete build logs for a given build ID from the specified bucket.
 func (c *gcsLogsClient) ReadBuildLogs(ctx context.Context, buildID string) (io.ReadCloser, error) {
-	objectName := fmt.Sprintf("log-%s.txt", buildID)
-	return c.bucket.Object(objectName).NewReader(ctx)
+	return gcsx.NewObjectReader(ctx, c.bucket.Object(MergedLogFile(buildID)))
 }
 
 // ReadStepLogs reads logs for a specific step within a build from the specified bucket.

--- a/pkg/rebuild/rebuild/storage.go
+++ b/pkg/rebuild/rebuild/storage.go
@@ -17,6 +17,7 @@ import (
 	gcs "cloud.google.com/go/storage"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/pkg/errors"
 	"google.golang.org/api/option"
 )
@@ -230,8 +231,7 @@ func (s *GCSStore) Reader(ctx context.Context, a Asset) (io.ReadCloser, error) {
 func (s *GCSStore) Writer(ctx context.Context, a Asset) (io.WriteCloser, error) {
 	objectPath := s.resourcePath(a)
 	obj := s.gcsClient.Bucket(s.bucket).Object(objectPath)
-	w := obj.NewWriter(ctx)
-	return w, nil
+	return gcsx.NewObjectWriter(ctx, obj), nil
 }
 
 // Stat describes the stored asset without reading its content.


### PR DESCRIPTION
Provides a common venue to implement forthcoming server-side copy
between these handles.