### PR TITLE
Trim GitLab project routes by path segment

### DIFF
--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -6,6 +6,7 @@ package uri
 import (
 	"net/url"
 	re "regexp"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -21,18 +22,30 @@ var (
 		gitlabRE,
 		bitbucketRE,
 	}
+	// Project routes that directly follow the project path. GitLab has served
+	// these under the /-/ prefix since 12.0 but older links omit it.
+	// NOTE: This is non-exhaustive and should be expanded as necessary.
+	gitlabRoutes = []string{
+		"badges", "blob", "commits", "container_registry", "issues", "packages",
+		"pipelines", "raw", "releases", "tags", "tree", "uploads", "wikis",
+	}
 )
 
 var errUnsupportedRepo = errors.Errorf("unsupported repo type")
 
+// trimGitLabRoute drops any project route from a matched GitLab path.
 func trimGitLabRoute(repo string) string {
-	if repo, _, found := strings.Cut(repo, "/-/"); found {
+	if root, _, found := strings.Cut(repo, "/-/"); found {
+		return root
+	}
+	pathStart := strings.IndexAny(repo, ":/")
+	if pathStart < 0 {
 		return repo
 	}
-	if repoRoot, _, found := strings.Cut(repo, "/tree/"); found {
-		pathStart := strings.IndexAny(repoRoot, ":/")
-		if pathStart >= 0 && strings.Count(repoRoot[pathStart+1:], "/") == 1 {
-			return repoRoot
+	segments := strings.Split(repo[pathStart+1:], "/")
+	for i := 2; i < len(segments); i++ {
+		if slices.Contains(gitlabRoutes, segments[i]) {
+			return repo[:pathStart+1] + strings.Join(segments[:i], "/")
 		}
 	}
 	return repo

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -49,6 +49,22 @@ func TestFindARepo(t *testing.T) {
 			"[![b](https://img.shields.io/github/v/tag/o/r)](https://github.com/org/project)",
 			"github.com/org/project",
 		},
+		{
+			"https://gitlab.com/group/subgroup/repo/blob/main/README.md",
+			"gitlab.com/group/subgroup/repo",
+		},
+		{
+			"https://gitlab.com/group/repo/badges/main/pipeline.svg",
+			"gitlab.com/group/repo",
+		},
+		{
+			"https://gitlab.com/group/repo/issues",
+			"gitlab.com/group/repo",
+		},
+		{
+			"https://gitlab.com/group/blob/repo",
+			"gitlab.com/group/blob/repo",
+		},
 	}
 	for _, test := range tests {
 		actual := FindCommonRepo(test.input)
@@ -104,6 +120,21 @@ func TestCanonicalizeRepoURI(t *testing.T) {
 		{
 			"https://gitlab.com/group/tree/repo/-/tree/main",
 			"https://gitlab.com/group/tree/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/subgroup/repo/blob/main/README.md",
+			"https://gitlab.com/group/subgroup/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/subgroup/repo/-/blob/main/README.md",
+			"https://gitlab.com/group/subgroup/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/repo/badges/main/pipeline.svg",
+			"https://gitlab.com/group/repo",
 			false,
 		},
 	}

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -37,6 +37,22 @@ func TestFindARepo(t *testing.T) {
 			"https://gitlab.com/group/tree/repo",
 			"gitlab.com/group/tree/repo",
 		},
+		{
+			"https://gitlab.com/group/subgroup/repo/blob/main/README.md",
+			"gitlab.com/group/subgroup/repo",
+		},
+		{
+			"https://gitlab.com/group/repo/badges/main/pipeline.svg",
+			"gitlab.com/group/repo",
+		},
+		{
+			"https://gitlab.com/group/repo/issues",
+			"gitlab.com/group/repo",
+		},
+		{
+			"https://gitlab.com/group/blob/repo",
+			"gitlab.com/group/blob/repo",
+		},
 	}
 	for _, test := range tests {
 		actual := FindCommonRepo(test.input)
@@ -92,6 +108,21 @@ func TestCanonicalizeRepoURI(t *testing.T) {
 		{
 			"https://gitlab.com/group/tree/repo/-/tree/main",
 			"https://gitlab.com/group/tree/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/subgroup/repo/blob/main/README.md",
+			"https://gitlab.com/group/subgroup/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/subgroup/repo/-/blob/main/README.md",
+			"https://gitlab.com/group/subgroup/repo",
+			false,
+		},
+		{
+			"https://gitlab.com/group/repo/badges/main/pipeline.svg",
+			"https://gitlab.com/group/repo",
 			false,
 		},
 	}


### PR DESCRIPTION
The /tree/ special case only fired when exactly two segments preceded it, so
routes on subgroup projects and every other legacy route stayed in the path.
Match route names by segment position instead. Only segments past the mandatory
group/project prefix are considered, so a subgroup named for a route is
unaffected. The listed routes are the ones observed in published package
metadata; the wider set of GitLab routes never occurred.

Across 4,605 GitLab references in the crates.io corpus this trims 310 results,
most of them CI badge URLs, and changes none of the 3,522 declared repository
fields.