### PR TITLE
Security: Unbounded Goroutine Leak in Rate Limiter

### DIFF
--- a/internal/ratex/backoff.go
+++ b/internal/ratex/backoff.go
@@ -15,6 +15,7 @@ type BackoffLimiter struct {
 	currentPeriod time.Duration
 	minimum       time.Duration
 	ch            chan struct{}
+	done          chan struct{}
 }
 
 func NewBackoffLimiter(minimum time.Duration) *BackoffLimiter {
@@ -22,22 +23,41 @@ func NewBackoffLimiter(minimum time.Duration) *BackoffLimiter {
 		currentPeriod: minimum,
 		minimum:       minimum,
 		ch:            make(chan struct{}),
+		done:          make(chan struct{}),
 	}
 	go func() {
 		for {
-			l.tick()
+			select {
+			case <-l.done:
+				return
+			default:
+				l.tick()
+			}
 		}
 	}()
 	return l
+}
+
+func (l *BackoffLimiter) Close() {
+	close(l.done)
 }
 
 func (l *BackoffLimiter) tick() {
 	l.mu.Lock()
 	duration := l.currentPeriod
 	l.mu.Unlock()
-	// If we want the in-flight sleep period to be interrupted, we can implement this with a time.AfterFunc(), and cancel the in-flight timer when the period is updated.
-	time.Sleep(duration)
-	l.ch <- struct{}{}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-l.done:
+		return
+	case <-timer.C:
+		select {
+		case <-l.done:
+			return
+		case l.ch <- struct{}{}:
+		}
+	}
 }
 
 // Wait blocks until the limiter permits another event to happen.


### PR DESCRIPTION
## Summary

Security: Unbounded Goroutine Leak in Rate Limiter

## Problem

**Severity**: `Medium` | **File**: `internal/ratex/backoff.go:L23`

In `internal/ratex/backoff.go`, the `NewBackoffLimiter` function starts a goroutine with an infinite `for` loop that is never stopped. Since there is no close mechanism for the `ch` channel or a way to terminate the goroutine, every time a `BackoffLimiter` is created and discarded, the goroutine leaks and runs indefinitely, potentially exhausting system resources over time.

## Solution

Provide a context or a `Close()`/`Stop()` method that safely terminates the background goroutine when the limiter is no longer needed.

## Changes

- `internal/ratex/backoff.go` (modified)