### PR TITLE
Return untyped nil for successful operations

### DIFF
--- a/tools/benchmark/run/run.go
+++ b/tools/benchmark/run/run.go
@@ -74,7 +74,12 @@ func (s *remoteExecutionService) RebuildPackage(ctx context.Context, req schema.
 			return nil, errors.Wrap(err, "getting rebuild operation")
 		}
 	}
-	return op.Result, op.Error
+	// NOTE: A direct return of op.Error would wrap the nil *OperationError
+	// in a non-nil error interface.
+	if op.Error != nil {
+		return op.Result, op.Error
+	}
+	return op.Result, nil
 }
 
 func (s *remoteExecutionService) Infer(ctx context.Context, req schema.InferenceRequest) (*schema.StrategyOneOf, error) {

--- a/tools/ctl/command/runone/runone.go
+++ b/tools/ctl/command/runone/runone.go
@@ -345,7 +345,11 @@ func handleRemote(ctx context.Context, cfg Config, deps *Deps, enc *json.Encoder
 				return nil, errors.Wrap(err, "encoding result")
 			}
 		}
-		return nil, op.Error
+		// NOTE: A direct return of op.Error would wrap the nil
+		// *OperationError in a non-nil error interface.
+		if op.Error != nil {
+			return nil, op.Error
+		}
 	default:
 		return nil, errors.Errorf("unknown mode: %s", mode)
 	}


### PR DESCRIPTION
Returning Operation.Error directly wraps a nil *OperationError in a
non-nil error interface, so successful ops read as failures. Guard
explicitly and return a literal nil.