### PR TITLE
Consolidate gs:// URL handling into gcsx

### DIFF
--- a/cmd/gsutil_writeonly/main.go
+++ b/cmd/gsutil_writeonly/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/pkg/errors"
 )
 
@@ -20,13 +21,8 @@ func isGCSPath(pth string) bool {
 }
 
 func gcsParts(pth string) (bucket, object string) {
-	pth = strings.TrimPrefix(pth, "gs://")
-	pth = strings.TrimLeft(pth, "/")
-	delim := strings.IndexRune(pth, '/')
-	if delim == -1 {
-		return pth, ""
-	}
-	return pth[:delim], pth[delim+1:]
+	bucket, object, _ = gcsx.ParseURL(pth)
+	return bucket, object
 }
 
 func copyFile(ctx context.Context, c *storage.Client, src, dest string) error {

--- a/internal/gcsx/url.go
+++ b/internal/gcsx/url.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gcsx
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ParseURL splits a gs:// URL into its bucket and object path.
+func ParseURL(gsURL string) (bucket, object string, err error) {
+	rest, ok := strings.CutPrefix(gsURL, "gs://")
+	if !ok {
+		return "", "", errors.Errorf("not a gs:// URL: %s", gsURL)
+	}
+	bucket, object, _ = strings.Cut(rest, "/")
+	return bucket, object, nil
+}
+
+// HTTPURL returns the object's path-style download endpoint.
+func HTTPURL(bucket, object string) string {
+	u := url.URL{Scheme: "https", Host: "storage.googleapis.com", Path: "/" + bucket + "/" + object}
+	return u.String()
+}
+
+// VirtualHostedURL returns the object's XML API endpoint with the bucket as
+// the host subdomain.
+func VirtualHostedURL(bucket, object string) string {
+	u := url.URL{Scheme: "https", Host: bucket + ".storage.googleapis.com", Path: "/" + object}
+	return u.String()
+}
+
+// MediaURL returns the object's JSON API media download endpoint, pinned to
+// generation when nonzero.
+func MediaURL(bucket, object string, generation int64) string {
+	q := url.Values{"alt": []string{"media"}}
+	if generation != 0 {
+		q.Set("generation", strconv.FormatInt(generation, 10))
+	}
+	u := url.URL{
+		Scheme: "https",
+		Host:   "storage.googleapis.com",
+		// The object is a single path segment in the JSON API: its slashes
+		// must be escaped.
+		Path:     "/download/storage/v1/b/" + bucket + "/o/" + object,
+		RawPath:  "/download/storage/v1/b/" + url.PathEscape(bucket) + "/o/" + url.PathEscape(object),
+		RawQuery: q.Encode(),
+	}
+	return u.String()
+}

--- a/internal/gcsx/url_test.go
+++ b/internal/gcsx/url_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gcsx
+
+import "testing"
+
+func TestHTTPURL(t *testing.T) {
+	got := HTTPURL("bucket", "path/to/obj")
+	want := "https://storage.googleapis.com/bucket/path/to/obj"
+	if got != want {
+		t.Errorf("HTTPURL() = %q, want %q", got, want)
+	}
+}
+
+func TestVirtualHostedURL(t *testing.T) {
+	got := VirtualHostedURL("bucket", "prefix")
+	want := "https://bucket.storage.googleapis.com/prefix"
+	if got != want {
+		t.Errorf("VirtualHostedURL() = %q, want %q", got, want)
+	}
+}
+
+func TestMediaURL(t *testing.T) {
+	got := MediaURL("bucket", "path/to obj", 123)
+	want := "https://storage.googleapis.com/download/storage/v1/b/bucket/o/path%2Fto%20obj?alt=media&generation=123"
+	if got != want {
+		t.Errorf("MediaURL() = %q, want %q", got, want)
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	for _, tc := range []struct {
+		url            string
+		bucket, object string
+		wantErr        bool
+	}{
+		{url: "gs://bucket/path/to/obj", bucket: "bucket", object: "path/to/obj"},
+		{url: "gs://bucket", bucket: "bucket"},
+		{url: "gs://bucket/", bucket: "bucket"},
+		{url: "https://bucket/obj", wantErr: true},
+		{url: "bucket/obj", wantErr: true},
+	} {
+		bucket, object, err := ParseURL(tc.url)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
+		}
+		if bucket != tc.bucket || object != tc.object {
+			t.Errorf("ParseURL(%q) = (%q, %q), want (%q, %q)", tc.url, bucket, object, tc.bucket, tc.object)
+		}
+	}
+}

--- a/internal/gitcache/backend.go
+++ b/internal/gitcache/backend.go
@@ -5,10 +5,8 @@ package gitcache
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -16,6 +14,7 @@ import (
 	"log"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/pkg/errors"
 )
 
@@ -64,18 +63,7 @@ func (g *gcsBackend) serve(rw http.ResponseWriter, req *http.Request, path strin
 		http.Error(rw, "Internal Error", 500)
 		return
 	}
-	redirect := url.URL{
-		Scheme: "https",
-		Host:   "storage.googleapis.com",
-		// The object is a single path segment in the JSON API: RawPath
-		// carries its escaped form and Path the decoded form, matching the
-		// GCS client's httpStorageClient.newRangeReaderXML. Escaping rules:
-		// https://cloud.google.com/storage/docs/request-endpoints#encoding
-		Path:     "/download/storage/v1/b/" + g.bucket + "/o/" + path,
-		RawPath:  "/download/storage/v1/b/" + url.PathEscape(g.bucket) + "/o/" + url.PathEscape(path),
-		RawQuery: fmt.Sprintf("alt=media&generation=%d", a.Generation),
-	}
-	http.Redirect(rw, req, redirect.String(), http.StatusFound)
+	http.Redirect(rw, req, gcsx.MediaURL(g.bucket, path, a.Generation), http.StatusFound)
 }
 
 func (g *gcsBackend) delete(ctx context.Context, path string) error {

--- a/internal/gitcache/gitcache.go
+++ b/internal/gitcache/gitcache.go
@@ -50,6 +50,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/pkg/errors"
 )
@@ -86,8 +87,7 @@ func NewServer(ctx context.Context, cacheStr string) (*Server, error) {
 // newBackend creates a cacheBackend from the given cache location string.
 func newBackend(ctx context.Context, cacheStr string) (cacheBackend, error) {
 	if strings.HasPrefix(cacheStr, "gs://") {
-		bucketName := strings.TrimPrefix(cacheStr, "gs://")
-		bucketName = strings.TrimSuffix(bucketName, "/")
+		bucketName, _, _ := gcsx.ParseURL(cacheStr)
 		client, err := storage.NewClient(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating GCS client")

--- a/pkg/build/url.go
+++ b/pkg/build/url.go
@@ -4,24 +4,18 @@
 package build
 
 import (
-	"fmt"
-	"net/url"
 	"strings"
+
+	"github.com/google/oss-rebuild/internal/gcsx"
 )
 
 // gsToHTTP converts a gs:// URL to an HTTP URL
 func gsToHTTP(gsURL string) (string, error) {
-	if !strings.HasPrefix(gsURL, "gs://") {
-		return "", fmt.Errorf("not a gs:// URL: %s", gsURL)
-	}
-	u, err := url.Parse(gsURL)
+	bucket, object, err := gcsx.ParseURL(gsURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid gs:// URL: %w", err)
+		return "", err
 	}
-	bucket := u.Host
-	object := strings.TrimPrefix(u.Path, "/")
-	httpURL := fmt.Sprintf("https://storage.googleapis.com/%s/%s", bucket, object)
-	return httpURL, nil
+	return gcsx.HTTPURL(bucket, object), nil
 }
 
 // NeedsAuth determines if a URL requires authentication based on configured prefixes

--- a/pkg/rebuild/rebuild/storage.go
+++ b/pkg/rebuild/rebuild/storage.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	gcs "cloud.google.com/go/storage"
@@ -181,7 +180,11 @@ type GCSStore struct {
 
 func NewGCSStoreFromClient(ctx context.Context, client *gcs.Client, uploadPrefix string) (*GCSStore, error) {
 	s := &GCSStore{gcsClient: client}
-	s.bucket, s.prefix, _ = strings.Cut(strings.TrimPrefix(uploadPrefix, "gs://"), "/")
+	var err error
+	s.bucket, s.prefix, err = gcsx.ParseURL(uploadPrefix)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing upload prefix")
+	}
 	{
 		var ok bool
 		s.runID, ok = ctx.Value(RunID).(string)

--- a/pkg/sysgraph/sgstorage/gcs.go
+++ b/pkg/sysgraph/sgstorage/gcs.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"google.golang.org/api/iterator"
 )
 
@@ -144,15 +145,11 @@ func (f *gcsFileInfo) Info() (fs.FileInfo, error) {
 }
 
 func parseGCSPath(fpath string) (bucket, object string, err error) {
-	if !strings.HasPrefix(fpath, "gs://") {
+	bucket, object, err = gcsx.ParseURL(fpath)
+	if err != nil || object == "" {
 		return "", "", fmt.Errorf("invalid GCS path: %s", fpath)
 	}
-	fpath = strings.TrimPrefix(fpath, "gs://")
-	parts := strings.SplitN(fpath, "/", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid GCS path: %s", fpath)
-	}
-	return parts[0], parts[1], nil
+	return bucket, object, nil
 }
 
 func readFromGCS(ctx context.Context, fpath string) (*BufferedReadCloser, error) {

--- a/tools/ctl/command/infer/infer.go
+++ b/tools/ctl/command/infer/infer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/api/inferenceservice"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/textwrap"
@@ -243,7 +244,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 	resources := build.Resources{
 		ToolURLs: map[build.ToolType]string{
 			// Ex: https://storage.googleapis.com/google-rebuild-bootstrap-tools/v0.0.0-20251211001310-499b5fb97512/timewarp
-			build.TimewarpTool: fmt.Sprintf("https://storage.googleapis.com/%s/%s/timewarp", cfg.BootstrapBucket, cfg.BootstrapVersion),
+			build.TimewarpTool: gcsx.HTTPURL(cfg.BootstrapBucket, cfg.BootstrapVersion+"/timewarp"),
 		},
 		BaseImageConfig: build.DefaultBaseImageConfig(),
 	}

--- a/tools/ctl/command/runbenchmark/runbenchmark.go
+++ b/tools/ctl/command/runbenchmark/runbenchmark.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cheggaaa/pb"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/internal/rundex"
 	"github.com/google/oss-rebuild/internal/taskqueue"
@@ -149,7 +150,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 			return nil, errors.Wrap(err, "Failed to create temp directory")
 		}
 		// TODO: Validate this.
-		prebuildURL := fmt.Sprintf("https://%s.storage.googleapis.com/%s", cfg.BootstrapBucket, cfg.BootstrapVersion)
+		prebuildURL := gcsx.VirtualHostedURL(cfg.BootstrapBucket, cfg.BootstrapVersion)
 		localCfg := benchrun.LocalExecutionServiceConfig{
 			PrebuildURL: prebuildURL,
 			Store:       store,

--- a/tools/ctl/command/runone/runone.go
+++ b/tools/ctl/command/runone/runone.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
+	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/pkg/act"
 	"github.com/google/oss-rebuild/pkg/act/api"
@@ -177,7 +178,7 @@ func handleLocal(ctx context.Context, cfg Config, deps *Deps, enc *json.Encoder,
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temp directory")
 	}
-	prebuildURL := fmt.Sprintf("https://%s.storage.googleapis.com/%s", cfg.BootstrapBucket, cfg.BootstrapVersion)
+	prebuildURL := gcsx.VirtualHostedURL(cfg.BootstrapBucket, cfg.BootstrapVersion)
 	localCfg := benchrun.LocalExecutionServiceConfig{
 		PrebuildURL: prebuildURL,
 		Store:       store,


### PR DESCRIPTION
Replace five hand-rolled bucket/object splits with gcsx.ParseURL: the
GCS asset store, the gs-to-HTTP conversion in pkg/build, sysgraph
storage, the gitcache backend, and gsutil_writeonly. Add constructors
for the three endpoint forms in use, built as url.URL values for
correct escaping: HTTPURL (path-style), VirtualHostedURL (XML API),
and MediaURL (JSON API download, generation-pinned), converting
gs-to-HTTP, the ctl timewarp and prebuild URLs, and the gitcache
redirect. One behavior tightening: NewGCSStoreFromClient previously
tolerated prefixes missing the gs:// scheme and now rejects them. All
callers already pass the scheme.