### PR TITLE
Try all matching tags during crates.io inference

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -111,7 +111,7 @@ func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string
 func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte, rcfg *rebuild.RepoConfig) (ref, dir string, err error) {
 	// Determine git ref to rebuild.
 	cargoTOMLGuess := rcfg.RefMap[t.Version]
-	tagGuess, err := rebuild.FindTagMatch(t.Package, t.Version, rcfg.Repository)
+	tagGuesses, err := rebuild.FindTagMatches(t.Package, t.Version, rcfg.Repository)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "[INTERNAL] tag heuristic error")
 	}
@@ -154,21 +154,23 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 		}
 		log.Printf("ref heuristic cargo_vcs_info not found in repo")
 		fallthrough
-	case tagGuess != "":
-		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(tagGuess))
-		if err == nil {
-			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, vcsDir); err != nil {
-				log.Printf("registry heuristic tag invalid: %v", err)
+	case len(tagGuesses) > 0:
+		for _, tagGuess := range tagGuesses {
+			c, err = rcfg.Repository.CommitObject(plumbing.NewHash(tagGuess))
+			if err == nil {
+				if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, vcsDir); err != nil {
+					log.Printf("registry heuristic tag invalid: %v", err)
+				} else {
+					log.Printf("using tag heuristic ref: %s", tagGuess[:9])
+					ref = tagGuess
+					dir = rebuild.DirOf(newPath)
+					return ref, dir, nil
+				}
+			} else if err == plumbing.ErrObjectNotFound {
+				log.Printf("tag heuristic ref not found in repo")
 			} else {
-				log.Printf("using tag heuristic ref: %s", tagGuess[:9])
-				ref = tagGuess
-				dir = rebuild.DirOf(newPath)
-				return ref, dir, nil
+				return "", "", errors.Wrapf(err, "[INTERNAL] Failed ref resolve from tag [repo=%s,ref=%s]", rcfg.URI, tagGuess)
 			}
-		} else if err == plumbing.ErrObjectNotFound {
-			log.Printf("tag heuristic ref not found in repo")
-		} else {
-			return "", "", errors.Wrapf(err, "[INTERNAL] Failed ref resolve from tag [repo=%s,ref=%s]", rcfg.URI, tagGuess)
 		}
 		log.Printf("ref heuristic tag not found in repo")
 		fallthrough
@@ -191,7 +193,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 		log.Printf("ref heuristic git log not found in repo")
 		fallthrough
 	default:
-		if cargoVCSGuess == "" && tagGuess == "" && cargoTOMLGuess == "" {
+		if cargoVCSGuess == "" && len(tagGuesses) == 0 && cargoTOMLGuess == "" {
 			return "", "", errors.Errorf("no git ref")
 		}
 		return "", "", errors.Errorf("no valid git ref")

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -111,7 +111,7 @@ func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string
 func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte, rcfg *rebuild.RepoConfig) (ref, dir string, err error) {
 	// Determine git ref to rebuild.
 	cargoTOMLGuess := rcfg.RefMap[t.Version]
-	tagGuess, err := rebuild.FindTagMatch(t.Package, t.Version, rcfg.Repository)
+	tagGuesses, err := rebuild.FindTagMatches(t.Package, t.Version, rcfg.Repository)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "[INTERNAL] tag heuristic error")
 	}
@@ -150,21 +150,23 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 		}
 		log.Printf("ref heuristic cargo_vcs_info not found in repo")
 		fallthrough
-	case tagGuess != "":
-		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(tagGuess))
-		if err == nil {
-			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, dir); err != nil {
-				log.Printf("registry heuristic tag invalid: %v", err)
+	case len(tagGuesses) > 0:
+		for _, tagGuess := range tagGuesses {
+			c, err = rcfg.Repository.CommitObject(plumbing.NewHash(tagGuess))
+			if err == nil {
+				if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, dir); err != nil {
+					log.Printf("registry heuristic tag invalid: %v", err)
+				} else {
+					log.Printf("using tag heuristic ref: %s", tagGuess[:9])
+					ref = tagGuess
+					dir = rebuild.DirOf(newPath)
+					return ref, dir, nil
+				}
+			} else if err == plumbing.ErrObjectNotFound {
+				log.Printf("tag heuristic ref not found in repo")
 			} else {
-				log.Printf("using tag heuristic ref: %s", tagGuess[:9])
-				ref = tagGuess
-				dir = rebuild.DirOf(newPath)
-				return ref, dir, nil
+				return "", "", errors.Wrapf(err, "[INTERNAL] Failed ref resolve from tag [repo=%s,ref=%s]", rcfg.URI, tagGuess)
 			}
-		} else if err == plumbing.ErrObjectNotFound {
-			log.Printf("tag heuristic ref not found in repo")
-		} else {
-			return "", "", errors.Wrapf(err, "[INTERNAL] Failed ref resolve from tag [repo=%s,ref=%s]", rcfg.URI, tagGuess)
 		}
 		log.Printf("ref heuristic tag not found in repo")
 		fallthrough
@@ -187,7 +189,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 		log.Printf("ref heuristic git log not found in repo")
 		fallthrough
 	default:
-		if cargoVCSGuess == "" && tagGuess == "" && cargoTOMLGuess == "" {
+		if cargoVCSGuess == "" && len(tagGuesses) == 0 && cargoTOMLGuess == "" {
 			return "", "", errors.Errorf("no git ref")
 		}
 		return "", "", errors.Errorf("no valid git ref")

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -75,6 +75,47 @@ edition = "2021"
 	}
 }
 
+func TestInferRefAndDirTriesAllMatchingTags(t *testing.T) {
+	// Both tags have the same rank, so lexical order puts the unrelated tag first.
+	repo := must(gitxtest.CreateRepoFromYAML(`commits:
+  - id: unrelated-tag
+    tag: 1.0.150
+    files:
+      Cargo.toml: |
+        [package]
+        name = "other"
+        version = "1.0.150"
+  - id: matching-tag
+    parent: unrelated-tag
+    tag: v1.0.150
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+`, nil))
+	crate := must(archivetest.TgzFile([]archive.TarEntry{
+		{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}},
+	}))
+	crateBytes := must(io.ReadAll(crate))
+
+	ref, dir, err := inferRefAndDir(
+		rebuild.Target{Package: "serde", Version: "1.0.150"},
+		&cratesio.CrateVersion{Version: cratesio.Version{Version: "1.0.150"}},
+		crateBytes,
+		&rebuild.RepoConfig{Repository: repo.Repository},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := repo.Commits["matching-tag"].String(); ref != want {
+		t.Errorf("inferRefAndDir() ref = %q, want %q", ref, want)
+	}
+	if dir != "" {
+		t.Errorf("inferRefAndDir() dir = %q, want empty", dir)
+	}
+}
+
 func TestInferStrategy(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -74,6 +74,46 @@ edition = "2021"
 	}
 }
 
+func TestInferRefAndDirTriesAllMatchingTags(t *testing.T) {
+	repo := must(gitxtest.CreateRepoFromYAML(`commits:
+  - id: unrelated-tag
+    tag: archive/v1.0.150
+    files:
+      Cargo.toml: |
+        [package]
+        name = "other"
+        version = "1.0.150"
+  - id: matching-tag
+    parent: unrelated-tag
+    tag: serde/v1.0.150
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+`, nil))
+	crate := must(archivetest.TgzFile([]archive.TarEntry{
+		{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}},
+	}))
+	crateBytes := must(io.ReadAll(crate))
+
+	ref, dir, err := inferRefAndDir(
+		rebuild.Target{Package: "serde", Version: "1.0.150"},
+		&cratesio.CrateVersion{Version: cratesio.Version{Version: "1.0.150"}},
+		crateBytes,
+		&rebuild.RepoConfig{Repository: repo.Repository},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := repo.Commits["matching-tag"].String(); ref != want {
+		t.Errorf("inferRefAndDir() ref = %q, want %q", ref, want)
+	}
+	if dir != "" {
+		t.Errorf("inferRefAndDir() dir = %q, want empty", dir)
+	}
+}
+
 func TestInferStrategy(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/pkg/rebuild/rebuild/git.go
+++ b/pkg/rebuild/rebuild/git.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -43,6 +44,54 @@ func MatchTag(tag, pkg, version string) (strict bool, approx bool) {
 	return
 }
 
+// tagAliases provides probable tag names for pkg accounting for e.g. npm @scope/, Maven group:artifact.
+func tagAliases(pkg string) []string {
+	aliases := []string{strings.ToLower(pkg)}
+	if i := strings.LastIndexAny(pkg, "/:"); i >= 0 && i+1 < len(pkg) {
+		aliases = append(aliases, strings.ToLower(pkg[i+1:]))
+	}
+	if t, ok := strings.CutPrefix(pkg, "@"); ok {
+		aliases = append(aliases, strings.ToLower(t))
+	}
+	return aliases
+}
+
+// tagResidue is what a tag contains besides the version.
+func tagResidue(tag, version string) string {
+	before, after, found := strings.Cut(tag, version)
+	if !found {
+		return strings.ToLower(tag)
+	}
+	r := strings.ToLower(strings.Trim(before+after, "-_/.@"))
+	return strings.Trim(strings.TrimSuffix(r, "v"), "-_/.@")
+}
+
+// tagRank measures how strongly a tag appears to relate to this package's release.
+func tagRank(tag, version string, aliases []string) int {
+	residue := tagResidue(tag, version)
+	if slices.Contains(aliases, residue) {
+		return 0 // contains package name alias AND version
+	}
+	if residue == "" {
+		return 1 // version alone. correct when the repo holds one package
+	}
+	for _, a := range aliases {
+		if strings.Contains(residue, a) || strings.Contains(a, residue) {
+			return 2 // partial alias match. correct when e.g. monorepo uses lang tag prefix like py-<pkg>-v<version>
+		}
+	}
+	return 3 // names something else
+}
+
+// sortTagMatches orders candidates by tagRank.
+func sortTagMatches(matches []string, pkg, version string) {
+	aliases := tagAliases(pkg)
+	sort.Strings(matches)
+	sort.SliceStable(matches, func(i, j int) bool {
+		return tagRank(matches[i], version, aliases) < tagRank(matches[j], version, aliases)
+	})
+}
+
 // FindTagMatch searches a repositories tags for a possible version match and returns the commit hash.
 func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err error) {
 	var matches, nearMatches []string
@@ -62,7 +111,7 @@ func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err
 		log.Printf("Rejected potential matches [pkg=%s,ver=%s,matches=%v]\n", pkg, version, nearMatches)
 	}
 	if len(matches) > 0 {
-		sort.Strings(matches)
+		sortTagMatches(matches, pkg, version)
 		if len(matches) > 1 {
 			log.Printf("Multiple tag matches [pkg=%s,ver=%s,matches=%v]\n", pkg, version, matches)
 		}

--- a/pkg/rebuild/rebuild/git.go
+++ b/pkg/rebuild/rebuild/git.go
@@ -92,12 +92,11 @@ func sortTagMatches(matches []string, pkg, version string) {
 	})
 }
 
-// FindTagMatch searches a repositories tags for a possible version match and returns the commit hash.
-func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err error) {
-	var matches, nearMatches []string
+func matchingTags(pkg, version string, repo *git.Repository) (matches []string, err error) {
+	var nearMatches []string
 	tags, err := allTags(repo)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	for _, tag := range tags {
 		strict, approx := MatchTag(tag, pkg, version)
@@ -115,17 +114,47 @@ func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err
 		if len(matches) > 1 {
 			log.Printf("Multiple tag matches [pkg=%s,ver=%s,matches=%v]\n", pkg, version, matches)
 		}
-		ref, err := repo.Tag(matches[0])
+	}
+	return matches, nil
+}
+
+func resolveTagMatch(match string, repo *git.Repository) (string, error) {
+	ref, err := repo.Tag(match)
+	if err != nil {
+		return "", err
+	}
+	if t, err := repo.TagObject(ref.Hash()); err == nil {
+		// Annotated tag. Use the Target pointer as the ref hash.
+		return t.Target.String(), nil
+	}
+	// Lightweight tag. Use the ref hash itself.
+	return ref.Hash().String(), nil
+}
+
+// FindTagMatches searches a repository's tags for possible version matches and returns their commit hashes.
+func FindTagMatches(pkg, version string, repo *git.Repository) (commits []string, err error) {
+	matches, err := matchingTags(pkg, version, repo)
+	if err != nil {
+		return nil, err
+	}
+	for _, match := range matches {
+		commit, err := resolveTagMatch(match, repo)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		if t, err := repo.TagObject(ref.Hash()); err == nil {
-			// Annotated tag. Use the Target pointer as the ref hash.
-			return t.Target.String(), nil
-		} else {
-			// Lightweight tag. Use the ref hash itself.
-			return ref.Hash().String(), nil
-		}
+		commits = append(commits, commit)
+	}
+	return commits, nil
+}
+
+// FindTagMatch searches a repository's tags for a possible version match and returns the first commit hash.
+func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err error) {
+	matches, err := matchingTags(pkg, version, repo)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) > 0 {
+		return resolveTagMatch(matches[0], repo)
 	}
 	return "", nil
 }

--- a/pkg/rebuild/rebuild/git.go
+++ b/pkg/rebuild/rebuild/git.go
@@ -42,12 +42,12 @@ func MatchTag(tag, pkg, version string) (strict bool, approx bool) {
 	return
 }
 
-// FindTagMatch searches a repositories tags for a possible version match and returns the commit hash.
-func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err error) {
+// FindTagMatches searches a repository's tags for possible version matches and returns their commit hashes.
+func FindTagMatches(pkg, version string, repo *git.Repository) (commits []string, err error) {
 	var matches, nearMatches []string
 	tags, err := allTags(repo)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	for _, tag := range tags {
 		strict, approx := MatchTag(tag, pkg, version)
@@ -65,17 +65,31 @@ func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err
 		if len(matches) > 1 {
 			log.Printf("Multiple tag matches [pkg=%s,ver=%s,matches=%v]\n", pkg, version, matches)
 		}
-		ref, err := repo.Tag(matches[0])
+	}
+	for _, match := range matches {
+		ref, err := repo.Tag(match)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		if t, err := repo.TagObject(ref.Hash()); err == nil {
 			// Annotated tag. Use the Target pointer as the ref hash.
-			return t.Target.String(), nil
+			commits = append(commits, t.Target.String())
 		} else {
 			// Lightweight tag. Use the ref hash itself.
-			return ref.Hash().String(), nil
+			commits = append(commits, ref.Hash().String())
 		}
+	}
+	return commits, nil
+}
+
+// FindTagMatch searches a repository's tags for a possible version match and returns the first commit hash.
+func FindTagMatch(pkg, version string, repo *git.Repository) (commit string, err error) {
+	commits, err := FindTagMatches(pkg, version, repo)
+	if err != nil {
+		return "", err
+	}
+	if len(commits) > 0 {
+		return commits[0], nil
 	}
 	return "", nil
 }

--- a/pkg/rebuild/rebuild/git_test.go
+++ b/pkg/rebuild/rebuild/git_test.go
@@ -4,6 +4,7 @@
 package rebuild
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/go-git/go-billy/v5/memfs"
@@ -43,6 +44,76 @@ func TestMatchTag(t *testing.T) {
 			strict, approx := MatchTag(tt.tag, tt.pkg, tt.version)
 			if strict != tt.strict || approx != tt.approx {
 				t.Errorf("MatchTag(%q, %q, %q) = (%v, %v), want (%v, %v)", tt.tag, tt.pkg, tt.version, strict, approx, tt.strict, tt.approx)
+			}
+		})
+	}
+}
+
+func TestSortTagMatches(t *testing.T) {
+	tests := []struct {
+		name    string
+		matches []string
+		pkg     string
+		version string
+		want    []string
+	}{
+		{
+			name:    "package tag beats sibling and repo tag",
+			matches: []string{"0.2.0", "grep-0.2.0", "grep-printer-0.2.0"},
+			pkg:     "grep",
+			version: "0.2.0",
+			want:    []string{"grep-0.2.0", "0.2.0", "grep-printer-0.2.0"},
+		},
+		{
+			name:    "repo tag beats an unrelated sibling",
+			matches: []string{"aaa-v1.0.0", "v1.0.0"},
+			pkg:     "mypackage",
+			version: "1.0.0",
+			want:    []string{"v1.0.0", "aaa-v1.0.0"},
+		},
+		{
+			name:    "scoped npm name matches an unscoped tag",
+			matches: []string{"babel-types@7.0.0", "core@7.0.0", "v7.0.0"},
+			pkg:     "@babel/core",
+			version: "7.0.0",
+			want:    []string{"core@7.0.0", "v7.0.0", "babel-types@7.0.0"},
+		},
+		{
+			name:    "maven coordinate matches the artifact tag",
+			matches: []string{"guava-33.0.0", "other-33.0.0"},
+			pkg:     "com.google.guava:guava",
+			version: "33.0.0",
+			want:    []string{"guava-33.0.0", "other-33.0.0"},
+		},
+		{
+			name:    "decorated package name beats a sibling",
+			matches: []string{"python-mypkg-langchain-v1.0.0", "python-mypkg-openai-v1.0.0"},
+			pkg:     "mypkg-openai",
+			version: "1.0.0",
+			want:    []string{"python-mypkg-openai-v1.0.0", "python-mypkg-langchain-v1.0.0"},
+		},
+		{
+			name:    "unranked tags keep lexicographic order",
+			matches: []string{"zzz-1.0.0", "aaa-1.0.0"},
+			pkg:     "mypackage",
+			version: "1.0.0",
+			want:    []string{"aaa-1.0.0", "zzz-1.0.0"},
+		},
+		{
+			name:    "separator and v-prefix variants all read as the package name",
+			matches: []string{"unrelated-1.0.0", "mypackage/v1.0.0"},
+			pkg:     "mypackage",
+			version: "1.0.0",
+			want:    []string{"mypackage/v1.0.0", "unrelated-1.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slices.Clone(tt.matches)
+			sortTagMatches(got, tt.pkg, tt.version)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("sortTagMatches(%v, %q, %q) diff (-want +got):\n%s", tt.matches, tt.pkg, tt.version, diff)
 			}
 		})
 	}

--- a/pkg/rebuild/rebuild/git_test.go
+++ b/pkg/rebuild/rebuild/git_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -155,6 +156,38 @@ func TestFindTagMatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindTagMatchOnlyResolvesFirstMatch(t *testing.T) {
+	storer := &failingTagStorage{Storer: memory.NewStorage()}
+	repo := must(git.Init(storer, memfs.New()))
+	commit := createCommit(repo, "commit")
+	createLightweightTag(repo, "mypackage-1.0.0", commit)
+	createLightweightTag(repo, "zzz-1.0.0", commit)
+	storer.fail = plumbing.NewTagReferenceName("zzz-1.0.0")
+
+	got, err := FindTagMatch("mypackage", "1.0.0", repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != commit {
+		t.Errorf("FindTagMatch() = %q, want %q", got, commit)
+	}
+	if _, err := FindTagMatches("mypackage", "1.0.0", repo); err == nil {
+		t.Error("FindTagMatches() error = nil")
+	}
+}
+
+type failingTagStorage struct {
+	storage.Storer
+	fail plumbing.ReferenceName
+}
+
+func (s *failingTagStorage) Reference(name plumbing.ReferenceName) (*plumbing.Reference, error) {
+	if name == s.fail {
+		return nil, plumbing.ErrReferenceNotFound
+	}
+	return s.Storer.Reference(name)
 }
 
 func TestAllTags(t *testing.T) {


### PR DESCRIPTION
> Parents: [#1424](https://redirect.github.com/google/oss-rebuild/pull/1424)

#1424 ranks matching tags, but crates.io inference still validates only the first candidate. When that tag belongs to another package in the same repository, a later candidate can be valid.

Use #1424's ranking, then validate each ranked candidate until one contains the requested package and version. Existing callers of `FindTagMatch` keep the current first-match behavior.

Testing:
- `go test ./...`
- `go vet ./...`
- Replayed 1,605 affected crates.io versions: #1424's top-ranked candidate recovered 1,257/1,605; validating later candidates recovered 1,605/1,605.
