### PR TITLE
Escape versions in tag matching

### DIFF
--- a/pkg/rebuild/rebuild/git.go
+++ b/pkg/rebuild/rebuild/git.go
@@ -30,8 +30,9 @@ var (
 
 // MatchTag evaluates whether the given tag is likely to refer to a package version.
 func MatchTag(tag, pkg, version string) (strict bool, approx bool) {
-	boundaryRE := regexp.MustCompile(fmt.Sprintf(boundaryPatternTpl, version))
-	continuationRE := regexp.MustCompile(fmt.Sprintf(continuationPatternTpl, version))
+	escapedVersion := regexp.QuoteMeta(version)
+	boundaryRE := regexp.MustCompile(fmt.Sprintf(boundaryPatternTpl, escapedVersion))
+	continuationRE := regexp.MustCompile(fmt.Sprintf(continuationPatternTpl, escapedVersion))
 	var org string
 	if slash := strings.IndexByte(pkg, '/'); slash != -1 {
 		org = pkg[:slash]

--- a/pkg/rebuild/rebuild/git_test.go
+++ b/pkg/rebuild/rebuild/git_test.go
@@ -24,6 +24,8 @@ func TestMatchTag(t *testing.T) {
 		approx  bool
 	}{
 		{"v1.0.0", "mypackage", "1.0.0", true, true},
+		{"v1.0.0+meta", "mypackage", "1.0.0+meta", true, true},
+		{"v1x0x0", "mypackage", "1.0.0", false, false},
 		{"v1.0.0-rc1", "mypackage", "1.0.0", false, true},
 		{"mypackage-1.0.0", "mypackage", "1.0.0", true, true},
 		{"1.0.0", "mypackage", "1.0.0", true, true},


### PR DESCRIPTION
`MatchTag` inserts version strings directly into regular expressions. Versions containing regular-expression metacharacters can miss exact tags or match unrelated text.

Escape the version before constructing the regular expressions. Approximate matching continues to use the original version string.

Testing:
- `go test ./...`
- `go vet ./...`
- Replayed 59 affected crates.io versions: the current implementation matched 0/59 tags, while this change matched 59/59.