### PR TITLE
Split docker run execution into phase scripts

### DIFF
--- a/pkg/build/local/run_args.go
+++ b/pkg/build/local/run_args.go
@@ -6,13 +6,9 @@ package local
 import (
 	"fmt"
 	"path"
-	"strings"
-
-	"github.com/pkg/errors"
 )
 
-// AuthMode selects how the AUTH_HEADER variable reaches the container in
-// ComposeDockerRunArgs.
+// AuthMode selects how the AUTH_HEADER variable reaches the container.
 type AuthMode int
 
 const (
@@ -27,17 +23,16 @@ const (
 	AuthEnvPassthrough
 )
 
-// RunArgsOpts parameterizes ComposeDockerRunArgs. It makes the legitimate
-// backend divergences explicit so alternate executors (e.g. the scratch VM
-// executor) share a single composition of `docker run` argv with the local
-// executor.
+// RunArgsOpts parameterizes the docker argv compositions.
 type RunArgsOpts struct {
 	// ContainerName is the container's --name.
 	ContainerName string
 	// OutputMountSrc is the docker-host directory mounted at the plan's
 	// output directory.
 	OutputMountSrc string
-	// Remove adds --rm.
+	// Remove adds --rm: the daemon removes the container once it exits. In
+	// the start/exec composition the container only exits when the caller
+	// stops its idle init.
 	Remove bool
 	// AllowPrivileged permits plans that request privileged execution to
 	// receive --privileged and the docker socket mount. Callers gate this on
@@ -45,23 +40,16 @@ type RunArgsOpts struct {
 	AllowPrivileged bool
 	// MemoryLimit sets --memory when non-empty.
 	MemoryLimit string
-	// AuthMode selects how AUTH_HEADER is delivered; AuthValue is its value
+	// AuthMode selects how AUTH_HEADER is delivered. AuthValue is its value
 	// for AuthInline.
 	AuthMode  AuthMode
 	AuthValue string
-	// KeepAlive wraps the inline script so the container stays up after the
-	// build completes (local interactive debugging).
-	KeepAlive bool
 }
 
-// ComposeDockerRunArgs builds the `docker run` argv for executing plan under
-// the given options. The returned argv excludes the docker command itself.
-func ComposeDockerRunArgs(plan *DockerRunPlan, opts RunArgsOpts) ([]string, error) {
-	args := []string{"run"}
-	if opts.Remove {
-		args = append(args, "--rm")
-	}
-	args = append(args, "--name", opts.ContainerName)
+// composeContainerArgs assembles the flags shared by both compositions:
+// identity, mounts, isolation, and env.
+func composeContainerArgs(plan *DockerRunPlan, opts RunArgsOpts) []string {
+	args := []string{"--name", opts.ContainerName}
 	args = append(args, "-v", fmt.Sprintf("%s:%s", opts.OutputMountSrc, path.Dir(plan.OutputPath)))
 	if plan.WorkingDir != "" {
 		args = append(args, "-w", plan.WorkingDir)
@@ -81,20 +69,24 @@ func ComposeDockerRunArgs(plan *DockerRunPlan, opts RunArgsOpts) ([]string, erro
 	}
 	// Disable core dumps
 	args = append(args, "--ulimit", "core=0")
-	args = append(args, plan.Image)
-	switch {
-	case opts.KeepAlive:
-		// To keep the container alive, execute the build script in the
-		// background and keep an infinite process in the foreground. The
-		// script is written to a file via heredoc, so an EOF literal inside
-		// it would corrupt the wrapper.
-		if strings.Contains(plan.Script, "EOF") {
-			return nil, errors.New("build script contains unexpected 'EOF' literal")
-		}
-		wrapped := fmt.Sprintf("cat << 'EOF' > /build.sh\n%s\nEOF\n/bin/sh /build.sh &\ntail -f /dev/null\n", plan.Script)
-		args = append(args, "/bin/sh", "-c", wrapped)
-	default:
-		args = append(args, "/bin/sh", "-c", plan.Script)
+	return args
+}
+
+// ComposeDockerStartArgs builds the `docker run` argv that starts the build
+// container idle. Phases then execute in it via ComposeDockerExecArgs. The
+// returned argv excludes the docker command itself.
+func ComposeDockerStartArgs(plan *DockerRunPlan, opts RunArgsOpts) []string {
+	args := []string{"run", "--detach"}
+	if opts.Remove {
+		args = append(args, "--rm")
 	}
-	return args, nil
+	args = append(args, composeContainerArgs(plan, opts)...)
+	return append(args, plan.Image, "sleep", "infinity")
+}
+
+// ComposeDockerExecArgs builds the `docker exec` argv running one phase in a
+// container started via ComposeDockerStartArgs. Container-level env is
+// inherited by every exec.
+func ComposeDockerExecArgs(container string, phase Phase) []string {
+	return []string{"exec", container, "/bin/sh", "-c", strictPrelude + "\n" + phase.Script}
 }

--- a/pkg/build/local/run_args_test.go
+++ b/pkg/build/local/run_args_test.go
@@ -4,109 +4,91 @@
 package local
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestComposeDockerRunArgs(t *testing.T) {
-	plan := &DockerRunPlan{
+func runArgsTestPlan() *DockerRunPlan {
+	return &DockerRunPlan{
 		Image:      "alpine:3.19",
-		Script:     "echo hello",
+		Setup:      "echo setup",
+		Source:     "echo source",
+		Deps:       "echo deps",
+		Build:      "echo build",
 		WorkingDir: "/workspace",
 		OutputPath: "/out/rebuild",
 	}
+}
+
+func TestComposeDockerStartArgs(t *testing.T) {
 	for _, tt := range []struct {
-		name    string
-		plan    *DockerRunPlan
-		opts    RunArgsOpts
-		want    []string
-		wantErr string
+		name string
+		plan *DockerRunPlan
+		opts RunArgsOpts
+		want []string
 	}{
 		{
 			name: "local defaults",
-			plan: plan,
+			plan: runArgsTestPlan(),
 			opts: RunArgsOpts{
 				ContainerName:  "b1",
 				OutputMountSrc: "/tmp/oss-rebuild-b1",
-				Remove:         true,
 			},
-			want: []string{"run", "--rm", "--name", "b1", "-v", "/tmp/oss-rebuild-b1:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
+			want: []string{"run", "--detach", "--name", "b1", "-v", "/tmp/oss-rebuild-b1:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
 		},
 		{
 			name: "inline auth",
-			plan: plan,
+			plan: runArgsTestPlan(),
+			opts: RunArgsOpts{
+				ContainerName:  "b1",
+				OutputMountSrc: "/tmp/b1",
+				AuthMode:       AuthInline,
+				AuthValue:      "Authorization: Bearer tok",
+			},
+			want: []string{"run", "--detach", "--name", "b1", "-v", "/tmp/b1:/out", "-w", "/workspace", "-e", "AUTH_HEADER=Authorization: Bearer tok", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
+		},
+		{
+			name: "removed on exit",
+			plan: runArgsTestPlan(),
 			opts: RunArgsOpts{
 				ContainerName:  "b1",
 				OutputMountSrc: "/tmp/b1",
 				Remove:         true,
-				AuthMode:       AuthInline,
-				AuthValue:      "Authorization: Bearer tok",
 			},
-			want: []string{"run", "--rm", "--name", "b1", "-v", "/tmp/b1:/out", "-w", "/workspace", "-e", "AUTH_HEADER=Authorization: Bearer tok", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
-		},
-		{
-			name: "env passthrough auth",
-			plan: plan,
-			opts: RunArgsOpts{
-				ContainerName:  "b1",
-				OutputMountSrc: "/home/builder/builds/b1/out",
-				Remove:         true,
-				AuthMode:       AuthEnvPassthrough,
-			},
-			want: []string{"run", "--rm", "--name", "b1", "-v", "/home/builder/builds/b1/out:/out", "-w", "/workspace", "-e", "AUTH_HEADER", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
+			want: []string{"run", "--detach", "--rm", "--name", "b1", "-v", "/tmp/b1:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
 		},
 		{
 			name: "privileged allowed",
-			plan: &DockerRunPlan{Image: "alpine:3.19", Script: "true", OutputPath: "/out/rebuild", Privileged: true},
+			plan: &DockerRunPlan{Image: "alpine:3.19", Build: "true", OutputPath: "/out/rebuild", Privileged: true},
 			opts: RunArgsOpts{
 				ContainerName:   "b1",
 				OutputMountSrc:  "/tmp/b1",
 				AllowPrivileged: true,
 			},
-			want: []string{"run", "--name", "b1", "-v", "/tmp/b1:/out", "--privileged", "-v", "/var/run/docker.sock:/var/run/docker.sock", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "true"},
+			want: []string{"run", "--detach", "--name", "b1", "-v", "/tmp/b1:/out", "--privileged", "-v", "/var/run/docker.sock:/var/run/docker.sock", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
 		},
 		{
 			name: "privileged denied",
-			plan: &DockerRunPlan{Image: "alpine:3.19", Script: "true", OutputPath: "/out/rebuild", Privileged: true},
+			plan: &DockerRunPlan{Image: "alpine:3.19", Build: "true", OutputPath: "/out/rebuild", Privileged: true},
 			opts: RunArgsOpts{
 				ContainerName:  "b1",
 				OutputMountSrc: "/tmp/b1",
 			},
-			want: []string{"run", "--name", "b1", "-v", "/tmp/b1:/out", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "true"},
-		},
-		{
-			name: "keepalive wraps script",
-			plan: plan,
-			opts: RunArgsOpts{
-				ContainerName:  "b1",
-				OutputMountSrc: "/tmp/b1",
-				KeepAlive:      true,
-			},
-			want: []string{"run", "--name", "b1", "-v", "/tmp/b1:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "cat << 'EOF' > /build.sh\necho hello\nEOF\n/bin/sh /build.sh &\ntail -f /dev/null\n"},
-		},
-		{
-			name:    "keepalive rejects EOF literal",
-			plan:    &DockerRunPlan{Image: "alpine:3.19", Script: "echo EOF", OutputPath: "/out/rebuild"},
-			opts:    RunArgsOpts{ContainerName: "b1", OutputMountSrc: "/tmp/b1", KeepAlive: true},
-			wantErr: "EOF",
+			want: []string{"run", "--detach", "--name", "b1", "-v", "/tmp/b1:/out", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ComposeDockerRunArgs(tt.plan, tt.opts)
-			if tt.wantErr != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-					t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("ComposeDockerRunArgs: %v", err)
-			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+			if diff := cmp.Diff(tt.want, ComposeDockerStartArgs(tt.plan, tt.opts)); diff != "" {
 				t.Errorf("args mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestComposeDockerExecArgs(t *testing.T) {
+	want := []string{"exec", "b1", "/bin/sh", "-c", "set -eux\necho setup"}
+	if diff := cmp.Diff(want, ComposeDockerExecArgs("b1", Phase{"setup", "echo setup"})); diff != "" {
+		t.Errorf("args mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/build/local/run_executor.go
+++ b/pkg/build/local/run_executor.go
@@ -33,7 +33,6 @@ type DockerRunExecutor struct {
 	activeBuilds     syncx.Map[string, *localHandle]
 	outputBufferSize int
 	retainContainer  bool
-	keepalive        bool
 	tempDirBase      string
 	authCallback     AuthCallback
 	allowPrivileged  bool
@@ -77,7 +76,6 @@ func NewDockerRunExecutor(config DockerRunExecutorConfig) (*DockerRunExecutor, e
 		activeBuilds:     syncx.Map[string, *localHandle]{},
 		outputBufferSize: outputBufferSize,
 		retainContainer:  config.RetainContainer,
-		keepalive:        config.KeepAlive,
 		tempDirBase:      tempBase,
 		authCallback:     config.AuthCallback,
 		allowPrivileged:  config.AllowPrivileged,
@@ -94,8 +92,7 @@ type DockerRunExecutorConfig struct {
 	CommandExecutor  CommandExecutor
 	MaxParallel      int          // Max number of simultaneous builds
 	OutputBufferSize int          // Buffer size for output pipe, defaults to 512KB
-	RetainContainer  bool         // If true, don't use --rm flag to retain containers
-	KeepAlive        bool         // Keep containers running. Caller is responsible for cleanup
+	RetainContainer  bool         // If true, retain containers stopped instead of removing them
 	TempDirBase      string       // Base directory for temp files, if empty uses os.TempDir()
 	AuthCallback     AuthCallback // Optional callback to generate auth headers when needed
 	AllowPrivileged  bool         // If true, allow privileged builds
@@ -168,7 +165,8 @@ func (e *DockerRunExecutor) Close(ctx context.Context) error {
 	}
 }
 
-// executeBuild runs the actual Docker run process
+// executeBuild starts the build container idle and drives the plan's phases
+// through it sequentially
 func (e *DockerRunExecutor) executeBuild(ctx context.Context, handle *localHandle, plan *DockerRunPlan, t rebuild.Target, opts build.Options) {
 	// TODO: Add support for SaveContainerImage in DockerRunExecutor.
 	if opts.SaveContainerImage {
@@ -210,10 +208,9 @@ func (e *DockerRunExecutor) executeBuild(ctx context.Context, handle *localHandl
 	argOpts := RunArgsOpts{
 		ContainerName:   handle.id, // Use BuildID as container name
 		OutputMountSrc:  hostOutputPath,
-		Remove:          !e.retainContainer && !opts.SavePostBuildContainer,
+		Remove:          !e.retainContainer,
 		AllowPrivileged: e.allowPrivileged,
 		MemoryLimit:     e.memoryLimit,
-		KeepAlive:       e.keepalive,
 	}
 	if plan.Privileged && !e.allowPrivileged {
 		log.Println("Warning: plan requested privileged execution but this executor does not allow privileged builds.")
@@ -230,19 +227,23 @@ func (e *DockerRunExecutor) executeBuild(ctx context.Context, handle *localHandl
 		}
 		argOpts.AuthMode, argOpts.AuthValue = AuthInline, authHeader
 	}
-	runArgs, err := ComposeDockerRunArgs(plan, argOpts)
-	if err != nil {
-		handle.updateStatus(build.BuildStateCompleted)
-		handle.setResult(build.Result{Error: err})
-		return
-	}
-	// Execute the Docker run command with streaming output
 	handle.updateStatus(build.BuildStateRunning)
 	outbuf := &bytes.Buffer{}
 	runWriter := io.MultiWriter(handle, outbuf)
-	buildErr := e.cmdExecutor.Execute(ctx, CommandOptions{
-		Output: runWriter,
-	}, e.dockerCmd, runArgs...)
+	// Start the container idling, then execute each phase in it. The start
+	// output is the container ID, not build output: keep it out of the logs.
+	idBuf := &bytes.Buffer{}
+	buildErr := e.cmdExecutor.Execute(ctx, CommandOptions{Output: idBuf}, e.dockerCmd, ComposeDockerStartArgs(plan, argOpts)...)
+	if buildErr != nil {
+		buildErr = errors.Wrap(buildErr, "starting build container")
+	} else {
+		for _, ph := range plan.Phases() {
+			if err := e.cmdExecutor.Execute(ctx, CommandOptions{Output: runWriter}, e.dockerCmd, ComposeDockerExecArgs(handle.id, ph)...); err != nil {
+				buildErr = errors.Wrapf(err, "executing %s phase", ph.Name)
+				break
+			}
+		}
+	}
 	// Export post-build container if requested.
 	if opts.SavePostBuildContainer {
 		postBuildPath := filepath.Join(hostOutputPath, string(rebuild.PostBuildContainerAsset))
@@ -270,16 +271,18 @@ func (e *DockerRunExecutor) executeBuild(ctx context.Context, handle *localHandl
 			}
 		}
 	}
-	// Clean up post-build container if it was retained for export.
-	if opts.SavePostBuildContainer && !e.retainContainer {
-		if rmErr := e.cmdExecutor.Execute(ctx, CommandOptions{}, e.dockerCmd, "rm", handle.id); rmErr != nil {
-			log.Printf("Failed to remove container %s: %v", handle.id, rmErr)
-		}
+	// Tear down the container: the idle entrypoint never exits on its own.
+	// RetainContainer keeps it around stopped (docker start revives it for
+	// interactive use). Teardown must survive build cancellation.
+	teardown := []string{"rm", "-f", handle.id}
+	if e.retainContainer {
+		teardown = []string{"stop", handle.id}
+	}
+	if err := e.cmdExecutor.Execute(context.WithoutCancel(ctx), CommandOptions{}, e.dockerCmd, teardown...); err != nil {
+		log.Printf("Failed to clean up container %s: %v", handle.id, err)
 	}
 	handle.updateStatus(build.BuildStateCompleted)
-	handle.setResult(build.Result{
-		Error: errors.Wrap(buildErr, "docker run failed"),
-	})
+	handle.setResult(build.Result{Error: buildErr})
 }
 
 // uploadFile uploads a local file to the asset store

--- a/pkg/build/local/run_executor_test.go
+++ b/pkg/build/local/run_executor_test.go
@@ -57,7 +57,10 @@ func TestDockerRunExecutor(t *testing.T) {
 			name: "successful execution",
 			plan: &DockerRunPlan{
 				Image:      "alpine:3.19",
-				Script:     "echo hello",
+				Setup:      "echo setup",
+				Source:     "echo source",
+				Deps:       "npm install",
+				Build:      "echo hello",
 				OutputPath: "/out/result.txt",
 				WorkingDir: "/workspace",
 			},
@@ -86,7 +89,27 @@ func TestDockerRunExecutor(t *testing.T) {
 			expectedCommands: []MockCommand{
 				{
 					Name: "docker",
-					Args: []string{"run", "--rm", "--name", "test-build-123", "-v", "/tmp/oss-rebuild-test-build-123:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
+					Args: []string{"run", "--detach", "--rm", "--name", "test-build-123", "-v", "/tmp/oss-rebuild-test-build-123:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"exec", "test-build-123", "/bin/sh", "-c", "set -eux\necho setup"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"exec", "test-build-123", "/bin/sh", "-c", "set -eux\necho source"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"exec", "test-build-123", "/bin/sh", "-c", "set -eux\nnpm install"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"exec", "test-build-123", "/bin/sh", "-c", "set -eux\necho hello"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"rm", "-f", "test-build-123"},
 				},
 			},
 			expectSuccess: true,
@@ -95,7 +118,7 @@ func TestDockerRunExecutor(t *testing.T) {
 			name: "docker command not found",
 			plan: &DockerRunPlan{
 				Image:      "alpine:3.19",
-				Script:     "echo hello",
+				Build:      "echo hello",
 				OutputPath: "/out/result.txt",
 			},
 			input: rebuild.Input{
@@ -118,7 +141,9 @@ func TestDockerRunExecutor(t *testing.T) {
 			name: "docker execution failure",
 			plan: &DockerRunPlan{
 				Image:      "alpine:3.19",
-				Script:     "false",
+				Setup:      "false",
+				Source:     "true",
+				Build:      "true",
 				OutputPath: "/out/result.txt",
 			},
 			input: rebuild.Input{
@@ -138,7 +163,12 @@ func TestDockerRunExecutor(t *testing.T) {
 			expectedCommands: []MockCommand{
 				{
 					Name:  "docker",
-					Args:  []string{"run", "--rm", "--name", "test-build-789", "-v", "/tmp/oss-rebuild-test-build-789:/out", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "false"},
+					Args:  []string{"run", "--detach", "--rm", "--name", "test-build-789", "-v", "/tmp/oss-rebuild-test-build-789:/out", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
+					Error: errors.New("exit status 1"),
+				},
+				{
+					Name:  "docker",
+					Args:  []string{"rm", "-f", "test-build-789"},
 					Error: errors.New("exit status 1"),
 				},
 			},
@@ -164,7 +194,9 @@ func TestDockerRunExecutor(t *testing.T) {
 			name: "timeout handling",
 			plan: &DockerRunPlan{
 				Image:      "alpine:3.19",
-				Script:     "sleep 10",
+				Setup:      "true",
+				Source:     "true",
+				Build:      "sleep 10",
 				OutputPath: "/out/result.txt",
 			},
 			input: rebuild.Input{
@@ -193,7 +225,9 @@ func TestDockerRunExecutor(t *testing.T) {
 			name: "with custom working directory",
 			plan: &DockerRunPlan{
 				Image:      "ubuntu:20.04",
-				Script:     "pwd",
+				Setup:      "true",
+				Source:     "true",
+				Build:      "pwd",
 				OutputPath: "/out/result.txt",
 				WorkingDir: "/custom/workdir",
 			},
@@ -217,7 +251,23 @@ func TestDockerRunExecutor(t *testing.T) {
 			expectedCommands: []MockCommand{
 				{
 					Name: "docker",
-					Args: []string{"run", "--rm", "--name", "test-build-workdir", "-v", "/tmp/oss-rebuild-test-build-workdir:/out", "-w", "/custom/workdir", "--ulimit", "core=0", "ubuntu:20.04", "/bin/sh", "-c", "pwd"},
+					Args: []string{"run", "--detach", "--rm", "--name", "test-build-workdir", "-v", "/tmp/oss-rebuild-test-build-workdir:/out", "-w", "/custom/workdir", "--ulimit", "core=0", "ubuntu:20.04", "sleep", "infinity"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"exec", "test-build-workdir", "/bin/sh", "-c", "set -eux\ntrue"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"exec", "test-build-workdir", "/bin/sh", "-c", "set -eux\ntrue"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"exec", "test-build-workdir", "/bin/sh", "-c", "set -eux\npwd"},
+				},
+				{
+					Name: "docker",
+					Args: []string{"rm", "-f", "test-build-workdir"},
 				},
 			},
 			expectSuccess: true,
@@ -337,7 +387,9 @@ func TestDockerRunExecutorConcurrency(t *testing.T) {
 		Planner: &mockPlanner{
 			plan: &DockerRunPlan{
 				Image:      "alpine:3.19",
-				Script:     "echo test",
+				Setup:      "true",
+				Source:     "true",
+				Build:      "echo test",
 				OutputPath: "/out/result.txt",
 			},
 		},
@@ -363,7 +415,6 @@ func TestDockerRunExecutorConcurrency(t *testing.T) {
 		options := build.Options{
 			BuildID: fmt.Sprintf("build-%d", i),
 		}
-
 		handle, err := executor.Start(ctx, input, options)
 		if err != nil {
 			t.Fatalf("Failed to start build %d: %v", i, err)
@@ -402,7 +453,9 @@ func TestDockerRunExecutorSavePostBuildContainer(t *testing.T) {
 		Planner: &mockPlanner{
 			plan: &DockerRunPlan{
 				Image:      "alpine:3.19",
-				Script:     "echo hello",
+				Setup:      "echo setup",
+				Source:     "echo source",
+				Build:      "echo hello",
 				OutputPath: "/out/result.txt",
 				WorkingDir: "/workspace",
 			},
@@ -440,7 +493,19 @@ func TestDockerRunExecutorSavePostBuildContainer(t *testing.T) {
 	expectedCommands := []MockCommand{
 		{
 			Name: "docker",
-			Args: []string{"run", "--name", "test-postbuild", "-v", "/tmp/oss-rebuild-test-postbuild:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "/bin/sh", "-c", "echo hello"},
+			Args: []string{"run", "--detach", "--rm", "--name", "test-postbuild", "-v", "/tmp/oss-rebuild-test-postbuild:/out", "-w", "/workspace", "--ulimit", "core=0", "alpine:3.19", "sleep", "infinity"},
+		},
+		{
+			Name: "docker",
+			Args: []string{"exec", "test-postbuild", "/bin/sh", "-c", "set -eux\necho setup"},
+		},
+		{
+			Name: "docker",
+			Args: []string{"exec", "test-postbuild", "/bin/sh", "-c", "set -eux\necho source"},
+		},
+		{
+			Name: "docker",
+			Args: []string{"exec", "test-postbuild", "/bin/sh", "-c", "set -eux\necho hello"},
 		},
 		{
 			Name: "docker",
@@ -456,7 +521,7 @@ func TestDockerRunExecutorSavePostBuildContainer(t *testing.T) {
 		},
 		{
 			Name: "docker",
-			Args: []string{"rm", "test-postbuild"},
+			Args: []string{"rm", "-f", "test-postbuild"},
 		},
 	}
 	if diff := cmp.Diff(expectedCommands, commands, cmp.Comparer(func(e1 error, e2 error) bool {

--- a/pkg/build/local/run_plan.go
+++ b/pkg/build/local/run_plan.go
@@ -3,12 +3,23 @@
 
 package local
 
-// DockerRunPlan represents a Docker run execution plan where we run an existing image
+import "strings"
+
+// DockerRunPlan represents a Docker run execution plan where phase scripts
+// run sequentially in one container started from an existing image.
 type DockerRunPlan struct {
 	// Image is the Docker image to run
 	Image string
-	// Script is the bash script to execute inside the container
-	Script string
+	// Setup installs system deps and fetches tools (e.g. timewarp)
+	Setup string
+	// Source populates /src with the package source
+	Source string
+	// Deps installs the package's build deps. Empty when the plan has no
+	// deps phase. Timewarp serves only for this phase's duration, matching
+	// the docker build variants.
+	Deps string
+	// Build produces the artifact and copies it to OutputPath
+	Build string
 	// WorkingDir sets the working directory in the container
 	WorkingDir string
 	// OutputPath specifies where artifacts should be copied from the container
@@ -17,4 +28,36 @@ type DockerRunPlan struct {
 	RequiresAuth bool
 	// Indicates whether to run the container in privileged mode
 	Privileged bool
+}
+
+// Phase is one sequentially executed script of a DockerRunPlan. Phase scripts
+// are cwd-independent: each phase runs in a fresh shell and no state flows
+// between phases beyond the container filesystem.
+type Phase struct {
+	Name   string
+	Script string
+}
+
+// strictPrelude is the shell strict-mode prelude prepended to every rendered
+// script.
+const strictPrelude = "set -eux"
+
+// Phases returns the plan's scripts in execution order, omitting the deps
+// phase when the plan has none.
+func (p *DockerRunPlan) Phases() []Phase {
+	phases := []Phase{{"setup", p.Setup}, {"source", p.Source}}
+	if p.Deps != "" {
+		phases = append(phases, Phase{"deps", p.Deps})
+	}
+	return append(phases, Phase{"build", p.Build})
+}
+
+// CombinedScript renders the phases as one script for display. Phase
+// cwd-independence keeps its semantics identical to per-phase execution.
+func (p *DockerRunPlan) CombinedScript() string {
+	scripts := []string{strictPrelude}
+	for _, ph := range p.Phases() {
+		scripts = append(scripts, ph.Script)
+	}
+	return strings.Join(scripts, "\n")
 }

--- a/pkg/build/local/run_planner.go
+++ b/pkg/build/local/run_planner.go
@@ -18,38 +18,57 @@ import (
 type DockerRunPlanner struct {
 }
 
-// dockerRunScriptArgs holds template arguments for the run script
+// dockerRunScriptArgs holds template arguments for the phase scripts
 type dockerRunScriptArgs struct {
 	Inst           rebuild.Instructions
+	OS             build.OS
 	PackageManager build.PackageManagerCommands
 	UseTimewarp    bool
 	TimewarpURL    string
 	TimewarpAuth   bool
 }
 
-// dockerRunScriptTpl is the template for the script executed in the container
-var dockerRunScriptTpl = template.Must(
-	template.New("docker run script").Funcs(template.FuncMap{
-		"indent": func(s string) string { return strings.ReplaceAll(s, "\n", "\n ") },
-		"join":   func(sep string, s []string) string { return strings.Join(s, sep) },
-		"list":   func(items ...string) []string { return items },
+// dockerRunPhaseTpls generate the per-phase scripts. Phase boundaries match
+// the docker build variants' layers. Scripts are cwd-independent (absolute
+// timewarp path, each phase re-enters /src) so they compose into a single
+// shell via CombinedScript without semantic drift.
+var dockerRunPhaseTpls = template.Must(
+	template.New("docker run phases").Funcs(template.FuncMap{
+		"list": func(items ...string) []string { return items },
 	}).Parse(
 		textwrap.Dedent(`
-			set -eux
-			{{.PackageManager.UpdateCmd}}
+			{{- define "setup" -}}
 			{{- if .UseTimewarp}}
+			{{- if eq .OS "alpine"}}
+			{{.PackageManager.InstallCommand (list "curl")}}
+			{{- else}}
+			{{.PackageManager.UpdateCmd}}
 			{{.PackageManager.InstallCommand (list "curl" "netcat-openbsd")}}
-			curl {{if .TimewarpAuth}}-H "$AUTH_HEADER" {{end}} {{.TimewarpURL}} > timewarp
-			chmod +x timewarp
-			./timewarp -port 8081 &
+			{{- end}}
+			curl {{if .TimewarpAuth}}-H "$AUTH_HEADER" {{end}}{{.TimewarpURL}} > /timewarp
+			chmod +x /timewarp
+			{{- end}}
+			{{.PackageManager.UpdateCmd}}
+			{{.PackageManager.InstallCommand .Inst.Requires.SystemDeps}}
+			{{- end}}
+			{{- define "source" -}}
+			mkdir -p /src && cd /src
+			{{.Inst.Source}}
+			{{- end}}
+			{{- define "deps" -}}
+			{{- if .UseTimewarp}}
+			/timewarp -port 8081 &
 			while ! nc -z localhost 8081;do sleep 1;done
 			{{- end}}
-			mkdir /src && cd /src
-			{{.PackageManager.InstallCommand .Inst.Requires.SystemDeps}}
-			{{.Inst.Source}}
+			cd /src
 			{{.Inst.Deps}}
+			{{- end}}
+			{{- define "build" -}}
+			cd /src
 			{{.Inst.Build}}
-			cp /src/{{.Inst.OutputPath}} /out/rebuild`)[1:],
+			cp /src/{{.Inst.OutputPath}} /out/rebuild
+			{{- end -}}
+			`),
 	),
 )
 
@@ -72,45 +91,51 @@ func (p *DockerRunPlanner) GeneratePlan(ctx context.Context, input rebuild.Input
 		return nil, errors.Wrap(err, "failed to generate rebuild instructions")
 	}
 	image := opts.Resources.BaseImageConfig.SelectFor(input)
-	script, err := p.generateScript(instructions, input, opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate command")
-	}
-	// Check if any auth is required for this plan
-	requiresAuth := len(opts.Resources.ToolAuthRequired) > 0
-
-	return &DockerRunPlan{
-		Image:        image,
-		Script:       script,
-		WorkingDir:   "/workspace",
-		OutputPath:   "/out/rebuild",
-		RequiresAuth: requiresAuth,
-		Privileged:   instructions.Requires.Privileged,
-	}, nil
-}
-
-func (p *DockerRunPlanner) generateScript(instructions rebuild.Instructions, input rebuild.Input, opts build.PlanOptions) (string, error) {
-	// Select base image and detect OS for package management
-	baseImage := opts.Resources.BaseImageConfig.SelectFor(input)
-	os := build.DetectOS(baseImage)
-	pkgMgr := build.GetPackageManagerCommands(os)
-	// Extract tool URLs and auth requirements
+	os := build.DetectOS(image)
 	timewarpURL, timewarpAuth, err := p.getToolURL(build.TimewarpTool, opts)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get timewarp URL")
+		return nil, errors.Wrap(err, "failed to get timewarp URL")
 	}
-	// Execute template to generate script
-	var buf strings.Builder
-	if err := dockerRunScriptTpl.Execute(&buf, dockerRunScriptArgs{
+	args := dockerRunScriptArgs{
 		Inst:           instructions,
-		PackageManager: pkgMgr,
+		OS:             os,
+		PackageManager: build.GetPackageManagerCommands(os),
 		UseTimewarp:    opts.UseTimewarp,
 		TimewarpURL:    timewarpURL,
 		TimewarpAuth:   timewarpAuth,
-	}); err != nil {
-		return "", errors.Wrap(err, "executing run script template")
 	}
-	return buf.String(), nil
+	phase := func(name string) (string, error) {
+		var buf strings.Builder
+		if err := dockerRunPhaseTpls.ExecuteTemplate(&buf, name, args); err != nil {
+			return "", errors.Wrapf(err, "executing %s phase template", name)
+		}
+		// Conditional first lines leave a leading newline in the render.
+		return strings.TrimSpace(buf.String()), nil
+	}
+	plan := &DockerRunPlan{
+		Image:        image,
+		WorkingDir:   "/workspace",
+		OutputPath:   "/out/rebuild",
+		RequiresAuth: len(opts.Resources.ToolAuthRequired) > 0,
+		Privileged:   instructions.Requires.Privileged,
+	}
+	if plan.Setup, err = phase("setup"); err != nil {
+		return nil, err
+	}
+	if plan.Source, err = phase("source"); err != nil {
+		return nil, err
+	}
+	// No deps instructions means no deps phase. Timewarp then never starts,
+	// matching the docker build variants' conditional deps layer.
+	if instructions.Deps != "" {
+		if plan.Deps, err = phase("deps"); err != nil {
+			return nil, err
+		}
+	}
+	if plan.Build, err = phase("build"); err != nil {
+		return nil, err
+	}
+	return plan, nil
 }
 
 func (p *DockerRunPlanner) getToolURL(toolType build.ToolType, opts build.PlanOptions) (toolURL string, needsAuth bool, err error) {

--- a/pkg/build/local/run_planner_test.go
+++ b/pkg/build/local/run_planner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/internal/textwrap"
 	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/rebuild/flow"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 )
 
@@ -55,14 +56,18 @@ func TestDockerRunPlanner(t *testing.T) {
 				Image:      "alpine:3.19",
 				WorkingDir: "/workspace",
 				OutputPath: "/out/rebuild",
-				Script: textwrap.Dedent(`
-			set -eux
+				Setup: textwrap.Dedent(`
 			apk update
-			mkdir /src && cd /src
-			apk add npm git
+			apk add npm git`[1:]),
+				Source: textwrap.Dedent(`
+			mkdir -p /src && cd /src
 			git clone https://github.com/example/test-package .
-			git checkout --force 'v1.0.0'
-			npm install
+			git checkout --force 'v1.0.0'`[1:]),
+				Deps: textwrap.Dedent(`
+			cd /src
+			npm install`[1:]),
+				Build: textwrap.Dedent(`
+			cd /src
 			npm pack
 			cp /src/test-package-1.0.0.tgz /out/rebuild`[1:]),
 			},
@@ -101,19 +106,70 @@ func TestDockerRunPlanner(t *testing.T) {
 				Image:      "alpine:3.19",
 				WorkingDir: "/workspace",
 				OutputPath: "/out/rebuild",
-				Script: textwrap.Dedent(`
-			set -eux
+				Setup: textwrap.Dedent(`
+			apk add curl
+			curl https://example.com/timewarp > /timewarp
+			chmod +x /timewarp
 			apk update
-			apk add curl netcat-openbsd
-			curl  https://example.com/timewarp > timewarp
-			chmod +x timewarp
-			./timewarp -port 8081 &
-			while ! nc -z localhost 8081;do sleep 1;done
-			mkdir /src && cd /src
-			apk add git
+			apk add git`[1:]),
+				Source: textwrap.Dedent(`
+			mkdir -p /src && cd /src
 			git clone https://github.com/example/test-package .
-			git checkout --force 'v1.0.0'
-			npm install
+			git checkout --force 'v1.0.0'`[1:]),
+				Deps: textwrap.Dedent(`
+			/timewarp -port 8081 &
+			while ! nc -z localhost 8081;do sleep 1;done
+			cd /src
+			npm install`[1:]),
+				Build: textwrap.Dedent(`
+			cd /src
+			npm pack
+			cp /src/test-package-1.0.0.tgz /out/rebuild`[1:]),
+			},
+		},
+		{
+			// No deps instructions: no deps phase, and timewarp is fetched
+			// but never started, matching the docker build variants.
+			name: "timewarp without deps",
+			input: rebuild.Input{
+				Target: rebuild.Target{
+					Ecosystem: rebuild.NPM,
+					Package:   "test-package",
+					Version:   "1.0.0",
+					Artifact:  "test-package-1.0.0.tgz",
+				},
+				Strategy: &rebuild.WorkflowStrategy{
+					Source:     []flow.Step{{Runs: "echo source"}},
+					Build:      []flow.Step{{Runs: "npm pack"}},
+					OutputPath: "test-package-1.0.0.tgz",
+				},
+			},
+			opts: build.PlanOptions{
+				UseTimewarp: true,
+				Resources: build.Resources{
+					BaseImageConfig: build.BaseImageConfig{
+						Default: "alpine:3.19",
+					},
+					ToolURLs: map[build.ToolType]string{
+						build.TimewarpTool: "https://example.com/timewarp",
+					},
+				},
+			},
+			expected: &DockerRunPlan{
+				Image:      "alpine:3.19",
+				WorkingDir: "/workspace",
+				OutputPath: "/out/rebuild",
+				Setup: textwrap.Dedent(`
+			apk add curl
+			curl https://example.com/timewarp > /timewarp
+			chmod +x /timewarp
+			apk update
+			apk add`[1:]),
+				Source: textwrap.Dedent(`
+			mkdir -p /src && cd /src
+			echo source`[1:]),
+				Build: textwrap.Dedent(`
+			cd /src
 			npm pack
 			cp /src/test-package-1.0.0.tgz /out/rebuild`[1:]),
 			},
@@ -144,12 +200,10 @@ func TestDockerRunPlanner(t *testing.T) {
 			expectedErr: "failed to generate rebuild instructions",
 		},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			planner := NewDockerRunPlanner()
 			plan, err := planner.GeneratePlan(context.Background(), tc.input, tc.opts)
-
 			if tc.expectedErr != "" {
 				if err == nil {
 					t.Fatalf("GeneratePlan() expected error, but got none")
@@ -159,7 +213,6 @@ func TestDockerRunPlanner(t *testing.T) {
 				}
 				return
 			}
-
 			if err != nil {
 				t.Fatalf("GeneratePlan() failed: %v", err)
 			}
@@ -167,5 +220,21 @@ func TestDockerRunPlanner(t *testing.T) {
 				t.Errorf("GeneratePlan() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestDockerRunPlanPhases(t *testing.T) {
+	plan := &DockerRunPlan{Setup: "s1", Source: "s2", Deps: "s3", Build: "s4"}
+	want := []Phase{{"setup", "s1"}, {"source", "s2"}, {"deps", "s3"}, {"build", "s4"}}
+	if diff := cmp.Diff(want, plan.Phases()); diff != "" {
+		t.Errorf("Phases() mismatch (-want +got):\n%s", diff)
+	}
+	plan.Deps = ""
+	want = []Phase{{"setup", "s1"}, {"source", "s2"}, {"build", "s4"}}
+	if diff := cmp.Diff(want, plan.Phases()); diff != "" {
+		t.Errorf("Phases() without deps mismatch (-want +got):\n%s", diff)
+	}
+	if got, want := plan.CombinedScript(), "set -eux\ns1\ns2\ns4"; got != want {
+		t.Errorf("CombinedScript() = %q, want %q", got, want)
 	}
 }

--- a/tools/ctl/command/infer/infer.go
+++ b/tools/ctl/command/infer/infer.go
@@ -266,7 +266,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 		if err != nil {
 			return nil, errors.Wrap(err, "generating plan")
 		}
-		buildScript = plan.Script
+		buildScript = plan.CombinedScript()
 	}
 	switch cfg.Format {
 	case "", "strategy", "strategy-or-status":

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -55,7 +55,6 @@ func NewTuiApp(dex rundex.Reader, watcher rundex.Watcher, rundexOpts rundex.Fetc
 			// starting the next run. This effectively keeps the "most recent"
 			// container available for interactive exploration
 			RetainContainer: true,
-			KeepAlive:       true,
 		})
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This mirrors the docker build structure better (no shared environment
between source, deps, and build) and exposes a similar structure more
amenable to per-phase timing.