### PR TITLE
Use path_in_vcs during crates.io inference

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -129,13 +129,17 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 		cargoVCSGuess = info.GitInfo.SHA1
 	}
 	dir = rcfg.Dir
+	vcsDir := dir
+	if info.Dir != nil {
+		vcsDir = *info.Dir
+	}
 	var c *object.Commit
 	switch {
 	// Ensure the package config has the expected name and version.
 	case cargoVCSGuess != "":
 		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(cargoVCSGuess))
 		if err == nil {
-			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, dir); err != nil {
+			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, vcsDir); err != nil {
 				log.Printf("registry ref invalid: %v", err)
 			} else {
 				log.Printf("using registry ref: %s", cargoVCSGuess[:9])

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -123,6 +123,38 @@ func TestInferStrategy(t *testing.T) {
 			},
 		},
 		{
+			name: "path from cargo_vcs_info",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      published/Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-01-01T00:00:00Z","rust_version": "1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"},"path_in_vcs":"published"}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+						Dir:  "published",
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
 			name: "rust_version from created_at",
 			repo: `commits:
   - id: initial-commit

--- a/pkg/registry/cratesio/cargo.go
+++ b/pkg/registry/cratesio/cargo.go
@@ -8,7 +8,7 @@ package cratesio
 // Format: https://doc.rust-lang.org/cargo/commands/cargo-package.html#cargo_vcs_infojson-format
 type CargoVCSInfo struct {
 	GitInfo `json:"git"`
-	Dir     string `json:"path_in_vcs"`
+	Dir     *string `json:"path_in_vcs"`
 }
 
 // GitInfo is the Git metadata included in the .cargo_vcs_info.json file.


### PR DESCRIPTION
`.cargo_vcs_info.json` records both the commit and the package's repository-relative path. Inference currently uses the commit but ignores the path. If a commit contains more than one manifest with the requested package name and version, it can select the wrong directory.

Use `path_in_vcs` as the first directory checked for the recorded commit. Artifacts that do not contain this field keep the existing directory, and the current manifest search remains the fallback.

Testing:
- `go test ./...`
- `go vet ./...`
- Replayed 172 affected published versions: the packaged path was selected in 0/172 before and 172/172 after
- Replayed 5,000 unaffected published versions: 5,000/5,000 remained correct