### PR TITLE
Create a object ref abstraction for gcsx

### DIFF
--- a/cmd/gsutil_writeonly/main.go
+++ b/cmd/gsutil_writeonly/main.go
@@ -20,24 +20,19 @@ func isGCSPath(pth string) bool {
 	return strings.HasPrefix(pth, "gs://")
 }
 
-func gcsParts(pth string) (bucket, object string) {
-	bucket, object, _ = gcsx.ParseURL(pth)
-	return bucket, object
-}
-
 func copyFile(ctx context.Context, c *storage.Client, src, dest string) error {
 	var err error
 	var srcR io.ReadCloser
 	if isGCSPath(src) {
-		b, o := gcsParts(src)
-		s, err := c.Bucket(b).IAM().TestPermissions(ctx, []string{"storage.objects.get"})
+		ref := gcsx.MustParseURL(src)
+		s, err := c.Bucket(ref.Bucket).IAM().TestPermissions(ctx, []string{"storage.objects.get"})
 		if err != nil {
 			return err
 		}
 		if len(s) != 1 {
-			return errors.Errorf("insufficient GCS read permissions [bucket=%s]", b)
+			return errors.Errorf("insufficient GCS read permissions [bucket=%s]", ref.Bucket)
 		}
-		srcR, err = c.Bucket(b).Object(o).NewReader(ctx)
+		srcR, err = ref.Handle(c).NewReader(ctx)
 		if err != nil {
 			return err
 		}
@@ -50,17 +45,17 @@ func copyFile(ctx context.Context, c *storage.Client, src, dest string) error {
 	defer srcR.Close()
 	var destW io.WriteCloser
 	if isGCSPath(dest) {
-		b, o := gcsParts(dest)
+		ref := gcsx.MustParseURL(dest)
 		if strings.HasSuffix(dest, "/") {
-			o = path.Join(o, path.Base(src))
+			ref.Object = path.Join(ref.Object, path.Base(src))
 		}
-		destW = c.Bucket(b).Object(o).NewWriter(ctx)
-		s, err := c.Bucket(b).IAM().TestPermissions(ctx, []string{"storage.objects.create"})
+		destW = ref.Handle(c).NewWriter(ctx)
+		s, err := c.Bucket(ref.Bucket).IAM().TestPermissions(ctx, []string{"storage.objects.create"})
 		if err != nil {
 			return err
 		}
 		if len(s) != 1 {
-			return errors.Errorf("insufficient GCS write permissions [bucket=%s]", b)
+			return errors.Errorf("insufficient GCS write permissions [bucket=%s]", ref.Bucket)
 		}
 	} else {
 		pth := dest

--- a/internal/gcsx/url.go
+++ b/internal/gcsx/url.go
@@ -8,47 +8,113 @@ import (
 	"strconv"
 	"strings"
 
+	gcs "cloud.google.com/go/storage"
 	"github.com/pkg/errors"
 )
 
-// ParseURL splits a gs:// URL into its bucket and object path.
-func ParseURL(gsURL string) (bucket, object string, err error) {
+// Bucket identifies a GCS bucket.
+type Bucket string
+
+// Object returns a ref for the named object in the bucket.
+func (b Bucket) Object(name string) Ref {
+	return Ref{Bucket: string(b), Object: name}
+}
+
+// Ref identifies a GCS object, optionally pinned to a generation.
+type Ref struct {
+	Bucket string
+	Object string
+	gen    int64
+}
+
+// ParseURL parses a gs:// URL into a Ref. A gsutil-style #<generation>
+// suffix pins the ref to that generation.
+func ParseURL(gsURL string) (Ref, error) {
 	rest, ok := strings.CutPrefix(gsURL, "gs://")
 	if !ok {
-		return "", "", errors.Errorf("not a gs:// URL: %s", gsURL)
+		return Ref{}, errors.Errorf("not a gs:// URL: %s", gsURL)
 	}
-	bucket, object, _ = strings.Cut(rest, "/")
-	return bucket, object, nil
+	var r Ref
+	path, gen, pinned := strings.Cut(rest, "#")
+	if pinned {
+		var err error
+		r.gen, err = strconv.ParseInt(gen, 10, 64)
+		if err != nil {
+			return Ref{}, errors.Wrapf(err, "parsing generation %q", gen)
+		}
+	}
+	r.Bucket, r.Object, _ = strings.Cut(path, "/")
+	return r, nil
+}
+
+// MustParseURL is ParseURL, panicking on error.
+func MustParseURL(gsURL string) Ref {
+	r, err := ParseURL(gsURL)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// Generation returns the ref pinned to the given generation.
+func (r Ref) Generation(gen int64) Ref {
+	r.gen = gen
+	return r
+}
+
+// Handle returns the object's handle on the given client, pinned to the
+// ref's generation when set.
+func (r Ref) Handle(client *gcs.Client) *gcs.ObjectHandle {
+	obj := client.Bucket(r.Bucket).Object(r.Object)
+	if r.gen != 0 {
+		obj = obj.Generation(r.gen)
+	}
+	return obj
+}
+
+// query renders the given parameters plus the generation pin, if any.
+func (r Ref) query(q url.Values) string {
+	if r.gen != 0 {
+		q.Set("generation", strconv.FormatInt(r.gen, 10))
+	}
+	return q.Encode()
 }
 
 // HTTPURL returns the object's path-style download endpoint.
-func HTTPURL(bucket, object string) string {
-	u := url.URL{Scheme: "https", Host: "storage.googleapis.com", Path: "/" + bucket + "/" + object}
+func (r Ref) HTTPURL() string {
+	u := url.URL{
+		Scheme:   "https",
+		Host:     "storage.googleapis.com",
+		Path:     "/" + r.Bucket + "/" + r.Object,
+		RawQuery: r.query(url.Values{}),
+	}
 	return u.String()
 }
 
 // VirtualHostedURL returns the object's XML API endpoint with the bucket as
 // the host subdomain.
-func VirtualHostedURL(bucket, object string) string {
-	u := url.URL{Scheme: "https", Host: bucket + ".storage.googleapis.com", Path: "/" + object}
+func (r Ref) VirtualHostedURL() string {
+	u := url.URL{
+		Scheme:   "https",
+		Host:     r.Bucket + ".storage.googleapis.com",
+		Path:     "/" + r.Object,
+		RawQuery: r.query(url.Values{}),
+	}
 	return u.String()
 }
 
-// MediaURL returns the object's JSON API media download endpoint, pinned to
-// generation when nonzero.
-func MediaURL(bucket, object string, generation int64) string {
-	q := url.Values{"alt": []string{"media"}}
-	if generation != 0 {
-		q.Set("generation", strconv.FormatInt(generation, 10))
-	}
+// MediaURL returns the object's JSON API media download endpoint.
+func (r Ref) MediaURL() string {
 	u := url.URL{
 		Scheme: "https",
 		Host:   "storage.googleapis.com",
-		// The object is a single path segment in the JSON API: its slashes
-		// must be escaped.
-		Path:     "/download/storage/v1/b/" + bucket + "/o/" + object,
-		RawPath:  "/download/storage/v1/b/" + url.PathEscape(bucket) + "/o/" + url.PathEscape(object),
-		RawQuery: q.Encode(),
+		// The object is a single path segment in the JSON API: RawPath
+		// carries its escaped form and Path the decoded form, matching the
+		// GCS client's httpStorageClient.newRangeReaderXML. Escaping rules:
+		// https://cloud.google.com/storage/docs/request-endpoints#encoding
+		Path:     "/download/storage/v1/b/" + r.Bucket + "/o/" + r.Object,
+		RawPath:  "/download/storage/v1/b/" + url.PathEscape(r.Bucket) + "/o/" + url.PathEscape(r.Object),
+		RawQuery: r.query(url.Values{"alt": []string{"media"}}),
 	}
 	return u.String()
 }

--- a/internal/gcsx/url_test.go
+++ b/internal/gcsx/url_test.go
@@ -3,18 +3,83 @@
 
 package gcsx
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	gcs "cloud.google.com/go/storage"
+)
+
+func TestBucketObject(t *testing.T) {
+	got := Bucket("bucket").Object("path/to/obj")
+	if want := (Ref{Bucket: "bucket", Object: "path/to/obj"}); got != want {
+		t.Errorf("Bucket().Object() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	for _, tc := range []struct {
+		url     string
+		want    Ref
+		wantErr bool
+	}{
+		{url: "gs://bucket/path/to/obj", want: Bucket("bucket").Object("path/to/obj")},
+		{url: "gs://bucket", want: Bucket("bucket").Object("")},
+		{url: "gs://bucket/", want: Bucket("bucket").Object("")},
+		{url: "gs://bucket/obj#1234567890", want: Bucket("bucket").Object("obj").Generation(1234567890)},
+		{url: "gs://bucket/obj#latest", wantErr: true},
+		{url: "https://bucket/obj", wantErr: true},
+		{url: "bucket/obj", wantErr: true},
+	} {
+		got, err := ParseURL(tc.url)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("ParseURL(%q) = %+v, want %+v", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestMustParseURL(t *testing.T) {
+	if got := MustParseURL("gs://bucket/obj"); got != Bucket("bucket").Object("obj") {
+		t.Errorf("MustParseURL() = %+v", got)
+	}
+	defer func() {
+		if recover() == nil {
+			t.Error("MustParseURL() did not panic on invalid input")
+		}
+	}()
+	MustParseURL("not-a-url")
+}
+
+func TestHandle(t *testing.T) {
+	client := &gcs.Client{}
+	got := Bucket("bucket").Object("obj").Handle(client)
+	if want := client.Bucket("bucket").Object("obj"); !reflect.DeepEqual(got, want) {
+		t.Errorf("Handle() = %+v, want %+v", got, want)
+	}
+	got = Bucket("bucket").Object("obj").Generation(123).Handle(client)
+	if want := client.Bucket("bucket").Object("obj").Generation(123); !reflect.DeepEqual(got, want) {
+		t.Errorf("Handle() pinned = %+v, want %+v", got, want)
+	}
+}
 
 func TestHTTPURL(t *testing.T) {
-	got := HTTPURL("bucket", "path/to/obj")
+	got := Bucket("bucket").Object("path/to/obj").HTTPURL()
 	want := "https://storage.googleapis.com/bucket/path/to/obj"
 	if got != want {
 		t.Errorf("HTTPURL() = %q, want %q", got, want)
 	}
+	got = Bucket("bucket").Object("obj").Generation(123).HTTPURL()
+	want = "https://storage.googleapis.com/bucket/obj?generation=123"
+	if got != want {
+		t.Errorf("HTTPURL() pinned = %q, want %q", got, want)
+	}
 }
 
 func TestVirtualHostedURL(t *testing.T) {
-	got := VirtualHostedURL("bucket", "prefix")
+	got := Bucket("bucket").Object("prefix").VirtualHostedURL()
 	want := "https://bucket.storage.googleapis.com/prefix"
 	if got != want {
 		t.Errorf("VirtualHostedURL() = %q, want %q", got, want)
@@ -22,31 +87,9 @@ func TestVirtualHostedURL(t *testing.T) {
 }
 
 func TestMediaURL(t *testing.T) {
-	got := MediaURL("bucket", "path/to obj", 123)
+	got := Bucket("bucket").Object("path/to obj").Generation(123).MediaURL()
 	want := "https://storage.googleapis.com/download/storage/v1/b/bucket/o/path%2Fto%20obj?alt=media&generation=123"
 	if got != want {
 		t.Errorf("MediaURL() = %q, want %q", got, want)
-	}
-}
-
-func TestParseURL(t *testing.T) {
-	for _, tc := range []struct {
-		url            string
-		bucket, object string
-		wantErr        bool
-	}{
-		{url: "gs://bucket/path/to/obj", bucket: "bucket", object: "path/to/obj"},
-		{url: "gs://bucket", bucket: "bucket"},
-		{url: "gs://bucket/", bucket: "bucket"},
-		{url: "https://bucket/obj", wantErr: true},
-		{url: "bucket/obj", wantErr: true},
-	} {
-		bucket, object, err := ParseURL(tc.url)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("ParseURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
-		}
-		if bucket != tc.bucket || object != tc.object {
-			t.Errorf("ParseURL(%q) = (%q, %q), want (%q, %q)", tc.url, bucket, object, tc.bucket, tc.object)
-		}
 	}
 }

--- a/internal/gitcache/backend.go
+++ b/internal/gitcache/backend.go
@@ -63,7 +63,7 @@ func (g *gcsBackend) serve(rw http.ResponseWriter, req *http.Request, path strin
 		http.Error(rw, "Internal Error", 500)
 		return
 	}
-	http.Redirect(rw, req, gcsx.MediaURL(g.bucket, path, a.Generation), http.StatusFound)
+	http.Redirect(rw, req, gcsx.Bucket(g.bucket).Object(path).Generation(a.Generation).MediaURL(), http.StatusFound)
 }
 
 func (g *gcsBackend) delete(ctx context.Context, path string) error {

--- a/internal/gitcache/gitcache.go
+++ b/internal/gitcache/gitcache.go
@@ -87,7 +87,7 @@ func NewServer(ctx context.Context, cacheStr string) (*Server, error) {
 // newBackend creates a cacheBackend from the given cache location string.
 func newBackend(ctx context.Context, cacheStr string) (cacheBackend, error) {
 	if strings.HasPrefix(cacheStr, "gs://") {
-		bucketName, _, _ := gcsx.ParseURL(cacheStr)
+		bucketName := gcsx.MustParseURL(cacheStr).Bucket
 		client, err := storage.NewClient(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating GCS client")

--- a/pkg/build/url.go
+++ b/pkg/build/url.go
@@ -9,15 +9,6 @@ import (
 	"github.com/google/oss-rebuild/internal/gcsx"
 )
 
-// gsToHTTP converts a gs:// URL to an HTTP URL
-func gsToHTTP(gsURL string) (string, error) {
-	bucket, object, err := gcsx.ParseURL(gsURL)
-	if err != nil {
-		return "", err
-	}
-	return gcsx.HTTPURL(bucket, object), nil
-}
-
 // NeedsAuth determines if a URL requires authentication based on configured prefixes
 func NeedsAuth(url string, authPrefixes []string) bool {
 	for _, prefix := range authPrefixes {
@@ -32,7 +23,11 @@ func NeedsAuth(url string, authPrefixes []string) bool {
 // For example, converts gs:// URLs to HTTP URLs
 func ConvertURLForRuntime(originalURL string) (string, error) {
 	if strings.HasPrefix(originalURL, "gs://") {
-		return gsToHTTP(originalURL)
+		ref, err := gcsx.ParseURL(originalURL)
+		if err != nil {
+			return "", err
+		}
+		return ref.HTTPURL(), nil
 	}
 	// For other URL schemes, return as-is
 	return originalURL, nil

--- a/pkg/build/url_test.go
+++ b/pkg/build/url_test.go
@@ -7,48 +7,6 @@ import (
 	"testing"
 )
 
-func TestGSToHTTP(t *testing.T) {
-	tests := []struct {
-		name     string
-		gsURL    string
-		wantHTTP string
-		wantErr  bool
-	}{
-		{
-			name:     "basic gs URL",
-			gsURL:    "gs://bucket/object",
-			wantHTTP: "https://storage.googleapis.com/bucket/object",
-			wantErr:  false,
-		},
-		{
-			name:    "non-gs URL",
-			gsURL:   "http://example.com/file",
-			wantErr: true,
-		},
-		{
-			name:     "invalid URL",
-			gsURL:    "gs://",
-			wantHTTP: "https://storage.googleapis.com//",
-			wantErr:  false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			httpURL, err := gsToHTTP(tt.gsURL)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GSToHTTP() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if err != nil {
-				return
-			}
-			if httpURL != tt.wantHTTP {
-				t.Errorf("GSToHTTP() httpURL = %v, want %v", httpURL, tt.wantHTTP)
-			}
-		})
-	}
-}
-
 func TestNeedsAuth(t *testing.T) {
 	authPrefixes := []string{"gs://", "https://private.example.com/"}
 
@@ -110,6 +68,12 @@ func TestConvertURLForRuntime(t *testing.T) {
 			name:        "https URL unchanged",
 			originalURL: "https://example.com/file",
 			wantURL:     "https://example.com/file",
+			wantErr:     false,
+		},
+		{
+			name:        "degenerate gs URL",
+			originalURL: "gs://",
+			wantURL:     "https://storage.googleapis.com//",
 			wantErr:     false,
 		},
 	}

--- a/pkg/rebuild/rebuild/storage.go
+++ b/pkg/rebuild/rebuild/storage.go
@@ -180,11 +180,11 @@ type GCSStore struct {
 
 func NewGCSStoreFromClient(ctx context.Context, client *gcs.Client, uploadPrefix string) (*GCSStore, error) {
 	s := &GCSStore{gcsClient: client}
-	var err error
-	s.bucket, s.prefix, err = gcsx.ParseURL(uploadPrefix)
+	ref, err := gcsx.ParseURL(uploadPrefix)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing upload prefix")
 	}
+	s.bucket, s.prefix = ref.Bucket, ref.Object
 	{
 		var ok bool
 		s.runID, ok = ctx.Value(RunID).(string)

--- a/pkg/sysgraph/sgstorage/gcs.go
+++ b/pkg/sysgraph/sgstorage/gcs.go
@@ -145,11 +145,11 @@ func (f *gcsFileInfo) Info() (fs.FileInfo, error) {
 }
 
 func parseGCSPath(fpath string) (bucket, object string, err error) {
-	bucket, object, err = gcsx.ParseURL(fpath)
-	if err != nil || object == "" {
+	ref, err := gcsx.ParseURL(fpath)
+	if err != nil || ref.Object == "" {
 		return "", "", fmt.Errorf("invalid GCS path: %s", fpath)
 	}
-	return bucket, object, nil
+	return ref.Bucket, ref.Object, nil
 }
 
 func readFromGCS(ctx context.Context, fpath string) (*BufferedReadCloser, error) {

--- a/tools/ctl/command/infer/infer.go
+++ b/tools/ctl/command/infer/infer.go
@@ -244,7 +244,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 	resources := build.Resources{
 		ToolURLs: map[build.ToolType]string{
 			// Ex: https://storage.googleapis.com/google-rebuild-bootstrap-tools/v0.0.0-20251211001310-499b5fb97512/timewarp
-			build.TimewarpTool: gcsx.HTTPURL(cfg.BootstrapBucket, cfg.BootstrapVersion+"/timewarp"),
+			build.TimewarpTool: gcsx.Bucket(cfg.BootstrapBucket).Object(cfg.BootstrapVersion + "/timewarp").HTTPURL(),
 		},
 		BaseImageConfig: build.DefaultBaseImageConfig(),
 	}

--- a/tools/ctl/command/runbenchmark/runbenchmark.go
+++ b/tools/ctl/command/runbenchmark/runbenchmark.go
@@ -150,7 +150,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 			return nil, errors.Wrap(err, "Failed to create temp directory")
 		}
 		// TODO: Validate this.
-		prebuildURL := gcsx.VirtualHostedURL(cfg.BootstrapBucket, cfg.BootstrapVersion)
+		prebuildURL := gcsx.Bucket(cfg.BootstrapBucket).Object(cfg.BootstrapVersion).VirtualHostedURL()
 		localCfg := benchrun.LocalExecutionServiceConfig{
 			PrebuildURL: prebuildURL,
 			Store:       store,

--- a/tools/ctl/command/runone/runone.go
+++ b/tools/ctl/command/runone/runone.go
@@ -178,7 +178,7 @@ func handleLocal(ctx context.Context, cfg Config, deps *Deps, enc *json.Encoder,
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temp directory")
 	}
-	prebuildURL := gcsx.VirtualHostedURL(cfg.BootstrapBucket, cfg.BootstrapVersion)
+	prebuildURL := gcsx.Bucket(cfg.BootstrapBucket).Object(cfg.BootstrapVersion).VirtualHostedURL()
 	localCfg := benchrun.LocalExecutionServiceConfig{
 		PrebuildURL: prebuildURL,
 		Store:       store,


### PR DESCRIPTION
The gcsx parsing and url methods are now centralized in a struct
representing a client-less object descriptor. Ref supports the builder
pattern like the client API (e.g. `Bucket("b").Object("o").Generation(n)`).