### PR TITLE
Use path_in_vcs for crates.io ref fallbacks

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -129,13 +129,17 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 		cargoVCSGuess = info.GitInfo.SHA1
 	}
 	dir = rcfg.Dir
+	vcsDir := dir
+	if info.Dir != nil {
+		vcsDir = *info.Dir
+	}
 	var c *object.Commit
 	switch {
 	// Ensure the package config has the expected name and version.
 	case cargoVCSGuess != "":
 		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(cargoVCSGuess))
 		if err == nil {
-			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, dir); err != nil {
+			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, vcsDir); err != nil {
 				log.Printf("registry ref invalid: %v", err)
 			} else {
 				log.Printf("using registry ref: %s", cargoVCSGuess[:9])

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -157,7 +157,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 	case tagGuess != "":
 		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(tagGuess))
 		if err == nil {
-			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, dir); err != nil {
+			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, vcsDir); err != nil {
 				log.Printf("registry heuristic tag invalid: %v", err)
 			} else {
 				log.Printf("using tag heuristic ref: %s", tagGuess[:9])
@@ -175,7 +175,7 @@ func inferRefAndDir(t rebuild.Target, vmeta *reg.CrateVersion, crateBytes []byte
 	case cargoTOMLGuess != "":
 		c, err = rcfg.Repository.CommitObject(plumbing.NewHash(cargoTOMLGuess))
 		if err == nil {
-			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, dir); err != nil {
+			if newPath, err := findAndValidateCargoTOML(rcfg.Repository, c, t.Package, t.Version, vcsDir); err != nil {
 				log.Printf("registry heuristic git log invalid: %v", err)
 			} else {
 				log.Printf("using git log heuristic ref: %s", cargoTOMLGuess[:9])

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"path"
@@ -864,6 +865,58 @@ version = 3
 				if diff := cmp.Diff(want, s); diff != "" {
 					t.Errorf("InferStrategy mismatch (-want +got):\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestInferRefAndDirUsesVCSPathForFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		tag    string
+		refMap bool
+	}{
+		{name: "tag", tag: "v1.0.150"},
+		{name: "Cargo.toml history", refMap: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := must(gitxtest.CreateRepoFromYAML(fmt.Sprintf(`commits:
+  - id: release
+    tag: %s
+    files:
+      current/Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      published/Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+`, tc.tag), nil))
+			refMap := map[string]string{}
+			if tc.refMap {
+				refMap["1.0.150"] = repo.Commits["release"].String()
+			}
+			crate := must(archivetest.TgzFile([]archive.TarEntry{
+				{
+					Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"},
+					Body:   []byte(`{"git":{"sha1":"0000000000000000000000000000000000000000"},"path_in_vcs":"published"}`),
+				},
+			}))
+			ref, dir, err := inferRefAndDir(
+				rebuild.Target{Package: "serde", Version: "1.0.150"},
+				&cratesio.CrateVersion{Version: cratesio.Version{Version: "1.0.150"}},
+				crate.Bytes(),
+				&rebuild.RepoConfig{Repository: repo.Repository, Dir: "current", RefMap: refMap},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := repo.Commits["release"].String(); ref != want {
+				t.Errorf("ref = %q, want %q", ref, want)
+			}
+			if want := "published"; dir != want {
+				t.Errorf("dir = %q, want %q", dir, want)
 			}
 		})
 	}

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -123,6 +123,38 @@ func TestInferStrategy(t *testing.T) {
 			},
 		},
 		{
+			name: "path from cargo_vcs_info",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      published/Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-01-01T00:00:00Z","rust_version": "1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"},"path_in_vcs":"published"}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+						Dir:  "published",
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
 			name: "rust_version from created_at",
 			repo: `commits:
   - id: initial-commit

--- a/pkg/registry/cratesio/cargo.go
+++ b/pkg/registry/cratesio/cargo.go
@@ -8,7 +8,7 @@ package cratesio
 // Format: https://doc.rust-lang.org/cargo/commands/cargo-package.html#cargo_vcs_infojson-format
 type CargoVCSInfo struct {
 	GitInfo `json:"git"`
-	Dir     string `json:"path_in_vcs"`
+	Dir     *string `json:"path_in_vcs"`
 }
 
 // GitInfo is the Git metadata included in the .cargo_vcs_info.json file.


### PR DESCRIPTION
Parents: #1417

When the VCS commit is unavailable, the tag and Cargo.toml history fallbacks still validate from the directory inferred at repository HEAD. In repositories with multiple matching package manifests, this can select a different package from the one recorded in the published crate.

Use `path_in_vcs` as the initial path for both fallbacks. `findAndValidateCargoTOML` retains the existing repository-wide search when that path is stale.

Testing:
- `go test ./...`
- `go vet ./...`