### PR TITLE
Require a host or shorthand separator in repo patterns

### DIFF
--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -13,9 +13,9 @@ import (
 
 var (
 	// NOTE: This is non-exhaustive and should be expanded as necessary.
-	githubRE    = re.MustCompile(`(?i)\bgithub(\.com)?[:/]([\w-]+/[\w-\.]+)`)
-	gitlabRE    = re.MustCompile(`(?i)\bgitlab(\.com)?[:/]([\w-]+(?:/[\w.-]+)+)`)
-	bitbucketRE = re.MustCompile(`(?i)\bbitbucket(\.org)?[:/]([\w-]+/[\w-\.]+)`)
+	githubRE    = re.MustCompile(`(?i)\bgithub(?:\.com[:/]|:)([\w-]+/[\w-\.]+)`)
+	gitlabRE    = re.MustCompile(`(?i)\bgitlab(?:\.com[:/]|:)([\w-]+(?:/[\w.-]+)+)`)
+	bitbucketRE = re.MustCompile(`(?i)\bbitbucket(?:\.org[:/]|:)([\w-]+/[\w-\.]+)`)
 	commonRepos = []*re.Regexp{
 		githubRE,
 		gitlabRE,

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -37,6 +37,18 @@ func TestFindARepo(t *testing.T) {
 			"https://gitlab.com/group/tree/repo",
 			"gitlab.com/group/tree/repo",
 		},
+		{
+			"https://img.shields.io/github/stars/rust-lang/rust",
+			"",
+		},
+		{
+			"https://img.shields.io/gitlab/pipeline/group/repo/main",
+			"",
+		},
+		{
+			"[![b](https://img.shields.io/github/v/tag/o/r)](https://github.com/org/project)",
+			"github.com/org/project",
+		},
 	}
 	for _, test := range tests {
 		actual := FindCommonRepo(test.input)


### PR DESCRIPTION
The optional (\.com)? group combined with a [:/] separator let a bare path
segment match, so a README mentioning .github/workflows/ci.yml resolved to
github.com/workflows/ci.yml. FindCommonRepo returns the leftmost match and
badge or workflow references usually precede the repository link, so the
wrong often repo won.

A brief survey of existing python, crates, and rubygems packages showed
predominantly improvements (dozens) with a single-digit number of
regressions so this is considered worthwhile.