### PR TITLE
Split scratch exec CreatedAt from worker-side StartedAt

### DIFF
--- a/internal/api/agentapiservice/scratch_exec.go
+++ b/internal/api/agentapiservice/scratch_exec.go
@@ -70,6 +70,7 @@ func ProjectScratchExec(e schema.ScratchExec) longrunning.Operation[schema.Scrat
 			ScratchID:  e.ScratchID,
 			ExitCode:   e.ExitCode,
 			OutURI:     e.OutURI,
+			CreatedAt:  e.CreatedAt,
 			StartedAt:  e.StartedAt,
 			FinishedAt: e.FinishedAt,
 		},
@@ -134,7 +135,6 @@ func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps 
 	}
 
 	opID := mintID(deps.IDGen)
-	startedAt := time.Now().UTC()
 	exec := schema.ScratchExec{
 		ID:             opID,
 		ScratchID:      req.ScratchID,
@@ -143,7 +143,7 @@ func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps 
 		TimeoutSeconds: timeoutSeconds,
 		State:          schema.ScratchExecPending,
 		OutURI:         outURIFor(deps.OutputBucket, scratch.ObliviousID, opID),
-		StartedAt:      startedAt,
+		CreatedAt:      time.Now().UTC(),
 	}
 	if err := deps.Execs.Insert(ctx, exec); err != nil {
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "execs insert"))
@@ -385,11 +385,11 @@ func (s *gcsSyncer) intervalAt(age time.Duration) time.Duration {
 // Terminal syncs always run. First syncs (lastModified zero) always
 // run because sinceLastCompose is effectively unbounded. Otherwise,
 // the schedule's interval-for-age gates the call.
-func (s *gcsSyncer) shouldCompose(now, startedAt, lastModified time.Time, done bool) bool {
+func (s *gcsSyncer) shouldCompose(now, createdAt, lastModified time.Time, done bool) bool {
 	if done {
 		return true
 	}
-	age := now.Sub(startedAt)
+	age := now.Sub(createdAt)
 	return now.Sub(lastModified) >= s.intervalAt(age)
 }
 
@@ -426,7 +426,7 @@ func (s *gcsSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch s
 	// skipped so the final tail always lands in GCS. A first sync
 	// (lastModified zero) is also never skipped because sinceLastCompose
 	// is enormous.
-	if status.TotalBytes > currentSize && s.shouldCompose(time.Now().UTC(), exec.StartedAt, lastModified, status.Done) {
+	if status.TotalBytes > currentSize && s.shouldCompose(time.Now().UTC(), exec.CreatedAt, lastModified, status.Done) {
 		if err := s.pullOutput(ctx, client, baseURL, scratch.ObliviousID, exec.ID, currentSize, currentGen); err != nil {
 			return exec, errors.Wrap(err, "pull output")
 		}
@@ -436,17 +436,33 @@ func (s *gcsSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch s
 		return exec, nil
 	}
 
+	final := finalFromStatus(exec, status, time.Now().UTC())
+	if err := s.execs.Update(ctx, final); err != nil {
+		return exec, errors.Wrap(err, "execs update final")
+	}
+	return final, nil
+}
+
+// finalFromStatus projects a terminal worker status onto the stored exec
+// record. Worker clocks are authoritative for the execution span: the worker
+// stamps both ends with the same VM clock, so their difference is free of
+// dispatch latency and cross-clock skew. StartedAt stays zero when the worker
+// never observed a start, and FinishedAt falls back to the broker clock (now)
+// so terminal records always carry an end time.
+func finalFromStatus(exec schema.ScratchExec, status *scratchworkerservice.ExecStatus, now time.Time) schema.ScratchExec {
 	final := exec
 	final.ExitCode = status.ExitCode
+	final.StartedAt = status.StartedAt
 	if !status.FinishedAt.IsZero() {
 		final.FinishedAt = status.FinishedAt
 	} else {
-		final.FinishedAt = time.Now().UTC()
+		final.FinishedAt = now
 	}
 	switch {
 	case status.TimedOut:
 		// Worker-enforced timeout: command was killed at its deadline.
-		// We observed the kill exit (typically 124); partial output remains in OutURI.
+		// We observed the kill exit (typically 124) and partial output
+		// remains in OutURI.
 		final.State = schema.ScratchExecTimedOut
 		final.Error = &schema.Status{
 			Code:    int(codes.DeadlineExceeded),
@@ -454,7 +470,7 @@ func (s *gcsSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch s
 		}
 	case status.ErrMsg != "":
 		// Worker reported an infra failure (spawn failed, stdin decode, ...).
-		// We do not have a known exit; treat as Lost.
+		// We do not have a known exit, so treat as Lost.
 		final.State = schema.ScratchExecLost
 		final.Error = &schema.Status{
 			Code:    int(codes.Internal),
@@ -463,10 +479,7 @@ func (s *gcsSyncer) Sync(ctx context.Context, exec schema.ScratchExec, scratch s
 	default:
 		final.State = schema.ScratchExecCompleted
 	}
-	if err := s.execs.Update(ctx, final); err != nil {
-		return exec, errors.Wrap(err, "execs update final")
-	}
-	return final, nil
+	return final
 }
 
 // finalize transitions exec to Lost with the given status and persists it;

--- a/internal/api/agentapiservice/scratch_exec_sync_test.go
+++ b/internal/api/agentapiservice/scratch_exec_sync_test.go
@@ -7,6 +7,11 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/api/scratchworkerservice"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/grpc/codes"
 )
 
 // schedule mirroring DefaultSyncSchedule's shape, but with named
@@ -157,6 +162,108 @@ func TestSyncer_ShouldCompose(t *testing.T) {
 			if got := s.shouldCompose(tc.now, started, tc.lastModified, tc.done); got != tc.want {
 				t.Errorf("shouldCompose(now+%v, lastMod=%v, done=%v) = %v, want %v",
 					tc.now.Sub(started), tc.lastModified.Sub(started), tc.done, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSyncer_FinalFromStatus(t *testing.T) {
+	created := time.Unix(1_700_000_000, 0).UTC()
+	workerStart := created.Add(2 * time.Second)
+	workerFinish := workerStart.Add(30 * time.Second)
+	brokerNow := created.Add(45 * time.Second)
+	base := schema.ScratchExec{
+		ID:        "op1",
+		ScratchID: "s1",
+		State:     schema.ScratchExecPending,
+		CreatedAt: created,
+	}
+	tests := []struct {
+		name   string
+		status scratchworkerservice.ExecStatus
+		want   schema.ScratchExec
+	}{
+		{
+			name: "WorkerClocksAdopted",
+			status: scratchworkerservice.ExecStatus{
+				Done:       true,
+				ExitCode:   3,
+				StartedAt:  workerStart,
+				FinishedAt: workerFinish,
+			},
+			want: schema.ScratchExec{
+				ID:         "op1",
+				ScratchID:  "s1",
+				State:      schema.ScratchExecCompleted,
+				ExitCode:   3,
+				CreatedAt:  created,
+				StartedAt:  workerStart,
+				FinishedAt: workerFinish,
+			},
+		},
+		{
+			// A worker that never observed a start leaves StartedAt zero.
+			// Only FinishedAt falls back to the broker clock.
+			name:   "MissingWorkerClocksFallBack",
+			status: scratchworkerservice.ExecStatus{Done: true},
+			want: schema.ScratchExec{
+				ID:         "op1",
+				ScratchID:  "s1",
+				State:      schema.ScratchExecCompleted,
+				CreatedAt:  created,
+				FinishedAt: brokerNow,
+			},
+		},
+		{
+			name: "TimedOut",
+			status: scratchworkerservice.ExecStatus{
+				Done:       true,
+				ExitCode:   124,
+				TimedOut:   true,
+				StartedAt:  workerStart,
+				FinishedAt: workerFinish,
+			},
+			want: schema.ScratchExec{
+				ID:         "op1",
+				ScratchID:  "s1",
+				State:      schema.ScratchExecTimedOut,
+				ExitCode:   124,
+				CreatedAt:  created,
+				StartedAt:  workerStart,
+				FinishedAt: workerFinish,
+				Error: &schema.Status{
+					Code:    int(codes.DeadlineExceeded),
+					Message: "command exceeded TimeoutSeconds",
+				},
+			},
+		},
+		{
+			name: "InfraErrorIsLost",
+			status: scratchworkerservice.ExecStatus{
+				Done:       true,
+				ErrMsg:     "spawn failed",
+				StartedAt:  workerStart,
+				FinishedAt: workerFinish,
+			},
+			want: schema.ScratchExec{
+				ID:         "op1",
+				ScratchID:  "s1",
+				State:      schema.ScratchExecLost,
+				CreatedAt:  created,
+				StartedAt:  workerStart,
+				FinishedAt: workerFinish,
+				Error: &schema.Status{
+					Code:    int(codes.Internal),
+					Message: "spawn failed",
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := finalFromStatus(base, &tc.status, brokerNow)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("finalFromStatus mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/api/agentapiservice/scratch_reap.go
+++ b/internal/api/agentapiservice/scratch_reap.go
@@ -55,10 +55,12 @@ func (d *ScratchReapDeps) idleThreshold() time.Duration {
 }
 
 // deadlineFor returns the op's hard deadline: its worker-enforced timeout
-// plus grace. Only meaningful for bounded ops (TimeoutSeconds set); ops
-// without a bound never expire and exempt their scratch from teardown.
+// plus grace, anchored at broker-side creation since the worker's observed
+// start only lands on the record at terminal sync. Only meaningful for
+// bounded ops (TimeoutSeconds set). Ops without a bound never expire and
+// exempt their scratch from teardown.
 func deadlineFor(exec schema.ScratchExec) time.Time {
-	return exec.StartedAt.Add(time.Duration(exec.TimeoutSeconds)*time.Second + opDeadlineGrace)
+	return exec.CreatedAt.Add(time.Duration(exec.TimeoutSeconds)*time.Second + opDeadlineGrace)
 }
 
 // ScratchReap deletes idle scratches and finalizes obsolete ops.
@@ -80,7 +82,7 @@ func ScratchReap(ctx context.Context, _ ScratchReapRequest, deps *ScratchReapDep
 	}
 	busy := make(map[string]bool)
 	for _, exec := range pending {
-		if exec.StartedAt.IsZero() {
+		if exec.CreatedAt.IsZero() {
 			continue
 		}
 		if exec.TimeoutSeconds <= 0 {
@@ -171,7 +173,7 @@ func syncPendingFor(ctx context.Context, deps *ScratchReapDeps, scratch schema.S
 // The deadline check stays ahead of the scratch-state checks so ops on a
 // scratch torn down earlier in the pass finalize TimedOut, not Lost.
 func terminalStateFor(ctx context.Context, deps *ScratchReapDeps, exec schema.ScratchExec, now time.Time) (schema.ScratchExecState, *schema.Status) {
-	if exec.TimeoutSeconds > 0 && !exec.StartedAt.IsZero() && now.After(deadlineFor(exec)) {
+	if exec.TimeoutSeconds > 0 && !exec.CreatedAt.IsZero() && now.After(deadlineFor(exec)) {
 		// The worker killed the command at its timeout, so a reachable
 		// worker has the real exit status and output. Pull those through
 		// before falling back to a blind TimedOut.

--- a/internal/api/agentapiservice/scratch_reap_test.go
+++ b/internal/api/agentapiservice/scratch_reap_test.go
@@ -89,7 +89,7 @@ func TestScratchReap_OpOnDeadScratchFinalizesLost(t *testing.T) {
 	}
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
-		StartedAt: now.Add(-5 * time.Minute),
+		CreatedAt: now.Add(-5 * time.Minute),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestScratchReap_UnboundedOpExemptsScratch(t *testing.T) {
 	}
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-old", ScratchID: "s-h", State: schema.ScratchExecPending,
-		StartedAt: now.Add(-3 * time.Hour),
+		CreatedAt: now.Add(-3 * time.Hour),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestScratchReap_PendingOpOnHealthyScratchStaysPending(t *testing.T) {
 	}
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-fresh", ScratchID: "s-h", State: schema.ScratchExecPending,
-		StartedAt: now.Add(-5 * time.Minute),
+		CreatedAt: now.Add(-5 * time.Minute),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestScratchReap_OrphanedOpScratchMissingEntirely(t *testing.T) {
 	now := time.Now().UTC()
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-orphan", ScratchID: "vanished", State: schema.ScratchExecPending,
-		StartedAt: now.Add(-5 * time.Minute),
+		CreatedAt: now.Add(-5 * time.Minute),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestScratchReap_PreTeardownSyncerInvokedPerPendingOp(t *testing.T) {
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
 		TimeoutSeconds: 3600,
-		StartedAt:      now.Add(-3 * time.Hour),
+		CreatedAt:      now.Add(-3 * time.Hour),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestScratchReap_IdleButBusyScratchSkipped(t *testing.T) {
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-long", ScratchID: "busy-s", State: schema.ScratchExecPending,
 		TimeoutSeconds: 4 * 60 * 60,
-		StartedAt:      now.Add(-time.Hour),
+		CreatedAt:      now.Add(-time.Hour),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestScratchReap_StampedTimeoutExpiryFinalizesTimedOut(t *testing.T) {
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-short", ScratchID: "s-h", State: schema.ScratchExecPending,
 		TimeoutSeconds: 60,
-		StartedAt:      now.Add(-20 * time.Minute),
+		CreatedAt:      now.Add(-20 * time.Minute),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -367,7 +367,7 @@ func TestScratchReap_PullThroughSyncFinalizes(t *testing.T) {
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-exp", ScratchID: "s-live", State: schema.ScratchExecPending,
 		TimeoutSeconds: 60,
-		StartedAt:      now.Add(-20 * time.Minute),
+		CreatedAt:      now.Add(-20 * time.Minute),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestScratchReap_PullThroughSyncErrorFallsBackTimedOut(t *testing.T) {
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-exp", ScratchID: "s-live", State: schema.ScratchExecPending,
 		TimeoutSeconds: 60,
-		StartedAt:      now.Add(-20 * time.Minute),
+		CreatedAt:      now.Add(-20 * time.Minute),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestScratchReap_SweepDoesNotClobberPreTeardownSync(t *testing.T) {
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
 		TimeoutSeconds: 3600,
-		StartedAt:      now.Add(-3 * time.Hour),
+		CreatedAt:      now.Add(-3 * time.Hour),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}
@@ -494,7 +494,7 @@ func TestScratchReap_TeardownRecheckSparesRevivedScratch(t *testing.T) {
 	if err := execs.Insert(ctx, schema.ScratchExec{
 		ID: "op-1", ScratchID: "s-1", State: schema.ScratchExecPending,
 		TimeoutSeconds: 3600,
-		StartedAt:      now.Add(-3 * time.Hour),
+		CreatedAt:      now.Add(-3 * time.Hour),
 	}); err != nil {
 		t.Fatalf("seed exec: %v", err)
 	}

--- a/pkg/rebuild/schema/scratch.go
+++ b/pkg/rebuild/schema/scratch.go
@@ -138,6 +138,14 @@ type Status struct {
 //   - Completed: ExitCode is the observed command exit; Error nil; OutURI complete.
 //   - TimedOut:  ExitCode is the kill exit (typically 124); Error carries detail; OutURI may be partial.
 //   - Lost:      Error non-nil; ExitCode 0 (no exit observed); OutURI may be partial.
+//
+// Clock semantics: CreatedAt is the broker's clock at op creation. StartedAt
+// and FinishedAt are the worker's observed command start and finish, copied
+// at terminal sync, so both ends of the execution span come from the same VM
+// clock and their difference is an accurate execution duration. StartedAt is
+// zero when the worker never reported a start (blind finalization), and
+// FinishedAt then falls back to a broker stamp so terminal records always
+// carry an end time.
 type ScratchExec struct {
 	ID        string   `json:"id" firestore:"id"`
 	ScratchID string   `json:"scratch_id,omitempty" firestore:"scratch_id,omitempty"`
@@ -149,6 +157,7 @@ type ScratchExec struct {
 	// Zero means unbounded: the reaper warns and leaves the scratch up.
 	TimeoutSeconds int              `json:"timeout_seconds,omitempty" firestore:"timeout_seconds,omitempty"`
 	OutURI         string           `json:"out_uri,omitempty" firestore:"out_uri,omitempty"`
+	CreatedAt      time.Time        `json:"created_at,omitzero" firestore:"created_at,omitempty"`
 	StartedAt      time.Time        `json:"started_at,omitzero" firestore:"started_at,omitempty"`
 	FinishedAt     time.Time        `json:"finished_at,omitzero" firestore:"finished_at,omitempty"`
 	State          ScratchExecState `json:"state" firestore:"state"`
@@ -161,6 +170,7 @@ type ScratchExecResult struct {
 	ScratchID  string    `json:"scratch_id"`
 	ExitCode   int       `json:"exit_code"`
 	OutURI     string    `json:"out_uri,omitempty"`
+	CreatedAt  time.Time `json:"created_at,omitzero"`
 	StartedAt  time.Time `json:"started_at,omitzero"`
 	FinishedAt time.Time `json:"finished_at,omitzero"`
 }


### PR DESCRIPTION
Previously, the two times recorded in the record for the scratch exec
were both broker-computed timestamps. While accurate, they're less
useful than the polling-independent worker-computed timestamps available
via that API.

This change repurposes the StartedAt and FinishedAt values to reflect
the worker-side observed time allowing for much more precise measurement
of the execution.