### PR TITLE
Record LLM token usage for agent sessions

### DIFF
--- a/internal/agent/logic.go
+++ b/internal/agent/logic.go
@@ -61,6 +61,7 @@ type defaultAgent struct {
 	thoughts    []thoughtData
 	assets      rebuild.AssetStore
 	gitTools    []*llm.FunctionDefinition
+	sideUsage   schema.TokenUsage // accumulates LLM token consumption from calls made outside the main chat
 }
 
 func NewDefaultAgent(t rebuild.Target, deps *AgentDeps) *defaultAgent {
@@ -273,12 +274,13 @@ func (a *defaultAgent) proposeInferenceWithAIAssist(ctx context.Context, initial
 		"Use the tools you have at your disposal to find the URL.",
 		"Finally, if you don't find the URL, just return an empty string.",
 	}
-	repoURL, err := llm.GenerateTextContent(ctx, a.deps.GenaiClient, llm.GeminiPro, &genai.GenerateContentConfig{
+	repoURL, usage, err := llm.GenerateTextContentWithUsage(ctx, a.deps.GenaiClient, llm.GeminiPro, &genai.GenerateContentConfig{
 		Temperature: genai.Ptr(float32(0.0)),
 		Tools: []*genai.Tool{
 			{GoogleSearch: &genai.GoogleSearch{}},
 		},
 	}, genai.NewPartFromText(strings.Join(prompt, "\n")))
+	a.addSideUsage(usage)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting AI repo hint")
 	}
@@ -651,4 +653,23 @@ func (a *defaultAgent) Propose(ctx context.Context, opts *ProposeOpts) (*schema.
 
 func (a *defaultAgent) RecordIteration(i *schema.AgentIteration) {
 	a.iterHistory = append(a.iterHistory, i)
+}
+
+// addSideUsage attributes the token usage of an LLM call made outside the main
+// chat to the agent's running total.
+func (a *defaultAgent) addSideUsage(m *genai.GenerateContentResponseUsageMetadata) {
+	if m == nil {
+		return
+	}
+	a.sideUsage = a.sideUsage.Add(tokenUsageFromMetadata(m, llm.GeminiPro))
+}
+
+// Usage returns the agent's cumulative LLM token consumption: the main chat's
+// tally plus side calls made outside it.
+func (a *defaultAgent) Usage() schema.TokenUsage {
+	u := a.sideUsage
+	if a.deps != nil && a.deps.Chat != nil {
+		u = u.Add(sumTokenUsage(a.deps.Chat.Usage(), a.deps.Chat.Model()))
+	}
+	return u
 }

--- a/internal/agent/logic.go
+++ b/internal/agent/logic.go
@@ -61,17 +61,7 @@ type defaultAgent struct {
 	thoughts    []thoughtData
 	assets      rebuild.AssetStore
 	gitTools    []*llm.FunctionDefinition
-	oobTokens   int64 // tokens spent on out-of-band model invocations
-}
-
-// TotalTokens returns the agent's full LLM token spend. This includes the main
-// chat as well as any out-of-band model invocations.
-func (a *defaultAgent) TotalTokens() int64 {
-	total := a.oobTokens
-	if a.deps != nil && a.deps.Chat != nil {
-		total += a.deps.Chat.TotalTokens()
-	}
-	return total
+	sideUsage   schema.TokenUsage // accumulates LLM token consumption from calls made outside the main chat
 }
 
 func NewDefaultAgent(t rebuild.Target, deps *AgentDeps) *defaultAgent {
@@ -290,7 +280,7 @@ func (a *defaultAgent) proposeInferenceWithAIAssist(ctx context.Context, initial
 			{GoogleSearch: &genai.GoogleSearch{}},
 		},
 	}, genai.NewPartFromText(strings.Join(prompt, "\n")))
-	a.oobTokens += llm.SumTokens([]*genai.GenerateContentResponseUsageMetadata{usage})
+	a.addSideUsage(usage)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting AI repo hint")
 	}
@@ -663,4 +653,23 @@ func (a *defaultAgent) Propose(ctx context.Context, opts *ProposeOpts) (*schema.
 
 func (a *defaultAgent) RecordIteration(i *schema.AgentIteration) {
 	a.iterHistory = append(a.iterHistory, i)
+}
+
+// addSideUsage attributes the token usage of an LLM call made outside the main
+// chat to the agent's running total.
+func (a *defaultAgent) addSideUsage(m *genai.GenerateContentResponseUsageMetadata) {
+	if m == nil {
+		return
+	}
+	a.sideUsage = a.sideUsage.Add(tokenUsageFromMetadata(m, llm.GeminiPro))
+}
+
+// Usage returns the agent's cumulative LLM token consumption: the main chat's
+// tally plus side calls made outside it.
+func (a *defaultAgent) Usage() schema.TokenUsage {
+	u := a.sideUsage
+	if a.deps != nil && a.deps.Chat != nil {
+		u = u.Add(sumTokenUsage(a.deps.Chat.Usage(), a.deps.Chat.Model()))
+	}
+	return u
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -40,6 +40,8 @@ type ProposeOpts struct {
 type Agent interface {
 	Propose(context.Context, *ProposeOpts) (*schema.StrategyOneOf, error)
 	RecordIteration(*schema.AgentIteration)
+	// Usage returns the agent's cumulative LLM token consumption so far.
+	Usage() schema.TokenUsage
 }
 
 type RunSessionReq struct {
@@ -71,10 +73,14 @@ func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent
 			Path:   path.Join(sessionID, "messages", fmt.Sprintf("%d", iterNum)),
 		}
 	}
+	// Snapshot the agent's cumulative token usage around Propose so this
+	// iteration is charged only the tokens it consumed.
+	beforeUsage := agent.Usage()
 	s, err := agent.Propose(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating strategy")
 	}
+	iterUsage := agent.Usage().Sub(beforeUsage).OrNil()
 	// Scratch-mode attempts run locally on the session's scratch VM and are
 	// not recorded server-side (the scratch exec ledger is their trail).
 	// Only a locally-verified success proceeds to the standard iteration
@@ -85,12 +91,16 @@ func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent
 		status, result := deps.ScratchRunner.Run(ctx, fmt.Sprintf("iter-%d", iterNum), s)
 		if status != schema.AgentIterationStatusSuccess {
 			now := time.Now().UTC()
+			// This local-only record is never persisted. The session total
+			// accounts for its tokens and the usage stamp is only for local
+			// visibility.
 			return &schema.AgentIteration{
 				SessionID: sessionID,
 				Number:    iterNum,
 				Strategy:  s,
 				Status:    status,
 				Result:    result,
+				Usage:     iterUsage,
 				Created:   now,
 				Updated:   now,
 			}, nil
@@ -107,6 +117,7 @@ func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent
 		SessionID:       sessionID,
 		IterationNumber: iterNum,
 		Strategy:        s,
+		Usage:           iterUsage,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "executing build")
@@ -116,7 +127,7 @@ func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent
 	return resp.Iteration, nil
 }
 
-func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) *schema.AgentCompleteRequest {
+func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (completeReq *schema.AgentCompleteRequest) {
 	if req.MaxIterations <= 0 {
 		return &schema.AgentCompleteRequest{
 			StopReason: schema.AgentCompleteReasonError,
@@ -142,6 +153,15 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) *sch
 		RegistryClient: deps.RegistryClient,
 		ScratchRunner:  deps.ScratchRunner,
 	})
+	// Attach the session's total token consumption (both GCB and scratch mode,
+	// including side calls) to whatever completion request we return. Iteration
+	// records only exist for GCB-mode sessions, so completion is the one place
+	// every session reports its total.
+	defer func() {
+		if completeReq != nil {
+			completeReq.Usage = a.Usage().OrNil()
+		}
+	}()
 	var err error
 	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, llm.GeminiPro, config, &llm.ChatOpts{Tools: a.getTools()})
 	if err != nil {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -41,6 +41,7 @@ type ProposeOpts struct {
 type Agent interface {
 	Propose(context.Context, *ProposeOpts) (*schema.StrategyOneOf, error)
 	RecordIteration(*schema.AgentIteration)
+	Usage() schema.TokenUsage // agent's cumulative LLM token consumption
 }
 
 type RunSessionReq struct {
@@ -73,10 +74,14 @@ func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent
 			Path:   path.Join(sessionID, "messages", fmt.Sprintf("%d", iterNum)),
 		}
 	}
+	// Snapshot the agent's cumulative token usage around Propose so this
+	// iteration is charged only the tokens it consumed.
+	beforeUsage := agent.Usage()
 	s, err := agent.Propose(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating strategy")
 	}
+	iterUsage := agent.Usage().Sub(beforeUsage).OrNil()
 	// Scratch-mode attempts run locally on the session's scratch VM and are
 	// not recorded server-side (the scratch exec ledger is their trail).
 	// Only a locally-verified success proceeds to the standard iteration
@@ -87,12 +92,16 @@ func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent
 		status, result := deps.ScratchRunner.Run(ctx, fmt.Sprintf("iter-%d", iterNum), s)
 		if status != schema.AgentIterationStatusSuccess {
 			now := time.Now().UTC()
+			// This local-only record is never persisted. The session total
+			// accounts for its tokens and the usage stamp is only for local
+			// visibility.
 			return &schema.AgentIteration{
 				SessionID: sessionID,
 				Number:    iterNum,
 				Strategy:  s,
 				Status:    status,
 				Result:    result,
+				Usage:     iterUsage,
 				Created:   now,
 				Updated:   now,
 			}, nil
@@ -109,6 +118,7 @@ func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent
 		SessionID:       sessionID,
 		IterationNumber: iterNum,
 		Strategy:        s,
+		Usage:           iterUsage,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "executing build")
@@ -144,6 +154,12 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (com
 		RegistryClient: deps.RegistryClient,
 		ScratchRunner:  deps.ScratchRunner,
 	})
+	// Stamp the session's LLM token spend onto whatever completion we return.
+	defer func() {
+		if completeReq != nil {
+			completeReq.Usage = a.Usage().OrNil()
+		}
+	}()
 	var err error
 	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, llm.GeminiPro, config, &llm.ChatOpts{Tools: a.getTools(), Retrier: deps.Retrier})
 	if err != nil {
@@ -162,12 +178,6 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (com
 		}
 		iterNum = 1
 	}
-	// Stamp the session's LLM token spend onto whatever completion we return.
-	defer func() {
-		if completeReq != nil {
-			completeReq.TotalTokens = a.TotalTokens()
-		}
-	}()
 	var transientErrs, buildAttempts int // tracks whether model made real progress or was throttled
 	for {
 		iterNum++

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -22,13 +22,20 @@ import (
 
 type fakeAgent struct {
 	strategy *schema.StrategyOneOf
+	// usage is the cumulative usage reported by Usage. When proposeUsage is
+	// non-zero, usage advances by it on each Propose to emulate token spend.
+	usage        schema.TokenUsage
+	proposeUsage schema.TokenUsage
 }
 
 func (a *fakeAgent) Propose(context.Context, *ProposeOpts) (*schema.StrategyOneOf, error) {
+	a.usage = a.usage.Add(a.proposeUsage)
 	return a.strategy, nil
 }
 
 func (a *fakeAgent) RecordIteration(*schema.AgentIteration) {}
+
+func (a *fakeAgent) Usage() schema.TokenUsage { return a.usage }
 
 func TestDoIterationScratchFailureIsLocalOnly(t *testing.T) {
 	runner := testRunner(&fakeExecutor{result: build.Result{Error: &scratch.ExitError{Code: 7}}})
@@ -58,6 +65,36 @@ func TestDoIterationScratchFailureIsLocalOnly(t *testing.T) {
 	}
 	if iter.Result == nil || !strings.Contains(iter.Result.ErrorMessage, "exit code 7") {
 		t.Errorf("Result = %+v, want exit code message", iter.Result)
+	}
+}
+
+// TestDoIterationAttachesUsageDelta verifies that a GCB-mode iteration charges
+// the request only the tokens consumed by its own Propose, computed as the
+// delta of the agent's cumulative usage.
+func TestDoIterationAttachesUsageDelta(t *testing.T) {
+	strategy := testStrategy()
+	agent := &fakeAgent{
+		strategy: strategy,
+		// Pretend a prior iteration already spent some tokens.
+		usage:        schema.TokenUsage{Input: 100, Model: "m"},
+		proposeUsage: schema.TokenUsage{Input: 10, Output: 5, Model: "m"},
+	}
+	var got *schema.AgentCreateIterationRequest
+	deps := RunSessionDeps{
+		IterationStub: func(_ context.Context, req schema.AgentCreateIterationRequest) (*schema.AgentCreateIterationResponse, error) {
+			got = &req
+			return &schema.AgentCreateIterationResponse{Iteration: &schema.AgentIteration{Status: schema.AgentIterationStatusFailed}}, nil
+		},
+	}
+	if _, err := doIteration(context.Background(), "sess", 2, agent, deps); err != nil {
+		t.Fatalf("doIteration: %v", err)
+	}
+	if got == nil || got.Usage == nil {
+		t.Fatalf("iteration request usage not set: %+v", got)
+	}
+	want := schema.TokenUsage{Input: 10, Output: 5, Model: "m"}
+	if *got.Usage != want {
+		t.Errorf("iteration usage = %+v, want %+v", *got.Usage, want)
 	}
 }
 

--- a/internal/agent/usage.go
+++ b/internal/agent/usage.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/genai"
+)
+
+// tokenUsageFromMetadata converts a genai usage-metadata record into a
+// schema.TokenUsage labeled with the model that produced it.
+func tokenUsageFromMetadata(m *genai.GenerateContentResponseUsageMetadata, model string) schema.TokenUsage {
+	if m == nil {
+		return schema.TokenUsage{Model: model}
+	}
+	return schema.TokenUsage{
+		Input:       int(m.PromptTokenCount) + int(m.ToolUsePromptTokenCount),
+		CachedInput: int(m.CachedContentTokenCount),
+		Output:      int(m.CandidatesTokenCount) + int(m.ThoughtsTokenCount),
+		Model:       model,
+	}
+}
+
+// sumTokenUsage sums a slice of genai usage-metadata records (as accumulated by
+// llm.Chat.Usage) into a single schema.TokenUsage labeled with model.
+func sumTokenUsage(ms []*genai.GenerateContentResponseUsageMetadata, model string) schema.TokenUsage {
+	total := schema.TokenUsage{Model: model}
+	for _, m := range ms {
+		total = total.Add(tokenUsageFromMetadata(m, model))
+	}
+	return total
+}

--- a/internal/agent/usage_test.go
+++ b/internal/agent/usage_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/genai"
+)
+
+func TestTokenUsageFromMetadata(t *testing.T) {
+	got := tokenUsageFromMetadata(&genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        11,
+		ToolUsePromptTokenCount: 5,
+		CandidatesTokenCount:    22,
+		ThoughtsTokenCount:      33,
+		CachedContentTokenCount: 4,
+	}, "gemini-2.5-pro")
+	want := schema.TokenUsage{
+		Input:       16,
+		CachedInput: 4,
+		Output:      55,
+		Model:       "gemini-2.5-pro",
+	}
+	if got != want {
+		t.Errorf("tokenUsageFromMetadata = %+v, want %+v", got, want)
+	}
+	// A nil record still carries the model label with zero counts.
+	if got := tokenUsageFromMetadata(nil, "m"); got != (schema.TokenUsage{Model: "m"}) {
+		t.Errorf("tokenUsageFromMetadata(nil) = %+v, want {Model: m}", got)
+	}
+}
+
+func TestSumTokenUsage(t *testing.T) {
+	got := sumTokenUsage([]*genai.GenerateContentResponseUsageMetadata{
+		{PromptTokenCount: 1, CandidatesTokenCount: 2},
+		{PromptTokenCount: 4, CandidatesTokenCount: 5, ThoughtsTokenCount: 3},
+		nil,
+	}, "m")
+	want := schema.TokenUsage{Input: 5, Output: 10, Model: "m"}
+	if got != want {
+		t.Errorf("sumTokenUsage = %+v, want %+v", got, want)
+	}
+	// An empty slice sums to a zero-count (nil-worthy) usage.
+	if got := sumTokenUsage(nil, "m"); got.OrNil() != nil {
+		t.Errorf("sumTokenUsage(nil) = %+v, want zero counts", got)
+	}
+}

--- a/internal/api/agentapiservice/complete.go
+++ b/internal/api/agentapiservice/complete.go
@@ -54,8 +54,8 @@ func AgentComplete(ctx context.Context, req schema.AgentCompleteRequest, deps *A
 		if req.Summary != "" {
 			session.Summary = req.Summary
 		}
-		if req.TotalTokens > 0 {
-			session.TotalTokens = req.TotalTokens
+		if req.Usage != nil {
+			session.Usage = req.Usage // token consumption, as tallied by the agent
 		}
 		return t.Set(sessionDoc, session)
 	})

--- a/internal/api/agentapiservice/complete.go
+++ b/internal/api/agentapiservice/complete.go
@@ -54,6 +54,9 @@ func AgentComplete(ctx context.Context, req schema.AgentCompleteRequest, deps *A
 		if req.Summary != "" {
 			session.Summary = req.Summary
 		}
+		if req.Usage != nil {
+			session.Usage = req.Usage // token consumption, as tallied by the agent
+		}
 		return t.Set(sessionDoc, session)
 	})
 	if err != nil {

--- a/internal/api/agentapiservice/iteration.go
+++ b/internal/api/agentapiservice/iteration.go
@@ -79,6 +79,7 @@ func AgentCreateIteration(ctx context.Context, req schema.AgentCreateIterationRe
 			Strategy:    req.Strategy,
 			ObliviousID: obliviousID,
 			Status:      schema.AgentIterationStatusPending,
+			Usage:       req.Usage, // preserved across the status updates below
 			Created:     iterTime,
 			Updated:     iterTime,
 		}

--- a/internal/api/agentapiservice/iteration.go
+++ b/internal/api/agentapiservice/iteration.go
@@ -79,6 +79,7 @@ func AgentCreateIteration(ctx context.Context, req schema.AgentCreateIterationRe
 			Strategy:    req.Strategy,
 			ObliviousID: obliviousID,
 			Status:      schema.AgentIterationStatusPending,
+			Usage:       req.Usage, //preserved across the status updates below
 			Created:     iterTime,
 			Updated:     iterTime,
 		}

--- a/pkg/llm/chat.go
+++ b/pkg/llm/chat.go
@@ -174,3 +174,8 @@ func (cm *Chat) History() []*genai.Content {
 func (cm *Chat) Usage() []*genai.GenerateContentResponseUsageMetadata {
 	return cm.usage
 }
+
+// Model returns the model name backing this chat.
+func (cm *Chat) Model() string {
+	return cm.model
+}

--- a/pkg/llm/chat.go
+++ b/pkg/llm/chat.go
@@ -194,21 +194,7 @@ func (cm *Chat) Usage() []*genai.GenerateContentResponseUsageMetadata {
 	return cm.usage
 }
 
-// TotalTokens returns the total tokens billed across every turn of this chat.
-// Each turn's count includes the (re-sent) prompt history, matching how the
-// provider bills, so the sum is the chat's true token spend.
-func (cm *Chat) TotalTokens() int64 {
-	return SumTokens(cm.usage)
-}
-
-// SumTokens totals the TotalTokenCount across a slice of usage metadata,
-// tolerating nil entries.
-func SumTokens(usage []*genai.GenerateContentResponseUsageMetadata) int64 {
-	var total int64
-	for _, u := range usage {
-		if u != nil {
-			total += int64(u.TotalTokenCount)
-		}
-	}
-	return total
+// Model returns the model name backing this chat.
+func (cm *Chat) Model() string {
+	return cm.model
 }

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -60,28 +60,38 @@ type ScriptResponse struct {
 }
 
 func GenerateTextContent(ctx context.Context, client *genai.Client, model string, config *genai.GenerateContentConfig, prompt ...*genai.Part) (string, error) {
+	text, _, err := GenerateTextContentWithUsage(ctx, client, model, config, prompt...)
+	return text, err
+}
+
+// GenerateTextContentWithUsage is GenerateTextContent that additionally returns
+// the response's token usage metadata (nil if the model reported none). Usage
+// is returned even alongside a formatting error so callers can attribute tokens
+// that were still consumed.
+func GenerateTextContentWithUsage(ctx context.Context, client *genai.Client, model string, config *genai.GenerateContentConfig, prompt ...*genai.Part) (string, *genai.GenerateContentResponseUsageMetadata, error) {
 	contents := []*genai.Content{{Parts: prompt, Role: "user"}}
 	resp, err := client.Models.GenerateContent(ctx, model, contents, config)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to generate content")
+		return "", nil, errors.Wrap(err, "failed to generate content")
 	}
+	usage := resp.UsageMetadata
 	if len(resp.Candidates) == 0 {
-		return "", errors.New("no candidates returned")
+		return "", usage, errors.New("no candidates returned")
 	}
 	candidate := resp.Candidates[0]
 	if candidate.FinishReason != genai.FinishReasonStop {
-		return "", errors.Errorf("generating content: %s", candidate.FinishMessage)
+		return "", usage, errors.Errorf("generating content: %s", candidate.FinishMessage)
 	}
 	switch len(candidate.Content.Parts) {
 	case 0:
-		return "", errors.New("empty response content")
+		return "", usage, errors.New("empty response content")
 	case 1:
 		if candidate.Content.Parts[0].Text != "" {
-			return candidate.Content.Parts[0].Text, nil
+			return candidate.Content.Parts[0].Text, usage, nil
 		}
-		return "", errors.New("part is not text")
+		return "", usage, errors.New("part is not text")
 	default:
-		return "", errors.New("multiple response parts")
+		return "", usage, errors.New("multiple response parts")
 	}
 }
 

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -65,6 +65,7 @@ func GenerateTextContent(ctx context.Context, client *genai.Client, model string
 }
 
 // GenerateTextContentWithUsage generates text content and returns the incurred usage.
+// Usage is returned even on error so consumed tokens can still be attributed.
 // Transient provider failures are retried with backoff.
 func GenerateTextContentWithUsage(ctx context.Context, client *genai.Client, model string, config *genai.GenerateContentConfig, prompt ...*genai.Part) (string, *genai.GenerateContentResponseUsageMetadata, error) {
 	contents := []*genai.Content{{Parts: prompt, Role: "user"}}
@@ -73,28 +74,23 @@ func GenerateTextContentWithUsage(ctx context.Context, client *genai.Client, mod
 		return "", nil, errors.Wrap(err, "failed to generate content")
 	}
 	usage := resp.UsageMetadata
-	text, err := textFromResponse(resp)
-	return text, usage, err
-}
-
-func textFromResponse(resp *genai.GenerateContentResponse) (string, error) {
 	if len(resp.Candidates) == 0 {
-		return "", errors.New("no candidates returned")
+		return "", usage, errors.New("no candidates returned")
 	}
 	candidate := resp.Candidates[0]
 	if candidate.FinishReason != genai.FinishReasonStop {
-		return "", errors.Errorf("generating content: %s", candidate.FinishMessage)
+		return "", usage, errors.Errorf("generating content: %s", candidate.FinishMessage)
 	}
 	switch len(candidate.Content.Parts) {
 	case 0:
-		return "", errors.New("empty response content")
+		return "", usage, errors.New("empty response content")
 	case 1:
 		if candidate.Content.Parts[0].Text != "" {
-			return candidate.Content.Parts[0].Text, nil
+			return candidate.Content.Parts[0].Text, usage, nil
 		}
-		return "", errors.New("part is not text")
+		return "", usage, errors.New("part is not text")
 	default:
-		return "", errors.New("multiple response parts")
+		return "", usage, errors.New("multiple response parts")
 	}
 }
 

--- a/pkg/llm/retry_test.go
+++ b/pkg/llm/retry_test.go
@@ -41,17 +41,3 @@ func TestIsTransient(t *testing.T) {
 		})
 	}
 }
-
-func TestSumTokens(t *testing.T) {
-	usage := []*genai.GenerateContentResponseUsageMetadata{
-		{TotalTokenCount: 100},
-		nil,
-		{TotalTokenCount: 250},
-	}
-	if got := SumTokens(usage); got != 350 {
-		t.Errorf("SumTokens = %d, want 350", got)
-	}
-	if got := SumTokens(nil); got != 0 {
-		t.Errorf("SumTokens(nil) = %d, want 0", got)
-	}
-}

--- a/pkg/rebuild/schema/costs.go
+++ b/pkg/rebuild/schema/costs.go
@@ -3,7 +3,58 @@
 
 package schema
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+// TokenUsage records LLM token consumption, bucketed by billing
+// treatment: cached input is discounted and thinking bills as output.
+type TokenUsage struct {
+	Input       int    `json:"input,omitempty" firestore:"input,omitempty"`               // includes cached and tool-use prompt tokens
+	CachedInput int    `json:"cached_input,omitempty" firestore:"cached_input,omitempty"` // subset of Input
+	Output      int    `json:"output,omitempty" firestore:"output,omitempty"`             // includes thinking tokens
+	Model       string `json:"model,omitempty" firestore:"model,omitempty"`
+}
+
+// Add returns the sum of u and other. Both must name the same model since a
+// sum carries a single label and is priced at that model's rates.
+// TODO: Track per-model subtotals so one session can mix models.
+func (u TokenUsage) Add(other TokenUsage) TokenUsage {
+	if u.Model != "" && other.Model != "" && u.Model != other.Model {
+		panic(fmt.Sprintf("summing TokenUsage across models %q and %q", u.Model, other.Model))
+	}
+	model := u.Model
+	if model == "" {
+		model = other.Model
+	}
+	return TokenUsage{
+		Input:       u.Input + other.Input,
+		CachedInput: u.CachedInput + other.CachedInput,
+		Output:      u.Output + other.Output,
+		Model:       model,
+	}
+}
+
+// Sub returns u minus other, component-wise, keeping u's model label. It
+// isolates the tokens spent between two snapshots of a running total.
+func (u TokenUsage) Sub(other TokenUsage) TokenUsage {
+	return TokenUsage{
+		Input:       u.Input - other.Input,
+		CachedInput: u.CachedInput - other.CachedInput,
+		Output:      u.Output - other.Output,
+		Model:       u.Model,
+	}
+}
+
+// OrNil returns a pointer to u, or nil when no tokens were counted so that
+// omitempty fields stay unset.
+func (u TokenUsage) OrNil() *TokenUsage {
+	if u.Input == 0 && u.CachedInput == 0 && u.Output == 0 {
+		return nil
+	}
+	return &u
+}
 
 // AttemptCosts records the measured resource costs of a single rebuild
 // attempt in raw units (seconds/bytes). Repository size/history lives in

--- a/pkg/rebuild/schema/costs_test.go
+++ b/pkg/rebuild/schema/costs_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTokenUsageAdd(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		u     TokenUsage
+		other TokenUsage
+		want  TokenUsage
+	}{
+		{
+			name:  "SameModel",
+			u:     TokenUsage{Input: 1, CachedInput: 2, Output: 3, Model: "m"},
+			other: TokenUsage{Input: 10, CachedInput: 20, Output: 30, Model: "m"},
+			want:  TokenUsage{Input: 11, CachedInput: 22, Output: 33, Model: "m"},
+		},
+		{
+			name:  "UnlabeledReceiverInheritsModel",
+			u:     TokenUsage{Input: 1},
+			other: TokenUsage{Input: 10, Model: "m"},
+			want:  TokenUsage{Input: 11, Model: "m"},
+		},
+		{
+			name:  "UnlabeledOtherKeepsModel",
+			u:     TokenUsage{Input: 1, Model: "m"},
+			other: TokenUsage{Input: 10},
+			want:  TokenUsage{Input: 11, Model: "m"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, tc.u.Add(tc.other)); diff != "" {
+				t.Errorf("Add() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTokenUsageAddAcrossModelsPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Add across models did not panic")
+		}
+	}()
+	TokenUsage{Model: "pro"}.Add(TokenUsage{Model: "flash"})
+}
+
+func TestTokenUsageSub(t *testing.T) {
+	after := TokenUsage{Input: 30, CachedInput: 2, Output: 16, Model: "m"}
+	before := TokenUsage{Input: 20, CachedInput: 2, Output: 8, Model: "m"}
+	want := TokenUsage{Input: 10, Output: 8, Model: "m"}
+	if diff := cmp.Diff(want, after.Sub(before)); diff != "" {
+		t.Errorf("Sub() diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestTokenUsageOrNil(t *testing.T) {
+	// A model label alone is not usage worth recording.
+	if got := (TokenUsage{Model: "m"}).OrNil(); got != nil {
+		t.Errorf("OrNil() of zero counts = %+v, want nil", got)
+	}
+	if got := (TokenUsage{Output: 1}).OrNil(); got == nil {
+		t.Error("OrNil() of non-zero counts = nil, want non-nil")
+	}
+}

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -541,6 +541,7 @@ type AgentCreateIterationRequest struct {
 	SessionID       string         `form:",required"`
 	IterationNumber int            `form:",required"`
 	Strategy        *StrategyOneOf `form:",required"`
+	Usage           *TokenUsage    `form:""` // LLM tokens consumed producing this iteration
 }
 
 var _ api.Input = AgentCreateIterationRequest{}
@@ -570,11 +571,11 @@ const (
 
 // AgentCompleteRequest finalizes session with results
 type AgentCompleteRequest struct {
-	SessionID          string `form:",required"`
-	StopReason         string `form:",required"`
-	SuccessIterationID string `form:""`
-	Summary            string `form:""`
-	TotalTokens        int64  `form:""` // total tokens used in the session
+	SessionID          string      `form:",required"`
+	StopReason         string      `form:",required"`
+	SuccessIterationID string      `form:""`
+	Summary            string      `form:""`
+	Usage              *TokenUsage `form:""` // total LLM tokens consumed across the session
 }
 
 var _ api.Input = AgentCompleteRequest{}
@@ -598,12 +599,12 @@ type AgentSession struct {
 	ExecutionName    string             `firestore:"execution_name,omitempty"`
 	ExecutionMode    AgentExecutionMode `firestore:"execution_mode,omitempty"` // Empty means GCB (sessions predating scratch support)
 	ScratchID        string             `firestore:"scratch_id,omitempty"`     // Scratch VM bound to the session (scratch execution mode only)
+	Usage            *TokenUsage        `firestore:"usage,omitempty"`          // total LLM tokens, reported at completion
 	Created          time.Time          `firestore:"created,omitempty"`
 	Updated          time.Time          `firestore:"updated,omitempty"`
 	StopReason       string             `firestore:"stop_reason,omitempty"`
 	SuccessIteration string             `firestore:"success_iteration,omitempty"`
 	Summary          string             `firestore:"summary,omitempty"`
-	TotalTokens      int64              `firestore:"total_tokens,omitempty"` // LLM token spend over the session
 }
 
 // AgentIteration stores iteration metadata in Firestore
@@ -615,6 +616,7 @@ type AgentIteration struct {
 	ObliviousID string            `firestore:"build_id,omitempty"`
 	Status      string            `firestore:"status,omitempty"`
 	Result      *AgentBuildResult `firestore:"result,omitempty"`
+	Usage       *TokenUsage       `firestore:"usage,omitempty"` // LLM tokens attributed to this iteration
 	Created     time.Time         `firestore:"created,omitempty"`
 	Updated     time.Time         `firestore:"updated,omitempty"`
 }

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -541,6 +541,7 @@ type AgentCreateIterationRequest struct {
 	SessionID       string         `form:",required"`
 	IterationNumber int            `form:",required"`
 	Strategy        *StrategyOneOf `form:",required"`
+	Usage           *TokenUsage    `form:""` // LLM tokens consumed producing this iteration
 }
 
 var _ api.Input = AgentCreateIterationRequest{}
@@ -569,10 +570,11 @@ const (
 
 // AgentCompleteRequest finalizes session with results
 type AgentCompleteRequest struct {
-	SessionID          string `form:",required"`
-	StopReason         string `form:",required"`
-	SuccessIterationID string `form:""`
-	Summary            string `form:""`
+	SessionID          string      `form:",required"`
+	StopReason         string      `form:",required"`
+	SuccessIterationID string      `form:""`
+	Summary            string      `form:""`
+	Usage              *TokenUsage `form:""` // total LLM tokens consumed across the session
 }
 
 var _ api.Input = AgentCompleteRequest{}
@@ -596,6 +598,7 @@ type AgentSession struct {
 	ExecutionName    string             `firestore:"execution_name,omitempty"`
 	ExecutionMode    AgentExecutionMode `firestore:"execution_mode,omitempty"` // Empty means GCB (sessions predating scratch support)
 	ScratchID        string             `firestore:"scratch_id,omitempty"`     // Scratch VM bound to the session (scratch execution mode only)
+	Usage            *TokenUsage        `firestore:"usage,omitempty"`          // total LLM tokens, reported at completion
 	Created          time.Time          `firestore:"created,omitempty"`
 	Updated          time.Time          `firestore:"updated,omitempty"`
 	StopReason       string             `firestore:"stop_reason,omitempty"`
@@ -612,6 +615,7 @@ type AgentIteration struct {
 	ObliviousID string            `firestore:"build_id,omitempty"`
 	Status      string            `firestore:"status,omitempty"`
 	Result      *AgentBuildResult `firestore:"result,omitempty"`
+	Usage       *TokenUsage       `firestore:"usage,omitempty"` // LLM tokens attributed to this iteration
 	Created     time.Time         `firestore:"created,omitempty"`
 	Updated     time.Time         `firestore:"updated,omitempty"`
 }


### PR DESCRIPTION
Capture genai usage metadata from the agent's main chat and side calls,
attribute per-iteration deltas around Propose, and persist totals on
AgentIteration records and the AgentSession at completion.