### PR TITLE
Add external agent mode

### DIFF
--- a/internal/api/apiservice/agent.go
+++ b/internal/api/apiservice/agent.go
@@ -141,60 +141,72 @@ func AgentCreate(ctx context.Context, req schema.AgentCreateRequest, deps *Agent
 			log.Printf("releasing scratch %s for failed session %s: %v", session.ScratchID, sessionID, err)
 		}
 	}
-	args := []string{
-		"--project=" + deps.Project,
-		"--location=" + deps.Location,
-		"--session-id=" + sessionID,
-		"--agent-api-url=" + deps.AgentAPIURL,
-		"--sessions-bucket=" + deps.SessionsBucket,
-		"--metadata-bucket=" + deps.MetadataBucket,
-		"--logs-bucket=" + deps.LogsBucket,
-		"--max-iterations=" + fmt.Sprintf("%d", maxIterations),
-		"--target-ecosystem=" + string(req.Target.Ecosystem),
-		"--target-package=" + req.Target.Package,
-		"--target-version=" + req.Target.Version,
-		"--target-artifact=" + req.Target.Artifact,
-	}
-	if executionMode == schema.AgentExecutionModeScratch {
-		args = append(args,
-			"--execution-mode="+string(schema.AgentExecutionModeScratch),
-			"--scratch-id="+session.ScratchID,
-			"--prebuild-bucket="+deps.PrebuildConfig.Bucket,
-			"--prebuild-dir="+deps.PrebuildConfig.Dir,
-			fmt.Sprintf("--prebuild-auth=%t", deps.PrebuildConfig.Auth),
-		)
+	if !req.ExternalAgent {
+		args := []string{
+			"--project=" + deps.Project,
+			"--location=" + deps.Location,
+			"--session-id=" + sessionID,
+			"--agent-api-url=" + deps.AgentAPIURL,
+			"--sessions-bucket=" + deps.SessionsBucket,
+			"--metadata-bucket=" + deps.MetadataBucket,
+			"--logs-bucket=" + deps.LogsBucket,
+			"--max-iterations=" + fmt.Sprintf("%d", maxIterations),
+			"--target-ecosystem=" + string(req.Target.Ecosystem),
+			"--target-package=" + req.Target.Package,
+			"--target-version=" + req.Target.Version,
+			"--target-artifact=" + req.Target.Artifact,
+		}
 		if deps.Host != "" {
 			args = append(args, "--host="+deps.Host)
 		}
-	}
-	// Create Cloud Run Job
-	op, err := deps.RunService.Projects.Locations.Jobs.Run(deps.AgentJobName, &run.GoogleCloudRunV2RunJobRequest{
-		Overrides: &run.GoogleCloudRunV2Overrides{
-			Timeout: fmt.Sprintf("%ds", deps.AgentTimeoutSeconds),
-			ContainerOverrides: []*run.GoogleCloudRunV2ContainerOverride{
-				{Args: args},
+		if executionMode == schema.AgentExecutionModeScratch {
+			args = append(args,
+				"--execution-mode="+string(schema.AgentExecutionModeScratch),
+				"--scratch-id="+session.ScratchID,
+				"--prebuild-bucket="+deps.PrebuildConfig.Bucket,
+				"--prebuild-dir="+deps.PrebuildConfig.Dir,
+				fmt.Sprintf("--prebuild-auth=%t", deps.PrebuildConfig.Auth),
+			)
+		}
+		// Create Cloud Run Job
+		op, err := deps.RunService.Projects.Locations.Jobs.Run(deps.AgentJobName, &run.GoogleCloudRunV2RunJobRequest{
+			Overrides: &run.GoogleCloudRunV2Overrides{
+				Timeout: fmt.Sprintf("%ds", deps.AgentTimeoutSeconds),
+				ContainerOverrides: []*run.GoogleCloudRunV2ContainerOverride{
+					{Args: args},
+				},
 			},
-		},
-	}).Do()
-	if err != nil {
-		releaseScratch()
-		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "creating cloud run job"))
+		}).Do()
+		if err != nil {
+			releaseScratch()
+			return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "creating cloud run job"))
+		}
+		session.ExecutionName, err = executionFromOp(op)
+		if err != nil {
+			// NOTE: Failing here would strand the launched job (a retry
+			// launches a second job and allocates a second scratch) and skip
+			// persisting ScratchID, which AgentComplete's teardown reads.
+			// Proceed without an execution name, as external-agent sessions do.
+			log.Printf("session %s: getting execution name from operation: %v", sessionID, err)
+		}
 	}
-	// Update session status
-	session.ExecutionName, err = executionFromOp(op)
-	if err != nil {
-		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "getting execution name from operation"))
-	}
+	// Update session status. External-agent sessions become RUNNING without an
+	// execution: the caller runs the agent binary externally.
 	session.Status = schema.AgentSessionStatusRunning
 	session.Updated = time.Now().UTC()
 	_, err = deps.FirestoreClient.Collection("agent_sessions").Doc(sessionID).Set(ctx, session)
 	if err != nil {
-		// NOTE: The job is already running. Leave the scratch for it and let
-		// the reaper handle any orphan.
+		if req.ExternalAgent {
+			// No agent will ever use the scratch. Release it eagerly.
+			releaseScratch()
+		}
+		// NOTE: With a launched job the scratch is left for the (possibly
+		// still viable) execution. The reaper handles any orphan.
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "updating session status"))
 	}
 	return &schema.AgentCreateResponse{
 		SessionID:     sessionID,
 		ExeuctionName: session.ExecutionName,
+		ScratchID:     session.ScratchID,
 	}, nil
 }

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -505,6 +505,7 @@ type AgentCreateRequest struct {
 	MaxIterations int                `form:""`
 	Context       *AgentContext      `form:""`
 	ExecutionMode AgentExecutionMode `form:""` // Empty means AgentExecutionModeGCB
+	ExternalAgent bool               `form:""` // Skip the hosted agent job launch: the caller runs the agent binary
 }
 
 var _ api.Input = AgentCreateRequest{}
@@ -530,6 +531,7 @@ type AgentContext struct {
 type AgentCreateResponse struct {
 	SessionID     string `json:"session_id"`
 	ExeuctionName string `json:"execution_name"`
+	ScratchID     string `json:"scratch_id,omitempty"` // Scratch-mode VM handle, passed by external-agent callers as --scratch-id
 }
 
 // AgentCreateIterationRequest records an iteration and triggers its GCB

--- a/pkg/rebuild/schema/schema_test.go
+++ b/pkg/rebuild/schema/schema_test.go
@@ -482,6 +482,10 @@ func TestAgentCreateRequest_Validate(t *testing.T) {
 			req:  AgentCreateRequest{Target: target, ExecutionMode: AgentExecutionModeScratch},
 		},
 		{
+			name: "external agent scratch mode",
+			req:  AgentCreateRequest{Target: target, ExecutionMode: AgentExecutionModeScratch, ExternalAgent: true},
+		},
+		{
 			name:    "invalid execution mode",
 			req:     AgentCreateRequest{Target: target, ExecutionMode: "warp"},
 			wantErr: true,

--- a/tools/ctl/command/runagent/runagent.go
+++ b/tools/ctl/command/runagent/runagent.go
@@ -35,6 +35,7 @@ type Config struct {
 	Artifact        string
 	AgentIterations int
 	ExecutionMode   string
+	LocalAgent      bool
 }
 
 // Validate ensures the configuration is valid.
@@ -106,6 +107,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 		Target:        t,
 		MaxIterations: cfg.AgentIterations,
 		ExecutionMode: schema.AgentExecutionMode(cfg.ExecutionMode),
+		ExternalAgent: cfg.LocalAgent,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "running attest")
@@ -145,7 +147,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 func Command() *cobra.Command {
 	cfg := Config{}
 	cmd := &cobra.Command{
-		Use:   "run-agent --project <project> --api <URI> --ecosystem <ecosystem> --package <name> --version <version> --artifact <name> [--agent-iterations <max iterations>] [--execution-mode <mode>]",
+		Use:   "run-agent --project <project> --api <URI> --ecosystem <ecosystem> --package <name> --version <version> --artifact <name> [--agent-iterations <max iterations>] [--execution-mode <mode>] [--local-agent]",
 		Short: "Run the agent on a single target",
 		Args:  cobra.NoArgs,
 		RunE: cli.RunE(
@@ -170,5 +172,6 @@ func flagSet(name string, cfg *Config) *flag.FlagSet {
 	set.StringVar(&cfg.Artifact, "artifact", "", "the artifact name")
 	set.IntVar(&cfg.AgentIterations, "agent-iterations", 3, "maximum number of agent iterations before giving up")
 	set.StringVar(&cfg.ExecutionMode, "execution-mode", "", "where iteration builds execute: gcb (default) or scratch")
+	set.BoolVar(&cfg.LocalAgent, "local-agent", false, "run the agent locally instead of launching the hosted agent job (iteration builds still run per --execution-mode)")
 	return set
 }


### PR DESCRIPTION
This provisions the scratch instance but allows an external caller to
drive the iterations.