### PR TITLE
Separate out run args

### DIFF
--- a/pkg/build/local/run_args.go
+++ b/pkg/build/local/run_args.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// AuthMode selects how the AUTH_HEADER variable reaches the container in
+// ComposeDockerRunArgs.
+type AuthMode int
+
+const (
+	// AuthNone passes no auth header.
+	AuthNone AuthMode = iota
+	// AuthInline inlines the header value into the argv
+	// (-e AUTH_HEADER=<value>). Suitable only when the argv is ephemeral.
+	AuthInline
+	// AuthEnvPassthrough passes the variable name only (-e AUTH_HEADER),
+	// inheriting the value from the docker CLI process environment. Used by
+	// backends whose argv is persisted and must not carry secrets.
+	AuthEnvPassthrough
+)
+
+// RunArgsOpts parameterizes ComposeDockerRunArgs. It makes the legitimate
+// backend divergences explicit so alternate executors (e.g. the scratch VM
+// executor) share a single composition of `docker run` argv with the local
+// executor.
+type RunArgsOpts struct {
+	// ContainerName is the container's --name.
+	ContainerName string
+	// OutputMountSrc is the docker-host directory mounted at the plan's
+	// output directory.
+	OutputMountSrc string
+	// Remove adds --rm.
+	Remove bool
+	// AllowPrivileged permits plans that request privileged execution to
+	// receive --privileged and the docker socket mount. Callers gate this on
+	// their own policy and are responsible for surfacing a refusal.
+	AllowPrivileged bool
+	// MemoryLimit sets --memory when non-empty.
+	MemoryLimit string
+	// AuthMode selects how AUTH_HEADER is delivered; AuthValue is its value
+	// for AuthInline.
+	AuthMode  AuthMode
+	AuthValue string
+	// KeepAlive wraps the inline script so the container stays up after the
+	// build completes (local interactive debugging).
+	KeepAlive bool
+}
+
+// ComposeDockerRunArgs builds the `docker run` argv for executing plan under
+// the given options. The returned argv excludes the docker command itself.
+func ComposeDockerRunArgs(plan *DockerRunPlan, opts RunArgsOpts) ([]string, error) {
+	args := []string{"run"}
+	if opts.Remove {
+		args = append(args, "--rm")
+	}
+	args = append(args, "--name", opts.ContainerName)
+	args = append(args, "-v", fmt.Sprintf("%s:%s", opts.OutputMountSrc, path.Dir(plan.OutputPath)))
+	if plan.WorkingDir != "" {
+		args = append(args, "-w", plan.WorkingDir)
+	}
+	if plan.Privileged && opts.AllowPrivileged {
+		args = append(args, "--privileged")
+		args = append(args, "-v", "/var/run/docker.sock:/var/run/docker.sock")
+	}
+	if opts.MemoryLimit != "" {
+		args = append(args, "--memory", opts.MemoryLimit)
+	}
+	switch opts.AuthMode {
+	case AuthInline:
+		args = append(args, "-e", fmt.Sprintf("AUTH_HEADER=%s", opts.AuthValue))
+	case AuthEnvPassthrough:
+		args = append(args, "-e", "AUTH_HEADER")
+	}
+	// Disable core dumps
+	args = append(args, "--ulimit", "core=0")
+	args = append(args, plan.Image)
+	switch {
+	case opts.KeepAlive:
+		// To keep the container alive, execute the build script in the
+		// background and keep an infinite process in the foreground. The
+		// script is written to a file via heredoc, so an EOF literal inside
+		// it would corrupt the wrapper.
+		if strings.Contains(plan.Script, "EOF") {
+			return nil, errors.New("build script contains unexpected 'EOF' literal")
+		}
+		wrapped := fmt.Sprintf("cat << 'EOF' > /build.sh\n%s\nEOF\n/bin/sh /build.sh &\ntail -f /dev/null\n", plan.Script)
+		args = append(args, "/bin/sh", "-c", wrapped)
+	default:
+		args = append(args, "/bin/sh", "-c", plan.Script)
+	}
+	return args, nil
+}

--- a/pkg/build/local/run_args_test.go
+++ b/pkg/build/local/run_args_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestComposeDockerRunArgs(t *testing.T) {
+	plan := &DockerRunPlan{
+		Image:      "alpine:3.19",
+		Script:     "echo hello",
+		WorkingDir: "/workspace",
+		OutputPath: "/out/rebuild",
+	}
+	for _, tt := range []struct {
+		name    string
+		plan    *DockerRunPlan
+		opts    RunArgsOpts
+		want    []string
+		wantErr string
+	}{
+		{
+			name: "local defaults",
+			plan: plan,
+			opts: RunArgsOpts{
+				ContainerName:  "b1",
+				OutputMountSrc: "/tmp/oss-rebuild-b1",
+				Remove:         true,
+			},
+			want: []string{"run", "--rm", "--name", "b1", "-v", "/tmp/oss-rebuild-b1:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
+		},
+		{
+			name: "inline auth",
+			plan: plan,
+			opts: RunArgsOpts{
+				ContainerName:  "b1",
+				OutputMountSrc: "/tmp/b1",
+				Remove:         true,
+				AuthMode:       AuthInline,
+				AuthValue:      "Authorization: Bearer tok",
+			},
+			want: []string{"run", "--rm", "--name", "b1", "-v", "/tmp/b1:/out", "-w", "/workspace", "-e", "AUTH_HEADER=Authorization: Bearer tok", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
+		},
+		{
+			name: "env passthrough auth",
+			plan: plan,
+			opts: RunArgsOpts{
+				ContainerName:  "b1",
+				OutputMountSrc: "/home/builder/builds/b1/out",
+				Remove:         true,
+				AuthMode:       AuthEnvPassthrough,
+			},
+			want: []string{"run", "--rm", "--name", "b1", "-v", "/home/builder/builds/b1/out:/out", "-w", "/workspace", "-e", "AUTH_HEADER", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
+		},
+		{
+			name: "privileged allowed",
+			plan: &DockerRunPlan{Image: "alpine:3.19", Script: "true", OutputPath: "/out/rebuild", Privileged: true},
+			opts: RunArgsOpts{
+				ContainerName:   "b1",
+				OutputMountSrc:  "/tmp/b1",
+				AllowPrivileged: true,
+			},
+			want: []string{"run", "--name", "b1", "-v", "/tmp/b1:/out", "--privileged", "-v", "/var/run/docker.sock:/var/run/docker.sock", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "true"},
+		},
+		{
+			name: "privileged denied",
+			plan: &DockerRunPlan{Image: "alpine:3.19", Script: "true", OutputPath: "/out/rebuild", Privileged: true},
+			opts: RunArgsOpts{
+				ContainerName:  "b1",
+				OutputMountSrc: "/tmp/b1",
+			},
+			want: []string{"run", "--name", "b1", "-v", "/tmp/b1:/out", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "true"},
+		},
+		{
+			name: "keepalive wraps script",
+			plan: plan,
+			opts: RunArgsOpts{
+				ContainerName:  "b1",
+				OutputMountSrc: "/tmp/b1",
+				KeepAlive:      true,
+			},
+			want: []string{"run", "--name", "b1", "-v", "/tmp/b1:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "cat << 'EOF' > /build.sh\necho hello\nEOF\n/bin/sh /build.sh &\ntail -f /dev/null\n"},
+		},
+		{
+			name:    "keepalive rejects EOF literal",
+			plan:    &DockerRunPlan{Image: "alpine:3.19", Script: "echo EOF", OutputPath: "/out/rebuild"},
+			opts:    RunArgsOpts{ContainerName: "b1", OutputMountSrc: "/tmp/b1", KeepAlive: true},
+			wantErr: "EOF",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ComposeDockerRunArgs(tt.plan, tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ComposeDockerRunArgs: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("args mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/build/local/run_executor.go
+++ b/pkg/build/local/run_executor.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/google/oss-rebuild/internal/bufiox"
@@ -208,27 +207,17 @@ func (e *DockerRunExecutor) executeBuild(ctx context.Context, handle *localHandl
 		}
 	}()
 	// Compose command args
-	runArgs := []string{"run"}
-	if !e.retainContainer && !opts.SavePostBuildContainer {
-		runArgs = append(runArgs, "--rm")
+	argOpts := RunArgsOpts{
+		ContainerName:   handle.id, // Use BuildID as container name
+		OutputMountSrc:  hostOutputPath,
+		Remove:          !e.retainContainer && !opts.SavePostBuildContainer,
+		AllowPrivileged: e.allowPrivileged,
+		MemoryLimit:     e.memoryLimit,
+		KeepAlive:       e.keepalive,
 	}
-	runArgs = append(runArgs, "--name", handle.id) // Use BuildID as container name
-	runArgs = append(runArgs, "-v", fmt.Sprintf("%s:%s", hostOutputPath, path.Dir(plan.OutputPath)))
-	if plan.WorkingDir != "" {
-		runArgs = append(runArgs, "-w", plan.WorkingDir)
+	if plan.Privileged && !e.allowPrivileged {
+		log.Println("Warning: plan requested privileged execution but this executor does not allow privileged builds.")
 	}
-	if plan.Privileged {
-		if e.allowPrivileged {
-			runArgs = append(runArgs, "--privileged")
-			runArgs = append(runArgs, "-v", "/var/run/docker.sock:/var/run/docker.sock")
-		} else {
-			log.Println("Warning: plan requested privileged execution but this executor does not allow privileged builds.")
-		}
-	}
-	if e.memoryLimit != "" {
-		runArgs = append(runArgs, "--memory", e.memoryLimit)
-	}
-
 	// Add AUTH_HEADER environment variable if auth is required and callback is available
 	if plan.RequiresAuth && e.authCallback != nil {
 		authHeader, err := e.authCallback()
@@ -239,26 +228,13 @@ func (e *DockerRunExecutor) executeBuild(ctx context.Context, handle *localHandl
 			})
 			return
 		}
-		runArgs = append(runArgs, "-e", fmt.Sprintf("AUTH_HEADER=%s", authHeader))
+		argOpts.AuthMode, argOpts.AuthValue = AuthInline, authHeader
 	}
-
-	// Disable core dumps
-	runArgs = append(runArgs, "--ulimit", "core=0")
-
-	runArgs = append(runArgs, plan.Image)
-	if e.keepalive {
-		// To keep the container alive, we need to execute the build script in the background and keep an infinte process in the forground.
-		// Write the script to a file then execute it in the background
-		if strings.Contains(plan.Script, "EOF") {
-			handle.updateStatus(build.BuildStateCompleted)
-			handle.setResult(build.Result{
-				Error: errors.New("build script contains unexpected 'EOF' literal"),
-			})
-		}
-		wrappedScript := fmt.Sprintf("cat << 'EOF' > /build.sh\n%s\nEOF\n/bin/sh /build.sh &\ntail -f /dev/null\n", plan.Script)
-		runArgs = append(runArgs, "/bin/sh", "-c", wrappedScript)
-	} else {
-		runArgs = append(runArgs, "/bin/sh", "-c", plan.Script)
+	runArgs, err := ComposeDockerRunArgs(plan, argOpts)
+	if err != nil {
+		handle.updateStatus(build.BuildStateCompleted)
+		handle.setResult(build.Result{Error: err})
+		return
 	}
 	// Execute the Docker run command with streaming output
 	handle.updateStatus(build.BuildStateRunning)


### PR DESCRIPTION
This separates out the logic for generating cli arguments such that it
can be shared with the scratch VM build type.