### PR TITLE
Write the legacy Cargo config name for toolchains before 1.39

### DIFF
--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -57,6 +57,7 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 					"registryCommit": b.RegistryCommit,
 					"packageNames":   strings.Join(b.PackageNames, ","),
 					"useGitIndex":    fmt.Sprintf("%t", len(b.PackageNames) > 0),
+					"rustVersion":    b.RustVersion,
 				},
 			},
 		},
@@ -107,14 +108,15 @@ var toolkit = []*flow.Tool{
 		Name: "cargo/setup-registry",
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
-				{{if and (eq .With.useGitIndex "true") (ne .TimewarpHost "") (ne .With.registryCommit "") -}}
+				{{- $cfg := "config"}}{{if ge (cmpSemver .With.rustVersion "1.39.0") 0}}{{$cfg = "config.toml"}}{{end}}
+				{{- if and (eq .With.useGitIndex "true") (ne .TimewarpHost "") (ne .With.registryCommit "") -}}
 				mkdir -p /cargo-index
 				wget -O - --header "X-Package-Names: {{.With.packageNames}}" "{{.BuildEnv.TimewarpURLFromString "cargogitarchive" .With.registryCommit}}index.git.tar" | tar -xf - -C /cargo-index
 				mkdir -p /.cargo
-				printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config.toml
+				printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/{{$cfg}}
 				{{- else if and (ne .TimewarpHost "") (ne .With.registryCommit "") -}}
 				mkdir -p /.cargo
-				printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "{{.BuildEnv.TimewarpURLFromString "cargosparse" .With.registryCommit}}"\n' > /.cargo/config.toml
+				printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "{{.BuildEnv.TimewarpURLFromString "cargosparse" .With.registryCommit}}"\n' > /.cargo/{{$cfg}}
 				{{- else -}}
 				# NOTE: Using current crates.io registry
 				{{- end -}}`)[1:],

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -215,6 +215,32 @@ printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-lo
 			},
 		},
 		{
+			// NOTE: Cargo reads config.toml only from 1.39.
+			"GitIndexRegistryLegacyConfigName",
+			&CratesIOCargoPackage{
+				Location:       defaultLocation,
+				RustVersion:    "1.35.0",
+				RegistryCommit: "abc1234",
+				PackageNames:   []string{"serde", "tokio"},
+			},
+			rebuild.BuildEnv{HasRepo: true, TimewarpHost: "localhost:8081"},
+			rebuild.Instructions{
+				Location: defaultLocation,
+				Source:   "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.35.0
+mkdir -p /cargo-index
+wget -O - --header "X-Package-Names: serde,tokio" "http://cargogitarchive:abc1234@localhost:8081/index.git.tar" | tar -xf - -C /cargo-index
+mkdir -p /.cargo
+printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config`,
+				Build: `export CARGO_TARGET_DIR="$PWD/target"
+(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+				Requires: rebuild.RequiredEnv{
+					SystemDeps: []string{"git", "rustup"},
+				},
+				OutputPath: "target/package/the_artifact",
+			},
+		},
+		{
 			"SparseRegistry",
 			&CratesIOCargoPackage{
 				Location:       defaultLocation,


### PR DESCRIPTION
Cargo only began reading .cargo/config.toml in 1.39, so the timewarp source
replacement was silently dropped for Rust 1.35 through 1.38 and those builds
resolved against the live crates.io index. 1.35 is the oldest release with a
MUSL build, so the whole window is reachable from inference.

The extensionless name works on every supported toolchain but newer Cargo
deprecates it, so select on the version rather than always using it.