### PR TITLE
Split source and deps into separate build layers

### DIFF
--- a/pkg/build/gcb/planner.go
+++ b/pkg/build/gcb/planner.go
@@ -269,18 +269,22 @@ var gcbDockerfileTpl = template.Must(
 			EOF
 			RUN sed 's/^ //' <<'EOF' | sh
 			 set -eux
-			{{- if .UseTimewarp}}
-			 ./timewarp -port 8080 &
-			 while ! nc -z localhost 8080;do sleep 1;done
-			{{- end}}
 			 mkdir /src && cd /src
 			 {{- if .Instructions.Source}}
 			 {{.Instructions.Source | indent}}
 			 {{- end}}
-			 {{- if .Instructions.Deps}}
-			 {{.Instructions.Deps | indent}}
-			 {{- end}}
 			EOF
+			{{- if .Instructions.Deps}}
+			RUN sed 's/^ //' <<'EOF' | sh
+			 set -eux
+			{{- if .UseTimewarp}}
+			 ./timewarp -port 8080 &
+			 while ! nc -z localhost 8080;do sleep 1;done
+			{{- end}}
+			 cd /src
+			 {{.Instructions.Deps | indent}}
+			EOF
+			{{- end}}
 			RUN sed 's/^ //' <<'EOF' >/build
 			 set -eux
 			 {{.Instructions.Build | indent}}

--- a/pkg/build/gcb/planner_test.go
+++ b/pkg/build/gcb/planner_test.go
@@ -68,6 +68,10 @@ RUN sed 's/^ //' <<'EOF' | sh
  mkdir /src && cd /src
  git clone github.com/example .
  git checkout --force 'main'
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ cd /src
  make deps ...
 EOF
 RUN sed 's/^ //' <<'EOF' >/build
@@ -179,6 +183,10 @@ EOF
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux
  mkdir /src && cd /src
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ cd /src
  make deps ...
 EOF
 RUN sed 's/^ //' <<'EOF' >/build
@@ -260,11 +268,15 @@ RUN sed 's/^ //' <<'EOF' | sh
 EOF
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux
- ./timewarp -port 8080 &
- while ! nc -z localhost 8080;do sleep 1;done
  mkdir /src && cd /src
  git clone github.com/example .
  git checkout --force 'main'
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ ./timewarp -port 8080 &
+ while ! nc -z localhost 8080;do sleep 1;done
+ cd /src
  make deps ...
 EOF
 RUN sed 's/^ //' <<'EOF' >/build
@@ -312,11 +324,15 @@ RUN --mount=type=secret,id=auth_header sed 's/^ //' <<'EOF' | sh
 EOF
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux
- ./timewarp -port 8080 &
- while ! nc -z localhost 8080;do sleep 1;done
  mkdir /src && cd /src
  git clone github.com/example .
  git checkout --force 'main'
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ ./timewarp -port 8080 &
+ while ! nc -z localhost 8080;do sleep 1;done
+ cd /src
  make deps ...
 EOF
 RUN sed 's/^ //' <<'EOF' >/build
@@ -364,11 +380,15 @@ RUN sed 's/^ //' <<'EOF' | sh
 EOF
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux
- ./timewarp -port 8080 &
- while ! nc -z localhost 8080;do sleep 1;done
  mkdir /src && cd /src
  git clone github.com/example .
  git checkout --force 'main'
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ ./timewarp -port 8080 &
+ while ! nc -z localhost 8080;do sleep 1;done
+ cd /src
  make deps ...
 EOF
 RUN sed 's/^ //' <<'EOF' >/build
@@ -417,11 +437,15 @@ RUN --mount=type=secret,id=auth_header sed 's/^ //' <<'EOF' | sh
 EOF
 RUN sed 's/^ //' <<'EOF' | sh
  set -eux
- ./timewarp -port 8080 &
- while ! nc -z localhost 8080;do sleep 1;done
  mkdir /src && cd /src
  git clone github.com/example .
  git checkout --force 'main'
+EOF
+RUN sed 's/^ //' <<'EOF' | sh
+ set -eux
+ ./timewarp -port 8080 &
+ while ! nc -z localhost 8080;do sleep 1;done
+ cd /src
  make deps ...
 EOF
 RUN sed 's/^ //' <<'EOF' >/build

--- a/pkg/build/local/build_planner.go
+++ b/pkg/build/local/build_planner.go
@@ -54,14 +54,20 @@ var dockerBuildDockerfileTpl = template.Must(
 			EOF
 			RUN sed 's/^ //' <<'EOF' | sh
 			 set -eux
+			 mkdir -p /src && cd /src
+			 {{.Instructions.Source| indent}}
+			EOF
+			{{- if .Instructions.Deps}}
+			RUN sed 's/^ //' <<'EOF' | sh
+			 set -eux
 			{{- if .UseTimewarp}}
 			 ./timewarp -port 8080 &
 			 while ! nc -z localhost 8080;do sleep 1;done
 			{{- end}}
-			 mkdir -p /src && cd /src
-			 {{.Instructions.Source| indent}}
+			 cd /src
 			 {{.Instructions.Deps | indent}}
 			EOF
+			{{- end}}
 			RUN sed 's/^ //' <<'EOF' >/build
 			 set -eux
 			 {{.Instructions.Build | indent}}


### PR DESCRIPTION
While historically these phases were merged, there wasn't a particularly
compelling reason to do so besides the marginal:
1) Fewer layers are better
2) Source and deps were both modelled to use the network
3) Slightly smaller script size

Since the source phase never touches a package registry, timewarp can
move into a dedicated deps layer that exists only when the build
definition requires it. And in a future where we could generate multiple
artifacts from potentially similar source checkouts, keeping the
checkout as its own layer allows us to reuse that state.

Another benefit we get from this change, though, is better modelling of
the time cost of source and deps phases. Separate layers permit far
simpler extraction logic for granular timing without ever having to
read and extract the data from the logs.