### PR TITLE
Make run planner artifact world-readable like build planner

### DIFF
--- a/pkg/build/local/run_planner.go
+++ b/pkg/build/local/run_planner.go
@@ -66,6 +66,7 @@ var dockerRunPhaseTpls = template.Must(
 			{{- define "build" -}}
 			cd /src
 			{{.Inst.Build}}
+			chmod 444 /src/{{.Inst.OutputPath}}
 			cp /src/{{.Inst.OutputPath}} /out/rebuild
 			{{- end -}}
 			`),

--- a/pkg/build/local/run_planner_test.go
+++ b/pkg/build/local/run_planner_test.go
@@ -69,6 +69,7 @@ func TestDockerRunPlanner(t *testing.T) {
 				Build: textwrap.Dedent(`
 			cd /src
 			npm pack
+			chmod 444 /src/test-package-1.0.0.tgz
 			cp /src/test-package-1.0.0.tgz /out/rebuild`[1:]),
 			},
 		},
@@ -124,6 +125,7 @@ func TestDockerRunPlanner(t *testing.T) {
 				Build: textwrap.Dedent(`
 			cd /src
 			npm pack
+			chmod 444 /src/test-package-1.0.0.tgz
 			cp /src/test-package-1.0.0.tgz /out/rebuild`[1:]),
 			},
 		},
@@ -171,6 +173,7 @@ func TestDockerRunPlanner(t *testing.T) {
 				Build: textwrap.Dedent(`
 			cd /src
 			npm pack
+			chmod 444 /src/test-package-1.0.0.tgz
 			cp /src/test-package-1.0.0.tgz /out/rebuild`[1:]),
 			},
 		},


### PR DESCRIPTION
The docker build variant chmods 444 before copying out. Without the
same in the run phase script, the produced artifact can be unreadable
to the consumer.