### PR TITLE
Fix Rust version expectation broken by concurrent merges

### DIFF
--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -151,7 +151,7 @@ func TestInferStrategy(t *testing.T) {
 						Ref:  repo.Commits["version-bump"].String(),
 						Dir:  "published",
 					},
-					RustVersion: "1.64.0",
+					RustVersion: "1.57.0",
 				}
 			},
 		},


### PR DESCRIPTION
#1360 was merged without syncing after #1417 both of which impacted the
version bound of one of the tests. This updates that test's value.