### PR TITLE
Copy GCB build logs into the build metadata store

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -222,7 +222,7 @@ func buildAndAttest(ctx context.Context, deps *RebuildPackageDeps, mux rebuild.R
 		rebuild.ProxyNetlogAsset:        remoteMetadata,
 		rebuild.DockerfileAsset:         deps.LocalMetadataStore,
 		rebuild.BuildInfoAsset:          deps.LocalMetadataStore,
-		// NOTE: Omit rebuild.DebugLogsAsset for now since we're not using it.
+		rebuild.DebugLogsAsset:          remoteMetadata,
 	})
 	in := rebuild.Input{
 		Target:   t,

--- a/internal/gcsx/copy.go
+++ b/internal/gcsx/copy.go
@@ -6,11 +6,13 @@ package gcsx
 
 import (
 	"context"
+	"io"
 
 	gcs "cloud.google.com/go/storage"
 )
 
-// ObjectReader streams an object's content.
+// ObjectReader streams an object's content while enabling server-side copies
+// to capable destinations.
 type ObjectReader struct {
 	*gcs.Reader
 	obj *gcs.ObjectHandle
@@ -25,14 +27,53 @@ func NewObjectReader(ctx context.Context, obj *gcs.ObjectHandle) (*ObjectReader,
 	return &ObjectReader{Reader: r, obj: obj}, nil
 }
 
-// ObjectWriter commits content to its object.
+// WriteTo copies the object server-side when the destination is a copier,
+// avoiding streaming the content through this process. It shadows the
+// embedded Reader's WriteTo, which io.Copy would otherwise dispatch to.
+func (r *ObjectReader) WriteTo(w io.Writer) (int64, error) {
+	if d, ok := w.(copier); ok {
+		return d.CopyFrom(r.obj)
+	}
+	return r.Reader.WriteTo(w)
+}
+
+// copier is a destination that can ingest a GCS object server-side.
+type copier interface {
+	CopyFrom(src *gcs.ObjectHandle) (int64, error)
+}
+
+// ObjectWriter commits content to its object, streamed or copied server-side
+// from another object.
 type ObjectWriter struct {
 	*gcs.Writer
-	ctx context.Context
-	obj *gcs.ObjectHandle
+	ctx    context.Context
+	obj    *gcs.ObjectHandle
+	copied bool
 }
+
+var _ copier = (*ObjectWriter)(nil)
 
 // NewObjectWriter opens obj for writing.
 func NewObjectWriter(ctx context.Context, obj *gcs.ObjectHandle) *ObjectWriter {
 	return &ObjectWriter{Writer: obj.NewWriter(ctx), ctx: ctx, obj: obj}
+}
+
+// CopyFrom copies src's content to the object server-side.
+func (w *ObjectWriter) CopyFrom(src *gcs.ObjectHandle) (int64, error) {
+	attrs, err := w.obj.CopierFrom(src).Run(w.ctx)
+	if err != nil {
+		return 0, err
+	}
+	w.copied = true
+	return attrs.Size, nil
+}
+
+// Close commits streamed content.
+// NOTE: After a server-side copy nothing was streamed so closing the unwritten
+// writer would commit an empty object over the copy.
+func (w *ObjectWriter) Close() error {
+	if w.copied {
+		return nil
+	}
+	return w.Writer.Close()
 }

--- a/internal/gcsx/copy_test.go
+++ b/internal/gcsx/copy_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gcsx
+
+import (
+	"io"
+	"testing"
+
+	gcs "cloud.google.com/go/storage"
+)
+
+type copyRecorder struct {
+	src *gcs.ObjectHandle
+}
+
+var _ copier = (*copyRecorder)(nil)
+
+func (r *copyRecorder) Write(p []byte) (int, error) { return len(p), nil }
+
+func (r *copyRecorder) CopyFrom(src *gcs.ObjectHandle) (int64, error) {
+	r.src = src
+	return 1, nil
+}
+
+// TestObjectReaderWriteTo proves io.Copy dispatches to the destination's
+// server-side copy: a nil embedded Reader makes any streaming attempt panic.
+func TestObjectReaderWriteTo(t *testing.T) {
+	obj := &gcs.ObjectHandle{}
+	rec := &copyRecorder{}
+	n, err := io.Copy(rec, &ObjectReader{obj: obj})
+	if err != nil {
+		t.Fatalf("io.Copy() error = %v", err)
+	}
+	if n != 1 {
+		t.Errorf("io.Copy() = %d, want 1", n)
+	}
+	if rec.src != obj {
+		t.Errorf("copy source = %v, want the reader's object", rec.src)
+	}
+}
+
+func TestObjectWriterClose(t *testing.T) {
+	// A nil embedded Writer makes any commit attempt panic: Close after a
+	// server-side copy must not touch it, which would commit an empty object.
+	w := &ObjectWriter{copied: true}
+	if err := w.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+}

--- a/pkg/build/gcb/executor.go
+++ b/pkg/build/gcb/executor.go
@@ -381,6 +381,8 @@ func (e *Executor) copyBuildLogs(ctx context.Context, store rebuild.AssetStore, 
 		return errors.Wrap(err, "reading build logs")
 	}
 	defer reader.Close()
-	_, err = io.Copy(writer, reader)
-	return errors.Wrap(err, "copying to asset")
+	if _, err := io.Copy(writer, reader); err != nil {
+		return errors.Wrap(err, "copying to asset")
+	}
+	return errors.Wrap(writer.Close(), "committing asset")
 }

--- a/pkg/gcb/gcb.go
+++ b/pkg/gcb/gcb.go
@@ -62,7 +62,9 @@ func NewGCSLogsClient(gcsClient *gcs.Client, bucket string) LogsClient {
 	}
 }
 
-// ReadBuildLogs reads the complete build logs for a given build ID from the specified bucket.
+// ReadBuildLogs reads the complete build logs for a given build ID from the
+// specified bucket. Copying the returned reader to a gcsx.ObjectWriter runs
+// server-side without streaming the content through this process.
 func (c *gcsLogsClient) ReadBuildLogs(ctx context.Context, buildID string) (io.ReadCloser, error) {
 	return gcsx.NewObjectReader(ctx, c.bucket.Object(MergedLogFile(buildID)))
 }

--- a/pkg/rebuild/rebuild/storage.go
+++ b/pkg/rebuild/rebuild/storage.go
@@ -227,7 +227,8 @@ func (s *GCSStore) Reader(ctx context.Context, a Asset) (io.ReadCloser, error) {
 	return r, nil
 }
 
-// Writer returns a writer for the given asset.
+// Writer returns a writer for the given asset. Copying a gcsx.ObjectReader
+// to it runs server-side without streaming the content through this process.
 func (s *GCSStore) Writer(ctx context.Context, a Asset) (io.WriteCloser, error) {
 	objectPath := s.resourcePath(a)
 	obj := s.gcsClient.Bucket(s.bucket).Object(objectPath)


### PR DESCRIPTION
Enable log copy (previously deliberately omitted) into the per-build
metadata location. The builtin io.Copy detects sources conforming to the
WriteTo interface so gcsx.ObjectReader.WriteTo to
storage.ObjectHandle.CopierFrom is invoked and runs the copy server-side
via object rewrite, a metadata-only operation for same-location
same-class buckets, so no log bytes stream through the service.