### PR TITLE
Support GitLab subgroup repository URLs

### DIFF
--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -14,7 +14,7 @@ import (
 var (
 	// NOTE: This is non-exhaustive and should be expanded as necessary.
 	githubRE    = re.MustCompile(`(?i)\bgithub(\.com)?[:/]([\w-]+/[\w-\.]+)`)
-	gitlabRE    = re.MustCompile(`(?i)\bgitlab(\.com)?[:/]([\w-]+/[\w-\.]+)`)
+	gitlabRE    = re.MustCompile(`(?i)\bgitlab(\.com)?[:/]([\w-]+(?:/[\w.-]+)+)`)
 	bitbucketRE = re.MustCompile(`(?i)\bbitbucket(\.org)?[:/]([\w-]+/[\w-\.]+)`)
 	commonRepos = []*re.Regexp{
 		githubRE,
@@ -25,6 +25,19 @@ var (
 
 var errUnsupportedRepo = errors.Errorf("unsupported repo type")
 
+func trimGitLabRoute(repo string) string {
+	if repo, _, found := strings.Cut(repo, "/-/"); found {
+		return repo
+	}
+	if repoRoot, _, found := strings.Cut(repo, "/tree/"); found {
+		pathStart := strings.IndexAny(repoRoot, ":/")
+		if pathStart >= 0 && strings.Count(repoRoot[pathStart+1:], "/") == 1 {
+			return repoRoot
+		}
+	}
+	return repo
+}
+
 // CanonicalizeRepoURI parses repos into a canonical HTTPS URI.
 func CanonicalizeRepoURI(uri string) (string, error) {
 	if uri == "" {
@@ -34,7 +47,7 @@ func CanonicalizeRepoURI(uri string) (string, error) {
 	// NOTE: For these well-known platforms, ToLower canonicalization is safe.
 	if repo = githubRE.FindString(uri); repo != "" {
 		repo = "//github.com/" + strings.TrimSuffix(strings.ToLower(repo[strings.IndexAny(repo, ":/")+1:]), ".git")
-	} else if repo = gitlabRE.FindString(uri); repo != "" {
+	} else if repo = trimGitLabRoute(gitlabRE.FindString(uri)); repo != "" {
 		repo = "//gitlab.com/" + strings.TrimSuffix(strings.ToLower(repo[strings.IndexAny(repo, ":/")+1:]), ".git")
 	} else if repo = bitbucketRE.FindString(uri); repo != "" {
 		repo = "//bitbucket.org/" + strings.TrimSuffix(strings.ToLower(repo[strings.IndexAny(repo, ":/")+1:]), ".git")
@@ -59,6 +72,9 @@ func CanonicalizeRepoURI(uri string) (string, error) {
 func FindCommonRepo(text string) string {
 	for _, pattern := range commonRepos {
 		if repo := pattern.FindString(text); repo != "" {
+			if pattern == gitlabRE {
+				repo = trimGitLabRoute(repo)
+			}
 			return repo
 		}
 	}

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -21,6 +21,22 @@ func TestFindARepo(t *testing.T) {
 		{"http://github.com/org/project/tree/branch", "github.com/org/project"}, // GitHub, with path
 		{"GitLab.com/Group/Repo", "GitLab.com/Group/Repo"},                      // GitLab, case insensitive
 		{"https://bitbucket.org/team/repo", "bitbucket.org/team/repo"},          // Bitbucket
+		{
+			"https://gitlab.com/245project/bevy-plugin/bevy-2dviewangle",
+			"gitlab.com/245project/bevy-plugin/bevy-2dviewangle",
+		},
+		{
+			"https://gitlab.com/group/subgroup/repo/-/tree/main",
+			"gitlab.com/group/subgroup/repo",
+		},
+		{
+			"https://gitlab.com/group/repo/tree/main",
+			"gitlab.com/group/repo",
+		},
+		{
+			"https://gitlab.com/group/tree/repo",
+			"gitlab.com/group/tree/repo",
+		},
 	}
 	for _, test := range tests {
 		actual := FindCommonRepo(test.input)
@@ -53,6 +69,31 @@ func TestCanonicalizeRepoURI(t *testing.T) {
 		{"https://Foo.com/This/Path", "https://foo.com/This/Path", false},                                               // Unknown URL, case sensitive
 		{"ssh://git@foo.com/path", "", true},                                                                            // SSH URL
 		{"https://us-east1-proj.sourcemanager.dev/org/repo", "https://us-east1-proj.sourcemanager.dev/org/repo", false}, // SSM URL
+		{
+			"https://gitlab.com/245project/bevy-plugin/bevy-2dviewangle",
+			"https://gitlab.com/245project/bevy-plugin/bevy-2dviewangle",
+			false,
+		},
+		{
+			"git@gitlab.com:group/subgroup/repo.git",
+			"https://gitlab.com/group/subgroup/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/subgroup/repo/-/tree/main",
+			"https://gitlab.com/group/subgroup/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/repo/tree/main",
+			"https://gitlab.com/group/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/tree/repo/-/tree/main",
+			"https://gitlab.com/group/tree/repo",
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
GitLab repositories can be nested under subgroups. The current pattern stops after two path segments, so nested project URLs resolve to the wrong repository.

Preserve the full GitLab project path while continuing to strip modern /-/ routes and legacy two-segment /tree/ routes.

Testing:
- `go test ./...`
- `go vet ./...`