### PR TITLE
Populate phase timings in docker build variants

### DIFF
--- a/internal/api/apiservice/rebuild_lro_test.go
+++ b/internal/api/apiservice/rebuild_lro_test.go
@@ -277,6 +277,9 @@ func TestCreateRebuildOpFast(t *testing.T) {
 				ReadBuildLogsFunc: func(ctx context.Context, buildID string) (io.ReadCloser, error) {
 					return io.NopCloser(bytes.NewBuffer(nil)), nil
 				},
+				ReadStepLogsFunc: func(ctx context.Context, buildID string, stepIndex int) (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewBuffer(nil)), nil
+				},
 			}
 		},
 		Client: gcbclient,

--- a/internal/api/apiservice/rebuild_test.go
+++ b/internal/api/apiservice/rebuild_test.go
@@ -647,6 +647,9 @@ RLpmHHG1JOVdOA==
 						ReadBuildLogsFunc: func(ctx context.Context, buildID string) (io.ReadCloser, error) {
 							return io.NopCloser(bytes.NewBufferString("BUILD LOG\n")), nil
 						},
+						ReadStepLogsFunc: func(ctx context.Context, buildID string, stepIndex int) (io.ReadCloser, error) {
+							return io.NopCloser(bytes.NewBuffer(nil)), nil
+						},
 					}
 				},
 				Client: gcbclient,

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -38,9 +38,8 @@ type Handle interface {
 // Result represents the completed build result
 type Result struct {
 	// Error represents a build-time failure (i.e. after build setup)
-	Error error
-	// Timings describes execution duration of various aspects of the build
-	Timings rebuild.Timings
+	Error   error
+	Timings *rebuild.BuildTimings // nil unless every build phase was measured
 }
 
 // ExecutorStatus represents the overall executor status

--- a/pkg/build/gcb/executor.go
+++ b/pkg/build/gcb/executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/oss-rebuild/internal/bufiox"
 	"github.com/google/oss-rebuild/internal/syncx"
 	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/build/timing"
 	"github.com/google/oss-rebuild/pkg/gcb"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
@@ -115,6 +116,7 @@ func (e *Executor) Start(ctx context.Context, input rebuild.Input, opts build.Op
 		UseNetworkProxy:   opts.UseNetworkProxy,
 		UseSyscallMonitor: opts.UseSyscallMonitor,
 		Resources:         opts.Resources,
+		RecordTimings:     opts.RecordTimings,
 	}
 	plan, err := e.planner.GeneratePlan(ctx, input, planOpts)
 	if err != nil {
@@ -262,6 +264,16 @@ func (e *Executor) executeBuild(ctx context.Context, handle *gcbHandle, cloudBui
 			}
 		}
 	}
+	// Extract phase timings from post-build observation.
+	// NOTE: Extraction failures are logged, never surfaced as build errors.
+	var timings *rebuild.BuildTimings
+	if buildErr == nil && buildInfo.BuildID != "" && plan.timingStep() >= 0 {
+		var err error
+		timings, err = e.extractTimings(ctx, buildInfo.BuildID, plan, buildResult)
+		if err != nil {
+			log.Printf("Build %s timing extraction failed: %v", buildInfo.BuildID, err)
+		}
+	}
 	// Upload assets to asset store if configured
 	if opts.Resources.AssetStore != nil {
 		if err := e.uploadContent(ctx, opts.Resources.AssetStore, rebuild.DockerfileAsset.For(t), []byte(plan.Dockerfile)); err != nil {
@@ -280,8 +292,52 @@ func (e *Executor) executeBuild(ctx context.Context, handle *gcbHandle, cloudBui
 	// NOTE: Delete before setResult so handle.Wait returns *after* executor considers it retired.
 	e.activeBuilds.Delete(handle.id)
 	handle.setResult(build.Result{
-		Error: buildErr,
+		Error:   buildErr,
+		Timings: timings,
 	})
+}
+
+// extractTimings assembles phase timings from the timing step's inspect and
+// history output. A sentinel-failed run yields a marked record: the image
+// phases completed (the image exists), and the container span runs until the
+// script's termination. An unusable container span leaves Build unmeasured
+// without discarding the image phases.
+// NOTE: The step's section is filtered out of the shared build log by line
+// prefix, so a line torn by a monitored-mode writer at worst drops that line.
+func (e *Executor) extractTimings(ctx context.Context, buildID string, plan *Plan, buildResult *cloudbuild.Build) (*rebuild.BuildTimings, error) {
+	r, err := e.logsClient.ReadStepLogs(ctx, buildID, plan.timingStep())
+	if err != nil {
+		return nil, errors.Wrap(err, "opening timing step logs")
+	}
+	defer r.Close()
+	section, err := io.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading timing step logs")
+	}
+	buildDur, err := timing.ContainerSpan(section)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading container span")
+	}
+	layers, err := timing.ParseHistory(section, plan.Layers)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing image history")
+	}
+	buildStart, err := stepStart(buildResult, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading main step start")
+	}
+	setup, source, deps, err := layers.Phases(buildStart)
+	if err != nil {
+		return nil, errors.Wrap(err, "deriving phase durations")
+	}
+	return timing.Validated(rebuild.BuildTimings{Setup: setup, Source: source, Deps: deps, Build: buildDur}), nil
+}
+
+func stepStart(b *cloudbuild.Build, i int) (time.Time, error) {
+	if b == nil || i >= len(b.Steps) || b.Steps[i] == nil || b.Steps[i].Timing == nil {
+		return time.Time{}, errors.New("step timing unavailable")
+	}
+	return time.Parse(time.RFC3339, b.Steps[i].Timing.StartTime)
 }
 
 // doBuild executes a build on Cloud Build, waits for completion and returns the resulting Build resource.

--- a/pkg/build/gcb/executor_test.go
+++ b/pkg/build/gcb/executor_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/pkg/build"
 	"github.com/google/oss-rebuild/pkg/gcb"
 	"github.com/google/oss-rebuild/pkg/gcb/gcbtest"
@@ -566,5 +567,121 @@ func TestGCBExecutorFailedBuild(t *testing.T) {
 	// Clean up
 	if err := executor.Close(ctx); err != nil {
 		t.Errorf("Close failed: %v", err)
+	}
+}
+
+func TestExecutorTimings(t *testing.T) {
+	ctx := context.Background()
+	goodStepLog := `+ docker inspect --format {{.State.StartedAt}} {{.State.FinishedAt}} container
+2026-07-01T00:01:20.500000000Z 2026-07-01T00:01:44.500000000Z
++ docker history --human=false --format {{json .}} img
+{"Comment":"buildkit.dockerfile.v0","CreatedAt":"2026-07-01T00:01:11Z","CreatedBy":"ENTRYPOINT","ID":"<missing>","Size":"0"}
+{"Comment":"buildkit.dockerfile.v0","CreatedAt":"2026-07-01T00:01:11Z","CreatedBy":"WORKDIR","ID":"<missing>","Size":"0"}
+{"Comment":"buildkit.dockerfile.v0","CreatedAt":"2026-07-01T00:01:11Z","CreatedBy":"RUN","ID":"<missing>","Size":"1024"}
+{"Comment":"buildkit.dockerfile.v0","CreatedAt":"2026-07-01T00:01:10Z","CreatedBy":"RUN","ID":"<missing>","Size":"4096"}
+{"Comment":"buildkit.dockerfile.v0","CreatedAt":"2026-07-01T00:00:30Z","CreatedBy":"RUN","ID":"<missing>","Size":"512"}
+{"Comment":"buildkit.dockerfile.v0","CreatedAt":"2026-07-01T00:00:10Z","CreatedBy":"RUN","ID":"<missing>","Size":"2048"}
+{"Comment":"base","CreatedAt":"2025-01-01T00:00:00Z","CreatedBy":"FROM","ID":"abc123","Size":"7340032"}
+`
+	buildResult := &cloudbuild.Build{
+		Id:         "test-build-gcb-123",
+		Status:     "SUCCESS",
+		StartTime:  "2026-07-01T00:00:00Z",
+		FinishTime: "2026-07-01T00:02:00Z",
+		Steps: []*cloudbuild.BuildStep{
+			{
+				Name:   "gcr.io/cloud-builders/docker",
+				Timing: &cloudbuild.TimeSpan{StartTime: "2026-07-01T00:00:00Z", EndTime: "2026-07-01T00:01:50Z"},
+			},
+		},
+	}
+	metadataBytes, _ := json.Marshal(&cloudbuild.BuildOperationMetadata{Build: buildResult})
+	operation := &cloudbuild.Operation{
+		Name:     "projects/test-project/operations/test-build-timings",
+		Metadata: googleapi.RawMessage(metadataBytes),
+	}
+	doneOperation := &cloudbuild.Operation{
+		Name:     operation.Name,
+		Done:     true,
+		Metadata: googleapi.RawMessage(metadataBytes),
+	}
+	mockClient := &gcbtest.MockClient{
+		CreateBuildFunc: func(ctx context.Context, project string, build *cloudbuild.Build) (*cloudbuild.Operation, error) {
+			return operation, nil
+		},
+		WaitForOperationFunc: func(ctx context.Context, op *cloudbuild.Operation) (*cloudbuild.Operation, error) {
+			return doneOperation, nil
+		},
+	}
+	for _, tc := range []struct {
+		name    string
+		stepLog string
+		want    *rebuild.BuildTimings
+	}{
+		{
+			name:    "Extracted",
+			stepLog: goodStepLog,
+			want: &rebuild.BuildTimings{
+				Setup:  10 * time.Second, // setup layer completion - step start
+				Source: 20 * time.Second, // source layer completion delta
+				Deps:   40 * time.Second, // deps layer completion delta
+				Build:  24 * time.Second, // container FinishedAt - StartedAt
+			},
+		},
+		{
+			// Extraction failures never surface as build errors.
+			name:    "UnusableLogTolerated",
+			stepLog: "no inspect or history output\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			executor, err := NewExecutor(ExecutorConfig{
+				Client:         mockClient,
+				Project:        "test-project",
+				ServiceAccount: "test@test.iam.gserviceaccount.com",
+				LogsBucket:     "test-bucket",
+				LogsClientFunc: func(bucket string) gcb.LogsClient {
+					return &gcbtest.MockLogsClient{
+						ReadStepLogsFunc: func(ctx context.Context, buildID string, stepIndex int) (io.ReadCloser, error) {
+							if stepIndex < 1 {
+								t.Errorf("ReadStepLogs stepIndex = %d, want the appended timing step", stepIndex)
+							}
+							return io.NopCloser(strings.NewReader(tc.stepLog)), nil
+						},
+					}
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewExecutor failed: %v", err)
+			}
+			input := rebuild.Input{
+				Target: rebuild.Target{Ecosystem: rebuild.NPM, Package: "test-package", Version: "1.0.0", Artifact: "test-package-1.0.0.tgz"},
+				Strategy: &rebuild.ManualStrategy{
+					Location:   rebuild.Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
+					Requires:   rebuild.RequiredEnv{SystemDeps: []string{"git", "node", "npm"}},
+					Deps:       "npm install",
+					Build:      "npm run build",
+					OutputPath: "dist/test-package-1.0.0.tgz",
+				},
+			}
+			handle, err := executor.Start(ctx, input, build.Options{
+				BuildID:       "test-build-timings",
+				RecordTimings: true,
+				Resources:     build.Resources{BaseImageConfig: build.BaseImageConfig{Default: "docker.io/library/alpine:3.19"}},
+			})
+			if err != nil {
+				t.Fatalf("Start failed: %v", err)
+			}
+			result, err := handle.Wait(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Error != nil {
+				t.Fatal(result.Error)
+			}
+			if diff := cmp.Diff(tc.want, result.Timings); diff != "" {
+				t.Errorf("Timings diff (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/build/gcb/plan.go
+++ b/pkg/build/gcb/plan.go
@@ -4,8 +4,15 @@
 package gcb
 
 import (
+	"slices"
+
+	"github.com/google/oss-rebuild/pkg/build/timing"
 	"google.golang.org/api/cloudbuild/v1"
 )
+
+// timingStepID identifies the appended timing observation step, found by Id
+// since step numbering shifts with the conditional save and export steps.
+const timingStepID = "timing"
 
 // Plan represents a Google Cloud Build execution plan
 type Plan struct {
@@ -13,4 +20,11 @@ type Plan struct {
 	Steps []*cloudbuild.BuildStep
 	// Dockerfile contains the generated Dockerfile content
 	Dockerfile string
+	// Layers declare the plan's layer positions for timing extraction
+	Layers timing.Layers
+}
+
+// timingStep returns the index of the appended timing step, negative when absent.
+func (p *Plan) timingStep() int {
+	return slices.IndexFunc(p.Steps, func(s *cloudbuild.BuildStep) bool { return s.Id == timingStepID })
 }

--- a/pkg/build/gcb/planner.go
+++ b/pkg/build/gcb/planner.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/oss-rebuild/internal/textwrap"
 	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/build/timing"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/pkg/errors"
 	"google.golang.org/api/cloudbuild/v1"
@@ -240,6 +241,7 @@ type gcbContainerArgs struct {
 }
 
 // gcbDockerfileTpl generates Dockerfiles for use in GCB
+// NOTE: Layer mappings must be kept in sync with dockerfileLayers.
 var gcbDockerfileTpl = template.Must(
 	template.New("gcb dockerfile").Funcs(template.FuncMap{
 		"indent": func(s string) string { return strings.ReplaceAll(s, "\n", "\n ") },
@@ -294,6 +296,16 @@ var gcbDockerfileTpl = template.Must(
 			ENTRYPOINT ["/bin/sh","/build"]
 			`)[1:], // remove leading newline
 	))
+
+// dockerfileLayers declares gcbDockerfileTpl's instruction shape.
+// NOTE: Template conditionals vary only script contents, never the sequence.
+func dockerfileLayers(hasDeps bool) timing.Layers {
+	l := timing.Layers{Appended: 5, Setup: 0, Source: 1, Deps: -1}
+	if hasDeps {
+		l.Appended, l.Deps = 6, 2
+	}
+	return l
+}
 
 // gcbStandardBuildTpl generates standard build scripts for Cloud Build steps
 var gcbStandardBuildTpl = template.Must(
@@ -538,10 +550,15 @@ func (p *Planner) GeneratePlan(ctx context.Context, input rebuild.Input, opts bu
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate Cloud Build steps")
 	}
-	return &Plan{
+	plan := &Plan{
 		Steps:      steps,
 		Dockerfile: dockerfile,
-	}, nil
+	}
+	// Layers only serve the timing step's extraction.
+	if opts.RecordTimings {
+		plan.Layers = dockerfileLayers(instructions.Deps != "")
+	}
+	return plan, nil
 }
 
 // generateDockerfile creates a Dockerfile from rebuild instructions and options using templates
@@ -613,6 +630,24 @@ func (p *Planner) generateSteps(target rebuild.Target, dockerfile string, reqs r
 		Args: []string{"cp", "container:" + path.Join("/out", target.Artifact), path.Join("/workspace", target.Artifact)},
 	}
 	steps = append(steps, extractStep)
+	// Timing observation step: reads clocks the build's log stream cannot
+	// affect.
+	// NOTE: No -e and || true throughout so a flaking inspect cannot fail a
+	// successful rebuild. GCB guarantees the converse: a failed main step
+	// prevents later steps, so this step cannot mask a failure.
+	// NOTE: The proxied daemon forwards to the step-shared docker socket, so
+	// the inspected container and image are visible here in proxy mode too.
+	if opts.RecordTimings {
+		steps = append(steps, &cloudbuild.BuildStep{
+			Id:   timingStepID,
+			Name: "gcr.io/cloud-builders/docker",
+			Script: strings.Join([]string{
+				"set -ux",
+				`docker inspect container -f '{{.State.StartedAt}} {{.State.FinishedAt}}' || true`,
+				`docker history --human=false --format '{{json .}}' img || true`,
+			}, "\n"),
+		})
+	}
 	// Save container image if requested
 	if opts.SaveContainerImage {
 		saveStep := &cloudbuild.BuildStep{

--- a/pkg/build/gcb/planner_test.go
+++ b/pkg/build/gcb/planner_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/internal/textwrap"
 	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/build/timing"
 	"github.com/google/oss-rebuild/pkg/rebuild/flow"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"google.golang.org/api/cloudbuild/v1"
@@ -1011,4 +1012,123 @@ chmod +x gsutil_writeonly
 	if diff := cmp.Diff(wantSteps, plan.Steps[1:]); diff != "" {
 		t.Errorf("Steps[1:] mismatch (-want +got):\n%s", diff)
 	}
+}
+
+// countAppended counts the rendered Dockerfile's post-FROM instructions.
+// Heredoc bodies are indented by the templates, so instruction keywords at
+// column zero are unambiguous.
+func countAppended(dockerfile string) int {
+	count := 0
+	for _, line := range strings.Split(dockerfile, "\n") {
+		tok, _, _ := strings.Cut(line, " ")
+		switch tok {
+		case "RUN", "WORKDIR", "ENTRYPOINT", "COPY", "ENV", "CMD":
+			count++
+		}
+	}
+	return count
+}
+
+func TestGCBPlannerLayers(t *testing.T) {
+	ctx := context.Background()
+	planner := NewPlanner(PlannerConfig{ServiceAccount: "test@test.iam.gserviceaccount.com"})
+	input := rebuild.Input{
+		Target: rebuild.Target{Ecosystem: rebuild.NPM, Package: "test-package", Version: "1.0.0", Artifact: "test-package-1.0.0.tgz"},
+		Strategy: &rebuild.ManualStrategy{
+			Location:   rebuild.Location{Repo: "github.com/example", Ref: "main", Dir: "/src"},
+			Deps:       "npm install",
+			Build:      "npm run build",
+			OutputPath: "dist/test-package-1.0.0.tgz",
+		},
+	}
+	baseOpts := build.PlanOptions{
+		Resources: build.Resources{
+			BaseImageConfig: build.BaseImageConfig{Default: "docker.io/library/alpine:3.19"},
+			ToolURLs: map[build.ToolType]string{
+				build.TimewarpTool: "https://example.com/timewarp",
+				build.ProxyTool:    "https://example.com/proxy",
+			},
+		},
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*build.PlanOptions)
+	}{
+		{name: "Standard", mutate: func(o *build.PlanOptions) {}},
+		{name: "Monitored", mutate: func(o *build.PlanOptions) { o.UseSyscallMonitor = true }},
+		{name: "Proxy", mutate: func(o *build.PlanOptions) { o.UseNetworkProxy = true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := baseOpts
+			tc.mutate(&opts)
+			opts.RecordTimings = true
+			plan, err := planner.GeneratePlan(ctx, input, opts)
+			if err != nil {
+				t.Fatalf("GeneratePlan failed: %v", err)
+			}
+			l := plan.Layers
+			if want := countAppended(plan.Dockerfile); l.Appended != want {
+				t.Errorf("Appended = %d, want post-FROM instruction count %d", l.Appended, want)
+			}
+			if l.Setup != 0 || l.Source != 1 || l.Deps != 2 {
+				t.Errorf("offsets = (%d, %d, %d), want (0, 1, 2)", l.Setup, l.Source, l.Deps)
+			}
+		})
+	}
+	t.Run("EmptyDeps", func(t *testing.T) {
+		in := input
+		in.Strategy = &rebuild.WorkflowStrategy{
+			Source:     []flow.Step{{Runs: "echo source"}},
+			OutputPath: "dist/test-package-1.0.0.tgz",
+		}
+		opts := baseOpts
+		opts.RecordTimings = true
+		plan, err := planner.GeneratePlan(ctx, in, opts)
+		if err != nil {
+			t.Fatalf("GeneratePlan failed: %v", err)
+		}
+		if plan.Layers.Deps >= 0 {
+			t.Errorf("Deps = %d, want negative without a deps layer", plan.Layers.Deps)
+		}
+		if want := countAppended(plan.Dockerfile); plan.Layers.Appended != want {
+			t.Errorf("Appended = %d, want post-FROM instruction count %d", plan.Layers.Appended, want)
+		}
+	})
+	t.Run("TimingStep", func(t *testing.T) {
+		opts := baseOpts
+		opts.RecordTimings = true
+		plan, err := planner.GeneratePlan(ctx, input, opts)
+		if err != nil {
+			t.Fatalf("GeneratePlan failed: %v", err)
+		}
+		if plan.timingStep() < 0 {
+			t.Fatal("timingStep() < 0, want appended step")
+		}
+		script := plan.Steps[plan.timingStep()].Script
+		for _, cmd := range []string{"set -ux", "docker inspect container", "docker history --human=false"} {
+			if !strings.Contains(script, cmd) {
+				t.Errorf("timing step missing %q:\n%s", cmd, script)
+			}
+		}
+		if strings.Contains(script, "set -e") {
+			t.Error("timing step must not exit on error")
+		}
+	})
+	t.Run("NoTimingStepByDefault", func(t *testing.T) {
+		plan, err := planner.GeneratePlan(ctx, input, baseOpts)
+		if err != nil {
+			t.Fatalf("GeneratePlan failed: %v", err)
+		}
+		if idx := plan.timingStep(); idx >= 0 {
+			t.Errorf("timingStep() = %d, want absent", idx)
+		}
+		if plan.Layers != (timing.Layers{}) {
+			t.Errorf("Layers = %+v, want zero without RecordTimings", plan.Layers)
+		}
+		for _, step := range plan.Steps {
+			if strings.Contains(step.Script, "docker history") {
+				t.Error("timing step present without RecordTimings")
+			}
+		}
+	})
 }

--- a/pkg/build/local/build_executor.go
+++ b/pkg/build/local/build_executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/oss-rebuild/internal/bufiox"
 	"github.com/google/oss-rebuild/internal/syncx"
 	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/build/timing"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/pkg/errors"
 )
@@ -116,6 +117,7 @@ func (e *DockerBuildExecutor) Start(ctx context.Context, input rebuild.Input, op
 		Resources:              opts.Resources,
 		SaveContainerImage:     opts.SaveContainerImage,
 		SavePostBuildContainer: opts.SavePostBuildContainer,
+		RecordTimings:          opts.RecordTimings,
 	}
 	plan, err := e.planner.GeneratePlan(ctx, input, planOpts)
 	if err != nil {
@@ -214,6 +216,7 @@ func (e *DockerBuildExecutor) executeBuild(ctx context.Context, handle *localHan
 	} else {
 		buildArgs = append(buildArgs, "-")
 	}
+	buildxStart := time.Now()
 	err := e.cmdExecutor.Execute(ctx, CommandOptions{
 		Input:  strings.NewReader(plan.Dockerfile),
 		Output: multiWriter,
@@ -225,13 +228,18 @@ func (e *DockerBuildExecutor) executeBuild(ctx context.Context, handle *localHan
 		})
 		return
 	}
+	// The planner declares layers only under Options.RecordTimings, so the
+	// declaration is the observation gate.
+	recordTimings := plan.Layers.Appended > 0
 	// Run Docker container with streaming and captured output.
+	// NOTE: The container is named and retained when observed so its state
+	// clocks survive for post-build inspection.
 	runArgs := []string{"run"}
-	if !e.retainContainer && !opts.SavePostBuildContainer {
-		runArgs = append(runArgs, "--rm")
-	}
-	if opts.SavePostBuildContainer {
+	if recordTimings || opts.SavePostBuildContainer {
 		runArgs = append(runArgs, "--name", handle.id)
+	}
+	if !e.retainContainer && !opts.SavePostBuildContainer && !recordTimings {
+		runArgs = append(runArgs, "--rm")
 	}
 	runArgs = append(runArgs, "-v", fmt.Sprintf("%s:%s", hostOutputPath, path.Dir(plan.OutputPath)), imageTag)
 	if plan.Privileged {
@@ -252,6 +260,13 @@ func (e *DockerBuildExecutor) executeBuild(ctx context.Context, handle *localHan
 	err = e.cmdExecutor.Execute(ctx, CommandOptions{
 		Output: multiWriter,
 	}, e.dockerCmd, runArgs...)
+	// Extract phase timings before cleanup discards the history and state
+	// clocks.
+	// NOTE: Extraction failures are logged, never surfaced as build errors.
+	var timings *rebuild.BuildTimings
+	if recordTimings {
+		timings = e.extractTimings(ctx, handle.id, imageTag, plan, buildxStart)
+	}
 	// Export post-build container if requested.
 	if opts.SavePostBuildContainer {
 		postBuildPath := filepath.Join(hostOutputPath, string(rebuild.PostBuildContainerAsset))
@@ -263,8 +278,8 @@ func (e *DockerBuildExecutor) executeBuild(ctx context.Context, handle *localHan
 	if opts.Resources.AssetStore != nil {
 		e.uploadAssets(ctx, plan, hostOutputPath, t, opts, handle.id, outbuf.Bytes())
 	}
-	// Clean up post-build container if it was retained for export.
-	if opts.SavePostBuildContainer && !e.retainContainer {
+	// Clean up the container if it was retained for export or observation.
+	if (opts.SavePostBuildContainer || recordTimings) && !e.retainContainer {
 		if rmErr := e.cmdExecutor.Execute(ctx, CommandOptions{}, e.dockerCmd, "rm", handle.id); rmErr != nil {
 			log.Printf("Failed to remove container %s: %v", handle.id, rmErr)
 		}
@@ -280,13 +295,45 @@ func (e *DockerBuildExecutor) executeBuild(ctx context.Context, handle *localHan
 	if err != nil {
 		handle.updateStatus(build.BuildStateCompleted)
 		handle.setResult(build.Result{
-			Error: errors.Wrap(err, "docker run failed"),
+			Error:   errors.Wrap(err, "docker run failed"),
+			Timings: timings,
 		})
 		return
 	}
 	// Set final successful result.
 	handle.updateStatus(build.BuildStateCompleted)
-	handle.setResult(build.Result{Error: nil})
+	handle.setResult(build.Result{Timings: timings})
+}
+
+// extractTimings assembles phase timings from image history and the retained
+// container's state clocks.
+func (e *DockerBuildExecutor) extractTimings(ctx context.Context, container, imageTag string, plan *DockerBuildPlan, buildxStart time.Time) *rebuild.BuildTimings {
+	histBuf := &bytes.Buffer{}
+	if err := e.cmdExecutor.Execute(ctx, CommandOptions{Output: histBuf}, e.dockerCmd, "history", "--human=false", "--format", "{{json .}}", imageTag); err != nil {
+		log.Printf("Build %s timing history failed: %v", container, err)
+		return nil
+	}
+	layers, err := timing.ParseHistory(histBuf.Bytes(), plan.Layers)
+	if err != nil {
+		log.Printf("Build %s timing history unparseable: %v", container, err)
+		return nil
+	}
+	setup, source, deps, err := layers.Phases(buildxStart)
+	if err != nil {
+		log.Printf("Build %s timing extraction refused: %v", container, err)
+		return nil
+	}
+	spanBuf := &bytes.Buffer{}
+	if err := e.cmdExecutor.Execute(ctx, CommandOptions{Output: spanBuf}, e.dockerCmd, "inspect", container, "-f", "{{.State.StartedAt}} {{.State.FinishedAt}}"); err != nil {
+		log.Printf("Build %s timing inspect failed: %v", container, err)
+		return nil
+	}
+	buildDur, err := timing.ContainerSpan(spanBuf.Bytes())
+	if err != nil {
+		log.Printf("Build %s timing inspect unparseable: %v", container, err)
+		return nil
+	}
+	return timing.Validated(rebuild.BuildTimings{Setup: setup, Source: source, Deps: deps, Build: buildDur})
 }
 
 // uploadAssets uploads build artifacts to the asset store.

--- a/pkg/build/local/build_executor_test.go
+++ b/pkg/build/local/build_executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/build/timing"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/pkg/errors"
 )
@@ -702,5 +703,143 @@ func TestDockerBuildExecutorConfig(t *testing.T) {
 	status := executor.Status()
 	if status.Capacity != 3 {
 		t.Errorf("Expected capacity 3, got %d", status.Capacity)
+	}
+}
+
+func TestDockerBuildExecutorTimings(t *testing.T) {
+	buildxOutput := `#1 [internal] load build definition from Dockerfile
+#1 DONE 0.0s
+#2 [1/5] FROM docker.io/library/alpine:3.21
+#2 DONE 1.0s
+#3 [2/5] RUN sed 's/^ //' <<'EOF' | sh
+#3 DONE 8.0s
+#4 [3/5] RUN sed 's/^ //' <<'EOF' | sh
+#4 DONE 2.0s
+#5 [4/5] RUN sed 's/^ //' <<'EOF' | sh
+#5 1.0 + cd /src
+#5 1.1 + npm install
+#5 DONE 30.0s
+#6 [5/5] RUN sed 's/^ //' <<'EOF' >/build
+#6 DONE 0.1s
+`
+	span := "2026-07-01T00:01:20.500000000Z 2026-07-01T00:01:44.500000000Z\n"
+	for _, tc := range []struct {
+		name        string
+		inspectOut  string
+		runErr      error
+		wantErr     bool
+		wantTimings bool
+	}{
+		{
+			name:        "Extracted",
+			inspectOut:  span,
+			wantTimings: true,
+		},
+		{
+			// Extraction failures never surface as build errors.
+			name:       "UnusableInspectTolerated",
+			inspectOut: "no state clocks here\n",
+		},
+		{
+			// Failed builds still carry whatever phase timings were extracted.
+			name:        "FailedRunStillCarriesTimings",
+			inspectOut:  span,
+			runErr:      errors.New("exit status 2"),
+			wantErr:     true,
+			wantTimings: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// History times are generated relative to the observed buildx call
+			// so the cache guard's comparison against the real host clock passes.
+			var buildxAt time.Time
+			histLine := func(at time.Time, createdBy string) string {
+				return `{"Comment":"buildkit.dockerfile.v0","CreatedAt":"` + at.Format(time.RFC3339) + `","CreatedBy":"` + createdBy + `","ID":"<missing>","Size":"0"}` + "\n"
+			}
+			cmdExecutor := NewMockCommandExecutor()
+			cmdExecutor.SetExecuteFunc(func(ctx context.Context, opts CommandOptions, name string, args ...string) error {
+				if len(args) == 0 || opts.Output == nil {
+					return nil
+				}
+				switch args[0] {
+				case "buildx":
+					buildxAt = time.Now()
+					opts.Output.Write([]byte(buildxOutput))
+				case "inspect":
+					opts.Output.Write([]byte(tc.inspectOut))
+				case "run":
+					opts.Output.Write([]byte("+ npm pack\ncontainer output\n"))
+					return tc.runErr
+				case "history":
+					var out strings.Builder
+					for _, e := range []struct {
+						offset    time.Duration
+						createdBy string
+					}{
+						{41 * time.Second, "ENTRYPOINT"},
+						{41 * time.Second, "WORKDIR"},
+						{41 * time.Second, "RUN build"},
+						{40 * time.Second, "RUN deps"},
+						{10 * time.Second, "RUN source"},
+						{8 * time.Second, "RUN setup"},
+					} {
+						out.WriteString(histLine(buildxAt.Add(e.offset), e.createdBy))
+					}
+					out.WriteString(histLine(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), "FROM"))
+					opts.Output.Write([]byte(out.String()))
+				}
+				return nil
+			})
+			executor, err := NewDockerBuildExecutor(DockerBuildExecutorConfig{
+				Planner: &mockBuildPlanner{
+					plan: &DockerBuildPlan{
+						Dockerfile: "FROM alpine:3.21\nRUN a\nRUN b\nRUN c\nRUN d",
+						OutputPath: "/out/result.tar.gz",
+						Layers:     timing.Layers{Appended: 6, Setup: 0, Source: 1, Deps: 2},
+					},
+				},
+				CommandExecutor: cmdExecutor,
+				MaxParallel:     1,
+				TempDirBase:     "/tmp",
+			})
+			if err != nil {
+				t.Fatalf("NewDockerBuildExecutor failed: %v", err)
+			}
+			handle, err := executor.Start(context.Background(), rebuild.Input{
+				Target: rebuild.Target{Ecosystem: rebuild.NPM, Package: "test-pkg", Version: "1.0.0"},
+			}, build.Options{BuildID: "test-build-timings"})
+			if err != nil {
+				t.Fatalf("Start failed: %v", err)
+			}
+			result, err := handle.Wait(context.Background())
+			if err != nil {
+				t.Fatalf("Wait failed: %v", err)
+			}
+			if (result.Error != nil) != tc.wantErr {
+				t.Fatalf("Error = %v, want error %v", result.Error, tc.wantErr)
+			}
+			if (result.Timings != nil) != tc.wantTimings {
+				t.Fatalf("Timings = %+v, want present %v", result.Timings, tc.wantTimings)
+			}
+			if !tc.wantTimings {
+				return
+			}
+			// History clocks are second-granularity and the mock observes buildx
+			// moments after the executor's start clock read, so Setup lands
+			// within a second of the 8s layer time on either side.
+			if got := result.Timings.Setup; got < 7*time.Second || got > 9*time.Second {
+				t.Errorf("Setup = %v, want ~8s", got)
+			}
+			if want := 2 * time.Second; result.Timings.Source != want {
+				t.Errorf("Source = %v, want %v", result.Timings.Source, want)
+			}
+			if want := 30 * time.Second; result.Timings.Deps != want {
+				t.Errorf("Deps = %v, want %v", result.Timings.Deps, want)
+			}
+			// Build comes from the retained container's state clocks.
+			if want := 24 * time.Second; result.Timings.Build != want {
+				t.Errorf("Build = %v, want %v", result.Timings.Build, want)
+			}
+		})
 	}
 }

--- a/pkg/build/local/build_plan.go
+++ b/pkg/build/local/build_plan.go
@@ -3,6 +3,8 @@
 
 package local
 
+import "github.com/google/oss-rebuild/pkg/build/timing"
+
 // DockerBuildPlan represents a Docker build execution plan where we build an image and run it
 type DockerBuildPlan struct {
 	// Dockerfile contains the generated Dockerfile content
@@ -16,4 +18,6 @@ type DockerBuildPlan struct {
 	OutputPath string
 	// Indicates whether to run the container in privileged mode
 	Privileged bool
+	// Layers declare the plan's phase boundaries for timing extraction
+	Layers timing.Layers
 }

--- a/pkg/build/local/build_planner.go
+++ b/pkg/build/local/build_planner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/oss-rebuild/internal/textwrap"
 	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/build/timing"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/pkg/errors"
 )
@@ -28,6 +29,7 @@ type dockerBuildContainerArgs struct {
 }
 
 // dockerBuildDockerfileTpl generates Dockerfiles for local Docker builds
+// NOTE: Layer mappings must be kept in sync with dockerfileLayers.
 var dockerBuildDockerfileTpl = template.Must(
 	template.New("docker build dockerfile").Funcs(template.FuncMap{
 		"indent": func(s string) string { return strings.ReplaceAll(s, "\n", "\n ") },
@@ -79,6 +81,16 @@ var dockerBuildDockerfileTpl = template.Must(
 			`)[1:], // remove leading newline
 	))
 
+// dockerfileLayers declares dockerBuildDockerfileTpl's instruction shape.
+// NOTE: Template conditionals vary only script contents, never the sequence.
+func dockerfileLayers(hasDeps bool) timing.Layers {
+	l := timing.Layers{Appended: 5, Setup: 0, Source: 1, Deps: -1}
+	if hasDeps {
+		l.Appended, l.Deps = 6, 2
+	}
+	return l
+}
+
 // DockerBuildPlanner generates Docker build execution plans
 type DockerBuildPlanner struct{}
 
@@ -101,11 +113,16 @@ func (p *DockerBuildPlanner) GeneratePlan(ctx context.Context, input rebuild.Inp
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate Dockerfile")
 	}
-	return &DockerBuildPlan{
+	plan := &DockerBuildPlan{
 		Dockerfile: dockerfile,
 		OutputPath: path.Join("/out", path.Base(instructions.OutputPath)),
 		Privileged: instructions.Requires.Privileged,
-	}, nil
+	}
+	// The declared layers gate the executor's post-build observation.
+	if opts.RecordTimings {
+		plan.Layers = dockerfileLayers(instructions.Deps != "")
+	}
+	return plan, nil
 }
 
 // generateDockerfile creates a Dockerfile from rebuild instructions and options using templates

--- a/pkg/build/local/build_planner_test.go
+++ b/pkg/build/local/build_planner_test.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/build/timing"
+	"github.com/google/oss-rebuild/pkg/rebuild/flow"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+func TestDockerBuildPlannerLayers(t *testing.T) {
+	planner := NewDockerBuildPlanner()
+	opts := build.PlanOptions{
+		Resources:     build.Resources{BaseImageConfig: build.BaseImageConfig{Default: "alpine:3.19"}},
+		RecordTimings: true,
+	}
+	for _, tc := range []struct {
+		name     string
+		strategy rebuild.Strategy
+		want     timing.Layers
+	}{
+		{
+			name: "WithDeps",
+			strategy: &rebuild.ManualStrategy{
+				Location:   rebuild.Location{Repo: "https://github.com/example/test-package", Ref: "v1.0.0"},
+				Deps:       "npm install",
+				Build:      "npm pack",
+				OutputPath: "test-package-1.0.0.tgz",
+			},
+			want: timing.Layers{Appended: 6, Setup: 0, Source: 1, Deps: 2},
+		},
+		{
+			name: "EmptyDeps",
+			strategy: &rebuild.WorkflowStrategy{
+				Source:     []flow.Step{{Runs: "echo source"}},
+				OutputPath: "test-package-1.0.0.tgz",
+			},
+			want: timing.Layers{Appended: 5, Setup: 0, Source: 1, Deps: -1},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := rebuild.Input{
+				Target:   rebuild.Target{Ecosystem: rebuild.NPM, Package: "test-package", Version: "1.0.0", Artifact: "test-package-1.0.0.tgz"},
+				Strategy: tc.strategy,
+			}
+			plan, err := planner.GeneratePlan(context.Background(), input, opts)
+			if err != nil {
+				t.Fatalf("GeneratePlan failed: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, plan.Layers); diff != "" {
+				t.Errorf("Layers mismatch (-want +got):\n%s", diff)
+			}
+			// Drift guard: the declared shape matches the rendered Dockerfile.
+			if runs := strings.Count(plan.Dockerfile, "\nRUN "); plan.Layers.Appended != runs+2 {
+				t.Errorf("Appended = %d, want RUN count + 2 = %d", plan.Layers.Appended, runs+2)
+			}
+			// Without the option no layers are declared and the executor
+			// skips observation.
+			noRecord := opts
+			noRecord.RecordTimings = false
+			plan, err = planner.GeneratePlan(context.Background(), input, noRecord)
+			if err != nil {
+				t.Fatalf("GeneratePlan failed: %v", err)
+			}
+			if plan.Layers != (timing.Layers{}) {
+				t.Errorf("Layers = %+v, want zero without RecordTimings", plan.Layers)
+			}
+		})
+	}
+}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -45,6 +45,8 @@ type Options struct {
 	SaveContainerImage bool
 	// SavePostBuildContainer saves the container state after executing the rebuild
 	SavePostBuildContainer bool
+	// RecordTimings appends read-only observation of build phase timings
+	RecordTimings bool
 }
 
 // PlanOptions configures plan generation behavior and resources
@@ -61,6 +63,8 @@ type PlanOptions struct {
 	SaveContainerImage bool
 	// SavePostBuildContainer saves the container state after executing the rebuild
 	SavePostBuildContainer bool
+	// RecordTimings appends read-only observation of build phase timings
+	RecordTimings bool
 }
 
 // CancelPolicy determines how build cancellation is handled

--- a/pkg/build/timing/container.go
+++ b/pkg/build/timing/container.go
@@ -1,0 +1,30 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package timing
+
+import (
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ContainerSpan reads a container's run duration from
+// `docker inspect -f '{{.State.StartedAt}} {{.State.FinishedAt}}'` output:
+// the first line holding two RFC3339Nano daemon clocks.
+func ContainerSpan(out []byte) (time.Duration, error) {
+	for line := range strings.Lines(string(out)) {
+		f := strings.Fields(line)
+		if len(f) != 2 {
+			continue
+		}
+		started, err1 := time.Parse(time.RFC3339Nano, f[0])
+		finished, err2 := time.Parse(time.RFC3339Nano, f[1])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		return finished.Sub(started), nil
+	}
+	return 0, errors.New("no container span in output")
+}

--- a/pkg/build/timing/history.go
+++ b/pkg/build/timing/history.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package timing
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// LayerTimes are the completion clocks of a build's appended history entries,
+// oldest first.
+type LayerTimes struct {
+	Times  []time.Time
+	layers Layers
+}
+
+// ParseHistory extracts this build's layer completion times from
+// `docker history --human=false --format '{{json .}}'` output, taking the
+// newest Appended rows by count.
+// NOTE: History clocks are second-granularity, so durations derived from
+// their deltas carry up to a second of error per boundary.
+// NOTE: Non-JSON lines are skipped so the same parser serves raw command
+// output and a step log interleaving set -x traces and inspect output.
+func ParseHistory(out []byte, l Layers) (LayerTimes, error) {
+	valid := l.Appended > 0 && l.Setup >= 0 && l.Source > l.Setup && l.Source < l.Appended
+	if l.Deps >= 0 {
+		valid = valid && l.Deps > l.Source && l.Deps < l.Appended
+	}
+	if !valid {
+		return LayerTimes{}, errors.Errorf("invalid layer declaration: %+v", l)
+	}
+	var times []time.Time
+	for line := range strings.Lines(string(out)) {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var row struct{ CreatedAt string }
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, row.CreatedAt)
+		if err != nil {
+			continue
+		}
+		times = append(times, t)
+	}
+	if len(times) < l.Appended {
+		return LayerTimes{}, errors.Errorf("history has %d parseable entries, plan appended %d", len(times), l.Appended)
+	}
+	// History lists newest first: reverse this build's rows to oldest-first.
+	lt := LayerTimes{
+		Times:  make([]time.Time, l.Appended),
+		layers: l,
+	}
+	for i, t := range times[:l.Appended] {
+		lt.Times[l.Appended-1-i] = t
+	}
+	return lt, nil
+}
+
+// Phases derives the phase durations from layer completion deltas, anchoring
+// Setup at the caller's backend-relative buildStart since history has no
+// start entry. Setup absorbs the image pull and preamble, and Deps absorbs
+// the timewarp startup that its layer runs before installing.
+// NOTE: A completion time predating buildStart, or out of order, means a
+// cached layer carrying its original timestamp: unmeasured and refused,
+// never zero.
+func (lt LayerTimes) Phases(buildStart time.Time) (setup, source, deps time.Duration, err error) {
+	prev := buildStart
+	for _, t := range lt.Times {
+		if t.Before(prev) {
+			return 0, 0, 0, errors.New("cached or disordered layer clocks")
+		}
+		prev = t
+	}
+	l := lt.layers
+	setup = lt.Times[l.Setup].Sub(buildStart)
+	source = lt.Times[l.Source].Sub(lt.Times[l.Source-1])
+	if l.Deps >= 0 {
+		deps = lt.Times[l.Deps].Sub(lt.Times[l.Deps-1])
+	}
+	return setup, source, deps, nil
+}

--- a/pkg/build/timing/timing.go
+++ b/pkg/build/timing/timing.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package timing extracts per-phase build timings by observing a completed
+// build: docker history layer clocks for the phases and container state
+// clocks for the Build phase, never build logs. Extraction is all-or-nothing:
+// a nil BuildTimings is the only failure representation, and extraction
+// failures never affect build outcome.
+package timing
+
+// Layers is a planner's declaration of this build's layer positions within
+// docker history output.
+type Layers struct {
+	// Appended counts history entries added above the base image: one per
+	// post-FROM instruction, including empty-layer metadata entries.
+	Appended int
+	// Setup, Source, and Deps index the phase RUN layers among the appended
+	// entries, oldest first. Deps is negative when the plan has no deps layer.
+	Setup  int
+	Source int
+	Deps   int
+}

--- a/pkg/build/timing/timing_test.go
+++ b/pkg/build/timing/timing_test.go
@@ -1,0 +1,224 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package timing
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// histLine renders one docker history JSON row.
+func histLine(created string) string {
+	return `{"Comment":"buildkit.dockerfile.v0","CreatedAt":"` + created + `","CreatedBy":"RUN ...","ID":"<missing>","Size":"0"}`
+}
+
+func TestParseHistory(t *testing.T) {
+	layers := Layers{Appended: 3, Setup: 0, Source: 1, Deps: -1}
+	for _, tc := range []struct {
+		name    string
+		out     string
+		layers  Layers
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "NewestFirstReversed",
+			out: strings.Join([]string{
+				histLine("2026-07-24T10:03:00Z"),
+				histLine("2026-07-24T10:02:00Z"),
+				histLine("2026-07-24T10:01:00Z"),
+				histLine("2026-07-24T09:00:00Z"), // base image row
+			}, "\n"),
+			layers: layers,
+			want:   []string{"2026-07-24T10:01:00Z", "2026-07-24T10:02:00Z", "2026-07-24T10:03:00Z"},
+		},
+		{
+			name: "SkipsNonJSONAndBadTimes",
+			out: strings.Join([]string{
+				"2026-07-24T10:07:00.123456789Z 2026-07-24T10:08:00.987654321Z", // inspect output
+				histLine("2026-07-24T10:03:00+02:00"),
+				`{"CreatedAt":"3 minutes ago"}`, // human format skipped
+				histLine("2026-07-24T10:02:00+02:00"),
+				"not json at all",
+				histLine("2026-07-24T10:01:00+02:00"),
+			}, "\n"),
+			layers: layers,
+			want:   []string{"2026-07-24T10:01:00+02:00", "2026-07-24T10:02:00+02:00", "2026-07-24T10:03:00+02:00"},
+		},
+		{
+			name:    "TooFewRows",
+			out:     histLine("2026-07-24T10:03:00Z"),
+			layers:  layers,
+			wantErr: true,
+		},
+		{
+			name:    "InvalidLayers",
+			out:     histLine("2026-07-24T10:03:00Z"),
+			layers:  Layers{Appended: 1, Setup: 0, Source: 0, Deps: -1},
+			wantErr: true,
+		},
+		{
+			name:    "InvalidDeps",
+			out:     histLine("2026-07-24T10:03:00Z"),
+			layers:  Layers{Appended: 3, Setup: 0, Source: 1, Deps: 1},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lt, err := ParseHistory([]byte(tc.out), tc.layers)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseHistory() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			var got []string
+			for _, at := range lt.Times {
+				got = append(got, at.Format(time.RFC3339))
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ParseHistory() times diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPhases(t *testing.T) {
+	at := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ts
+	}
+	buildStart := at("2026-07-24T10:00:00Z")
+	for _, tc := range []struct {
+		name                string
+		layers              Layers
+		times               []string
+		setup, source, deps time.Duration
+		wantErr             bool
+	}{
+		{
+			name:   "Normal",
+			layers: Layers{Setup: 0, Source: 1, Deps: 2},
+			times:  []string{"2026-07-24T10:00:30Z", "2026-07-24T10:02:00Z", "2026-07-24T10:02:10Z"},
+			setup:  30 * time.Second,
+			source: 90 * time.Second,
+			deps:   10 * time.Second,
+		},
+		{
+			name:   "NoDepsLayer",
+			layers: Layers{Setup: 0, Source: 1, Deps: -1},
+			times:  []string{"2026-07-24T10:00:30Z", "2026-07-24T10:02:00Z"},
+			setup:  30 * time.Second,
+			source: 90 * time.Second,
+		},
+		{
+			// Metadata entries complete within the last RUN's clock second.
+			name:   "EqualClocksTolerated",
+			layers: Layers{Setup: 0, Source: 1, Deps: -1},
+			times:  []string{"2026-07-24T10:00:30Z", "2026-07-24T10:02:00Z", "2026-07-24T10:02:00Z", "2026-07-24T10:02:00Z"},
+			setup:  30 * time.Second,
+			source: 90 * time.Second,
+		},
+		{
+			name:    "CachedLayerPredatesBuild",
+			layers:  Layers{Setup: 0, Source: 1, Deps: 2},
+			times:   []string{"2026-07-24T09:00:00Z", "2026-07-24T10:02:00Z", "2026-07-24T10:02:10Z"},
+			wantErr: true,
+		},
+		{
+			name:    "Disordered",
+			layers:  Layers{Setup: 0, Source: 1, Deps: 2},
+			times:   []string{"2026-07-24T10:02:00Z", "2026-07-24T10:00:30Z", "2026-07-24T10:02:10Z"},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lt := LayerTimes{layers: tc.layers}
+			for _, s := range tc.times {
+				lt.Times = append(lt.Times, at(s))
+			}
+			setup, source, deps, err := lt.Phases(buildStart)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Phases() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if setup != tc.setup || source != tc.source || deps != tc.deps {
+				t.Errorf("Phases() = (%v, %v, %v), want (%v, %v, %v)", setup, source, deps, tc.setup, tc.source, tc.deps)
+			}
+		})
+	}
+}
+
+func TestContainerSpan(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		out     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name: "SkipsTraceAndSingleClockLines",
+			out: strings.Join([]string{
+				"+ docker inspect container -f {{.State.StartedAt}} {{.State.FinishedAt}}",
+				"2026-07-01T00:01:12.000000000Z",
+				"2026-07-01T00:01:20.500000000Z 2026-07-01T00:01:44.500000000Z",
+			}, "\n"),
+			want: 24 * time.Second,
+		},
+		{
+			name:    "NoSpan",
+			out:     "no state clocks here\n",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ContainerSpan([]byte(tc.out))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ContainerSpan() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("ContainerSpan() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidated(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   rebuild.BuildTimings
+		want *rebuild.BuildTimings
+	}{
+		{
+			name: "Complete",
+			in:   rebuild.BuildTimings{Setup: 30 * time.Second, Source: 45 * time.Second, Deps: 45 * time.Second, Build: 60 * time.Second},
+			want: &rebuild.BuildTimings{Setup: 30 * time.Second, Source: 45 * time.Second, Deps: 45 * time.Second, Build: 60 * time.Second},
+		},
+		{
+			name: "DepsLegitimatelyZero",
+			in:   rebuild.BuildTimings{Setup: 30 * time.Second, Source: 90 * time.Second, Build: 60 * time.Second},
+			want: &rebuild.BuildTimings{Setup: 30 * time.Second, Source: 90 * time.Second, Build: 60 * time.Second},
+		},
+		{
+			name: "NilWithoutBuild",
+			in:   rebuild.BuildTimings{Setup: 30 * time.Second, Source: 90 * time.Second},
+		},
+		{
+			name: "NilOnNegativePhase",
+			in:   rebuild.BuildTimings{Setup: 30 * time.Second, Source: -time.Second, Build: 60 * time.Second},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, Validated(tc.in)); diff != "" {
+				t.Errorf("Validated() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/build/timing/validate.go
+++ b/pkg/build/timing/validate.go
@@ -1,0 +1,18 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package timing
+
+import "github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+
+// Validated returns the record when the consistency invariants hold:
+// non-negative phases and a measured Build. Violations return nil, so every
+// non-nil BuildTimings is invariant-checked.
+// TODO: Support partial timing results, revisiting this all-or-nothing
+// validation.
+func Validated(t rebuild.BuildTimings) *rebuild.BuildTimings {
+	if t.Build <= 0 || t.Setup < 0 || t.Source < 0 || t.Deps < 0 {
+		return nil
+	}
+	return &t
+}

--- a/pkg/rebuild/rebuild/models.go
+++ b/pkg/rebuild/rebuild/models.go
@@ -83,6 +83,14 @@ type Input struct {
 	Strategy Strategy
 }
 
+// BuildTimings are the measured durations of each build phase.
+type BuildTimings struct {
+	Setup  time.Duration
+	Source time.Duration
+	Deps   time.Duration // legitimately zero when the plan had no deps layer
+	Build  time.Duration
+}
+
 // Timings describe how long different sections of the rebuild took.
 type Timings struct {
 	CloneEstimate time.Duration


### PR DESCRIPTION
Docker history layer deltas supply the Setup, Source, and Deps phase
durations, one layer per phase under the split Dockerfile structure.
Container state clocks from a post-build inspect supply the Build phase
on both backends. No log parsing is involved. Extraction is
all-or-nothing: a record exists iff every phase was determined,
otherwise the result carries nil rather than a partial or estimated
figure.

NOTE: We omit timing support in the 'docker run' builder for now.