### PR TITLE
Resolve pinned Cargo toolchains during inference

### DIFF
--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -262,10 +262,12 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	}
 	// rust_version is the crate's minimum supported Rust version, not
 	// necessarily the toolchain used to publish it.
-	if declared := vmeta.RustVersion; declared != "" {
+	declaredRustVersion := vmeta.RustVersion
+	if declared := declaredRustVersion; declared != "" {
 		if strings.Count(declared, ".") == 1 {
 			declared += ".0"
 		}
+		declaredRustVersion = declared
 		if semver.Cmp(rustVersion, declared) < 0 {
 			rustVersion = declared
 		}
@@ -290,6 +292,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	}
 	// Extract package names from Cargo.lock for git-based index support
 	var indexCommit string
+	var lockfileLo string
 	var packageNames []string
 	if lockContent != nil && semver.Cmp(rustVersion, "1.34.0") >= 0 {
 		lf, err := cargolock.ParseLockfile(string(lockContent))
@@ -297,7 +300,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			return nil, errors.Wrap(err, "[INTERNAL] failed to parse Cargo.lock")
 		}
 		// Use lock file format version to refine the Rust version lower bound.
-		lockfileLo := lockfileRustVersionFloor(lf.FormatVersion)
+		lockfileLo = lockfileRustVersionFloor(lf.FormatVersion)
 		if lockfileLo != "" && semver.Cmp(rustVersion, lockfileLo) < 0 {
 			rustVersion = lockfileLo
 		}
@@ -333,6 +336,25 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 		}
 		slices.Sort(packageNames)
 	}
+	toolchainResolved := false
+	if sourceVersion, found, err := findPinnedStableToolchain(tree, dir); err != nil {
+		return nil, errors.Wrap(err, "reading repository toolchain")
+	} else if found {
+		latestAtPublish, err := reg.RustVersionAt(vmeta.Created)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolving repository toolchain")
+		}
+		hasMUSLBuild, releaseErr := reg.HasMUSLBuild(sourceVersion)
+		if releaseErr == nil && hasMUSLBuild &&
+			semver.Cmp(sourceVersion, latestAtPublish) <= 0 &&
+			(declaredRustVersion == "" || semver.Cmp(sourceVersion, declaredRustVersion) >= 0) &&
+			(minVer == "" || semver.Cmp(sourceVersion, minVer) >= 0) &&
+			(maxVer == "" || semver.Cmp(sourceVersion, maxVer) <= 0) &&
+			(lockfileLo == "" || semver.Cmp(sourceVersion, lockfileLo) >= 0) {
+			rustVersion = sourceVersion
+			toolchainResolved = true
+		}
+	}
 	// TODO: This should be moved to build-time since strategies are intended to be, at least notionally, distro-independent.
 	hasMUSLBuild, err := reg.HasMUSLBuild(rustVersion)
 	if err != nil {
@@ -350,10 +372,11 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			Ref:  ref,
 			Dir:  dir,
 		},
-		RustVersion:     rustVersion,
-		ExcludeLockfile: excludeLockfile,
-		RegistryCommit:  indexCommit,
-		PackageNames:    packageNames,
+		RustVersion:       rustVersion,
+		ToolchainResolved: toolchainResolved,
+		ExcludeLockfile:   excludeLockfile,
+		RegistryCommit:    indexCommit,
+		PackageNames:      packageNames,
 	}, nil
 }
 

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -262,10 +262,12 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	}
 	// rust_version is the crate's minimum supported Rust version, not
 	// necessarily the toolchain used to publish it.
-	if declared := vmeta.RustVersion; declared != "" {
+	declaredRustVersion := vmeta.RustVersion
+	if declared := declaredRustVersion; declared != "" {
 		if strings.Count(declared, ".") == 1 {
 			declared += ".0"
 		}
+		declaredRustVersion = declared
 		if semver.Cmp(rustVersion, declared) < 0 {
 			rustVersion = declared
 		}
@@ -290,6 +292,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 	}
 	// Extract package names from Cargo.lock for git-based index support
 	var indexCommit string
+	var lockfileLo string
 	var packageNames []string
 	if lockContent != nil && semver.Cmp(rustVersion, "1.34.0") >= 0 {
 		lf, err := cargolock.ParseLockfile(string(lockContent))
@@ -297,7 +300,7 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			return nil, errors.Wrap(err, "[INTERNAL] failed to parse Cargo.lock")
 		}
 		// Use lock file format version to refine the Rust version lower bound.
-		lockfileLo := lockfileRustVersionFloor(lf.FormatVersion)
+		lockfileLo = lockfileRustVersionFloor(lf.FormatVersion)
 		if lockfileLo != "" && semver.Cmp(rustVersion, lockfileLo) < 0 {
 			rustVersion = lockfileLo
 		}
@@ -333,6 +336,25 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 		}
 		slices.Sort(packageNames)
 	}
+	toolchainResolved := false
+	if sourceVersion, found, err := findPinnedStableToolchain(tree, dir); err != nil {
+		return nil, errors.Wrap(err, "reading repository toolchain")
+	} else if found {
+		latestAtPublish, err := reg.RustVersionAt(vmeta.Created)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolving repository toolchain")
+		}
+		hasMUSLBuild, releaseErr := reg.HasMUSLBuild(sourceVersion)
+		if releaseErr == nil && hasMUSLBuild &&
+			semver.Cmp(sourceVersion, latestAtPublish) <= 0 &&
+			(declaredRustVersion == "" || semver.Cmp(sourceVersion, declaredRustVersion) >= 0) &&
+			(minVer == "" || semver.Cmp(sourceVersion, minVer) >= 0) &&
+			(maxVer == "" || semver.Cmp(sourceVersion, maxVer) <= 0) &&
+			(lockfileLo == "" || semver.Cmp(sourceVersion, lockfileLo) >= 0) {
+			rustVersion = sourceVersion
+			toolchainResolved = true
+		}
+	}
 	// TODO: This should be moved to build-time since strategies are intended to be, at least notionally, distro-independent.
 	hasMUSLBuild, err := reg.HasMUSLBuild(rustVersion)
 	if err != nil {
@@ -348,9 +370,10 @@ func (Rebuilder) InferStrategy(ctx context.Context, t rebuild.Target, mux rebuil
 			Ref:  ref,
 			Dir:  dir,
 		},
-		RustVersion:    rustVersion,
-		RegistryCommit: indexCommit,
-		PackageNames:   packageNames,
+		RustVersion:       rustVersion,
+		ToolchainResolved: toolchainResolved,
+		RegistryCommit:    indexCommit,
+		PackageNames:      packageNames,
 	}, nil
 }
 

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -817,6 +817,289 @@ version = 3
 				}
 			},
 		},
+		{
+			name: "resolved repository toolchain",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.35.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2019-06-01T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(pre150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion:       "1.35.0",
+					ToolchainResolved: true,
+				}
+			},
+		},
+		{
+			name: "repository toolchain conflicts with artifact bounds",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.41.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain replaces the date heuristic",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion:       "1.60.0",
+					ToolchainResolved: true,
+				}
+			},
+		},
+		{
+			name: "repository toolchain published after the crate",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.65.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-09-30T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain below declared rust version",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.61.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain below lockfile floor",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.77.2\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2024-05-20T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.lock"}, Body: []byte("version = 4\n")},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.78.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain above artifact bounds",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(pre150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.54.0",
+				}
+			},
+		},
+		{
+			name: "unknown repository toolchain release",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.9\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain without musl build",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.34.2\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2019-06-01T00:00:00Z","rust_version":"1.34.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(pre150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.35.0",
+				}
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -844,6 +844,325 @@ version = 3
 				}
 			},
 		},
+		{
+			name: "resolved repository toolchain",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.35.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2019-06-01T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(pre150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion:       "1.35.0",
+					ToolchainResolved: true,
+				}
+			},
+		},
+		{
+			name: "repository toolchain conflicts with artifact bounds",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.41.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain replaces the date heuristic",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion:       "1.60.0",
+					ToolchainResolved: true,
+				}
+			},
+		},
+		{
+			name: "repository toolchain controls exclude lockfile",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.86.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2025-08-01T00:00:00Z"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion:       "1.86.0",
+					ToolchainResolved: true,
+				}
+			},
+		},
+		{
+			name: "repository toolchain published after the crate",
+			repo: `commits:
+  - id: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.0"
+  - id: version-bump
+    parent: initial-commit
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.65.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-09-30T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain below declared rust version",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.61.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain below lockfile floor",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.77.2\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2024-05-20T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.lock"}, Body: []byte("version = 4\n")},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.78.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain above artifact bounds",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.0\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(pre150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.54.0",
+				}
+			},
+		},
+		{
+			name: "unknown repository toolchain release",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.60.9\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2022-11-07T00:00:00Z","rust_version":"1.35.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(post150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.64.0",
+				}
+			},
+		},
+		{
+			name: "repository toolchain without musl build",
+			repo: `commits:
+  - id: version-bump
+    files:
+      Cargo.toml: |
+        [package]
+        name = "serde"
+        version = "1.0.150"
+      rust-toolchain: "1.34.2\n"
+`,
+			metadata: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download","created_at":"2019-06-01T00:00:00Z","rust_version":"1.34.0"}}`,
+			filesFn: func(repo *gitxtest.Repository) []archive.TarEntry {
+				return []archive.TarEntry{
+					{Header: &tar.Header{Name: "serde-1.0.150/.cargo_vcs_info.json"}, Body: []byte(`{"git":{"sha1":"` + repo.Commits["version-bump"].String() + `"}}`)},
+					{Header: &tar.Header{Name: "serde-1.0.150/Cargo.toml"}, Body: []byte(pre150CargoTOML)},
+				}
+			},
+			wantFn: func(repo *gitxtest.Repository) rebuild.Strategy {
+				return &CratesIOCargoPackage{
+					Location: rebuild.Location{
+						Repo: "https://github.com/serde-rs/serde",
+						Ref:  repo.Commits["version-bump"].String(),
+					},
+					RustVersion: "1.35.0",
+				}
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -20,11 +20,12 @@ type ExplicitLockfile struct {
 // CratesIOCargoPackage aggregates the options controlling a cargo build of a cratesio package.
 type CratesIOCargoPackage struct {
 	rebuild.Location
-	RustVersion      string            `json:"rust_version" yaml:"rust_version,omitempty"`
-	ExplicitLockfile *ExplicitLockfile `json:"explicit_lockfile" yaml:"explicit_lockfile,omitempty"`
-	ExcludeLockfile  bool              `json:"exclude_lockfile,omitempty" yaml:"exclude_lockfile,omitempty"`
-	RegistryCommit   string            `json:"registry_commit,omitempty" yaml:"registry_commit,omitempty"`
-	PackageNames     []string          `json:"package_names,omitempty" yaml:"package_names,omitempty"`
+	RustVersion       string            `json:"rust_version" yaml:"rust_version,omitempty"`
+	ToolchainResolved bool              `json:"toolchain_resolved,omitempty" yaml:"toolchain_resolved,omitempty"`
+	ExplicitLockfile  *ExplicitLockfile `json:"explicit_lockfile" yaml:"explicit_lockfile,omitempty"`
+	ExcludeLockfile   bool              `json:"exclude_lockfile,omitempty" yaml:"exclude_lockfile,omitempty"`
+	RegistryCommit    string            `json:"registry_commit,omitempty" yaml:"registry_commit,omitempty"`
+	PackageNames      []string          `json:"package_names,omitempty" yaml:"package_names,omitempty"`
 }
 
 var _ rebuild.Strategy = &CratesIOCargoPackage{}
@@ -65,11 +66,12 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 		Build: []flow.Step{{
 			Uses: "cargo/build/package",
 			With: map[string]string{
-				"dir":             b.Location.Dir,
-				"rustVersion":     b.RustVersion,
-				"excludeLockfile": fmt.Sprintf("%t", b.ExcludeLockfile),
-				"registryCommit":  b.RegistryCommit,
-				"useGitIndex":     fmt.Sprintf("%t", len(b.PackageNames) > 0),
+				"dir":               b.Location.Dir,
+				"rustVersion":       b.RustVersion,
+				"toolchainResolved": fmt.Sprintf("%t", b.ToolchainResolved),
+				"excludeLockfile":   fmt.Sprintf("%t", b.ExcludeLockfile),
+				"registryCommit":    b.RegistryCommit,
+				"useGitIndex":       fmt.Sprintf("%t", len(b.PackageNames) > 0),
 			},
 		}},
 		OutputDir: "target/package",
@@ -129,9 +131,14 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
 				export CARGO_TARGET_DIR="$PWD/target"
+				{{if eq .With.toolchainResolved "true" -}}
+				package_dir="$PWD{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}/{{.With.dir}}{{end}}"
+				(cd / && RUSTUP_TOOLCHAIN={{.With.rustVersion}} /root/.cargo/bin/cargo package --manifest-path "$package_dir/Cargo.toml" --no-verify{{if eq .With.excludeLockfile "true"}} --exclude-lockfile{{end}})
+				{{else -}}
 				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.dir}} && {{end -}}
 				/root/.cargo/bin/cargo package --no-verify{{if eq .With.excludeLockfile "true"}} --exclude-lockfile{{end}}
-				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}`)[1:],
+				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}
+				{{- end}}`)[1:],
 			Needs: []string{"rustup"},
 		}},
 	},

--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -20,10 +20,11 @@ type ExplicitLockfile struct {
 // CratesIOCargoPackage aggregates the options controlling a cargo build of a cratesio package.
 type CratesIOCargoPackage struct {
 	rebuild.Location
-	RustVersion      string            `json:"rust_version" yaml:"rust_version,omitempty"`
-	ExplicitLockfile *ExplicitLockfile `json:"explicit_lockfile" yaml:"explicit_lockfile,omitempty"`
-	RegistryCommit   string            `json:"registry_commit,omitempty" yaml:"registry_commit,omitempty"`
-	PackageNames     []string          `json:"package_names,omitempty" yaml:"package_names,omitempty"`
+	RustVersion       string            `json:"rust_version" yaml:"rust_version,omitempty"`
+	ToolchainResolved bool              `json:"toolchain_resolved,omitempty" yaml:"toolchain_resolved,omitempty"`
+	ExplicitLockfile  *ExplicitLockfile `json:"explicit_lockfile" yaml:"explicit_lockfile,omitempty"`
+	RegistryCommit    string            `json:"registry_commit,omitempty" yaml:"registry_commit,omitempty"`
+	PackageNames      []string          `json:"package_names,omitempty" yaml:"package_names,omitempty"`
 }
 
 var _ rebuild.Strategy = &CratesIOCargoPackage{}
@@ -64,10 +65,11 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 		Build: []flow.Step{{
 			Uses: "cargo/build/package",
 			With: map[string]string{
-				"dir":            b.Location.Dir,
-				"rustVersion":    b.RustVersion,
-				"registryCommit": b.RegistryCommit,
-				"useGitIndex":    fmt.Sprintf("%t", len(b.PackageNames) > 0),
+				"dir":               b.Location.Dir,
+				"rustVersion":       b.RustVersion,
+				"toolchainResolved": fmt.Sprintf("%t", b.ToolchainResolved),
+				"registryCommit":    b.RegistryCommit,
+				"useGitIndex":       fmt.Sprintf("%t", len(b.PackageNames) > 0),
 			},
 		}},
 		OutputDir: "target/package",
@@ -127,9 +129,14 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
 				export CARGO_TARGET_DIR="$PWD/target"
+				{{if eq .With.toolchainResolved "true" -}}
+				package_dir="$PWD{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}/{{.With.dir}}{{end}}"
+				(cd / && RUSTUP_TOOLCHAIN={{.With.rustVersion}} /root/.cargo/bin/cargo package --manifest-path "$package_dir/Cargo.toml" --no-verify)
+				{{else -}}
 				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.dir}} && {{end -}}
 				/root/.cargo/bin/cargo package --no-verify
-				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}`)[1:],
+				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}
+				{{- end}}`)[1:],
 			Needs: []string{"rustup"},
 		}},
 	},

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -283,6 +283,82 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 				OutputPath: "target/package/the_artifact",
 			},
 		},
+		{
+			"ResolvedToolchain",
+			&CratesIOCargoPackage{
+				Location:          defaultLocation,
+				RustVersion:       "1.84.1",
+				ToolchainResolved: true,
+			},
+			rebuild.BuildEnv{HasRepo: true},
+			rebuild.Instructions{
+				Location: defaultLocation,
+				Source:   "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.84.1
+# NOTE: Using current crates.io registry`,
+				Build: `export CARGO_TARGET_DIR="$PWD/target"
+package_dir="$PWD/the_dir"
+(cd / && RUSTUP_TOOLCHAIN=1.84.1 /root/.cargo/bin/cargo package --manifest-path "$package_dir/Cargo.toml" --no-verify)
+`,
+				Requires: rebuild.RequiredEnv{
+					SystemDeps: []string{"git", "rustup"},
+				},
+				OutputPath: "target/package/the_artifact",
+			},
+		},
+		{
+			"ResolvedToolchainExcludeLockfile",
+			&CratesIOCargoPackage{
+				Location:          defaultLocation,
+				RustVersion:       "1.87.0",
+				ToolchainResolved: true,
+				ExcludeLockfile:   true,
+			},
+			rebuild.BuildEnv{HasRepo: true},
+			rebuild.Instructions{
+				Location: defaultLocation,
+				Source:   "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.87.0
+# NOTE: Using current crates.io registry`,
+				Build: `export CARGO_TARGET_DIR="$PWD/target"
+package_dir="$PWD/the_dir"
+(cd / && RUSTUP_TOOLCHAIN=1.87.0 /root/.cargo/bin/cargo package --manifest-path "$package_dir/Cargo.toml" --no-verify --exclude-lockfile)
+`,
+				Requires: rebuild.RequiredEnv{
+					SystemDeps: []string{"git", "rustup"},
+				},
+				OutputPath: "target/package/the_artifact",
+			},
+		},
+		{
+			"ResolvedToolchainNoDir",
+			&CratesIOCargoPackage{
+				Location: rebuild.Location{
+					Ref:  "the_ref",
+					Repo: "the_repo",
+				},
+				RustVersion:       "1.84.1",
+				ToolchainResolved: true,
+			},
+			rebuild.BuildEnv{HasRepo: true},
+			rebuild.Instructions{
+				Location: rebuild.Location{
+					Ref:  "the_ref",
+					Repo: "the_repo",
+				},
+				Source: "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.84.1
+# NOTE: Using current crates.io registry`,
+				Build: `export CARGO_TARGET_DIR="$PWD/target"
+package_dir="$PWD"
+(cd / && RUSTUP_TOOLCHAIN=1.84.1 /root/.cargo/bin/cargo package --manifest-path "$package_dir/Cargo.toml" --no-verify)
+`,
+				Requires: rebuild.RequiredEnv{
+					SystemDeps: []string{"git", "rustup"},
+				},
+				OutputPath: "target/package/the_artifact",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -262,6 +262,58 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 				OutputPath: "target/package/the_artifact",
 			},
 		},
+		{
+			"ResolvedToolchain",
+			&CratesIOCargoPackage{
+				Location:          defaultLocation,
+				RustVersion:       "1.84.1",
+				ToolchainResolved: true,
+			},
+			rebuild.BuildEnv{HasRepo: true},
+			rebuild.Instructions{
+				Location: defaultLocation,
+				Source:   "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.84.1
+# NOTE: Using current crates.io registry`,
+				Build: `export CARGO_TARGET_DIR="$PWD/target"
+package_dir="$PWD/the_dir"
+(cd / && RUSTUP_TOOLCHAIN=1.84.1 /root/.cargo/bin/cargo package --manifest-path "$package_dir/Cargo.toml" --no-verify)
+`,
+				Requires: rebuild.RequiredEnv{
+					SystemDeps: []string{"git", "rustup"},
+				},
+				OutputPath: "target/package/the_artifact",
+			},
+		},
+		{
+			"ResolvedToolchainNoDir",
+			&CratesIOCargoPackage{
+				Location: rebuild.Location{
+					Ref:  "the_ref",
+					Repo: "the_repo",
+				},
+				RustVersion:       "1.84.1",
+				ToolchainResolved: true,
+			},
+			rebuild.BuildEnv{HasRepo: true},
+			rebuild.Instructions{
+				Location: rebuild.Location{
+					Ref:  "the_ref",
+					Repo: "the_repo",
+				},
+				Source: "git checkout --force 'the_ref'",
+				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.84.1
+# NOTE: Using current crates.io registry`,
+				Build: `export CARGO_TARGET_DIR="$PWD/target"
+package_dir="$PWD"
+(cd / && RUSTUP_TOOLCHAIN=1.84.1 /root/.cargo/bin/cargo package --manifest-path "$package_dir/Cargo.toml" --no-verify)
+`,
+				Requires: rebuild.RequiredEnv{
+					SystemDeps: []string{"git", "rustup"},
+				},
+				OutputPath: "target/package/the_artifact",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/rebuild/cratesio/toolchain.go
+++ b/pkg/rebuild/cratesio/toolchain.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cratesio
+
+import (
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/pelletier/go-toml/v2"
+)
+
+var stableRelease = regexp.MustCompile(`^1\.\d+\.\d+$`)
+
+// findPinnedStableToolchain returns a fully-qualified stable channel when the
+// effective repository toolchain file does not request additional setup.
+func findPinnedStableToolchain(tree *object.Tree, dir string) (string, bool, error) {
+	current := path.Clean(dir)
+	if path.IsAbs(current) {
+		return "", false, nil
+	}
+	for {
+		for _, name := range []string{"rust-toolchain", "rust-toolchain.toml"} {
+			file, err := tree.File(path.Join(current, name))
+			if err == object.ErrFileNotFound {
+				continue
+			}
+			if err != nil {
+				return "", false, err
+			}
+			if file.Mode != filemode.Regular && file.Mode != filemode.Executable {
+				return "", false, nil
+			}
+			contents, err := file.Contents()
+			if err != nil {
+				return "", false, err
+			}
+			return parseStableToolchain(contents)
+		}
+		if current == "." {
+			return "", false, nil
+		}
+		current = path.Dir(current)
+	}
+}
+
+func parseStableToolchain(contents string) (string, bool, error) {
+	contents = strings.TrimSpace(contents)
+	if stableRelease.MatchString(contents) {
+		return contents, true, nil
+	}
+	var document map[string]any
+	if err := toml.Unmarshal([]byte(contents), &document); err != nil {
+		return "", false, nil
+	}
+	if len(document) != 1 {
+		return "", false, nil
+	}
+	toolchain, ok := document["toolchain"].(map[string]any)
+	if !ok || len(toolchain) != 1 {
+		return "", false, nil
+	}
+	channel, ok := toolchain["channel"].(string)
+	if !ok || !stableRelease.MatchString(channel) {
+		return "", false, nil
+	}
+	return channel, true, nil
+}

--- a/pkg/rebuild/cratesio/toolchain_test.go
+++ b/pkg/rebuild/cratesio/toolchain_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cratesio
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
+)
+
+func TestFindPinnedStableToolchain(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		files gitxtest.FileContent
+		dir   string
+		want  string
+	}{
+		{
+			name: "plain file",
+			files: gitxtest.FileContent{
+				"rust-toolchain": "1.84.1\n",
+			},
+			want: "1.84.1",
+		},
+		{
+			name: "toml file",
+			files: gitxtest.FileContent{
+				"rust-toolchain.toml": "[toolchain]\nchannel = \"1.84.1\"\n",
+			},
+			want: "1.84.1",
+		},
+		{
+			name: "nearest file",
+			files: gitxtest.FileContent{
+				"rust-toolchain":            "1.77.2\n",
+				"crates/pkg/rust-toolchain": "1.84.1\n",
+			},
+			dir:  "crates/pkg",
+			want: "1.84.1",
+		},
+		{
+			name: "legacy filename wins",
+			files: gitxtest.FileContent{
+				"rust-toolchain":      "nightly\n",
+				"rust-toolchain.toml": "[toolchain]\nchannel = \"1.84.1\"\n",
+			},
+		},
+		{
+			name: "moving stable is left unchanged",
+			files: gitxtest.FileContent{
+				"rust-toolchain": "stable\n",
+			},
+		},
+		{
+			name: "partial release is left unchanged",
+			files: gitxtest.FileContent{
+				"rust-toolchain": "1.84\n",
+			},
+		},
+		{
+			name: "additional toolchain settings are left unchanged",
+			files: gitxtest.FileContent{
+				"rust-toolchain.toml": "[toolchain]\nchannel = \"1.84.1\"\ncomponents = [\"rustfmt\"]\n",
+			},
+		},
+		{
+			name: "additional top-level table is left unchanged",
+			files: gitxtest.FileContent{
+				"rust-toolchain.toml": "[toolchain]\nchannel = \"1.84.1\"\n\n[metadata]\nowner = \"example\"\n",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := must(gitxtest.CreateRepo([]gitxtest.Commit{{
+				ID:    "target",
+				Files: tc.files,
+			}}, nil))
+			commit := must(repo.CommitObject(repo.Commits["target"]))
+			tree := must(commit.Tree())
+			got, ok, err := findPinnedStableToolchain(tree, tc.dir)
+			if err != nil {
+				t.Fatalf("findPinnedStableToolchain: %v", err)
+			}
+			if got != tc.want || ok != (tc.want != "") {
+				t.Errorf("findPinnedStableToolchain() = %q, %v; want %q, %v", got, ok, tc.want, tc.want != "")
+			}
+		})
+	}
+}
+
+func TestFindPinnedStableToolchainIgnoresSymlink(t *testing.T) {
+	repo := must(gitxtest.CreateRepo([]gitxtest.Commit{{
+		ID: "initial",
+		Files: gitxtest.FileContent{
+			"1.84.1": "ignored\n",
+		},
+	}}, nil))
+	worktree := must(repo.Worktree())
+	if err := worktree.Filesystem.Symlink("1.84.1", "rust-toolchain"); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+	if _, err := worktree.Add("rust-toolchain"); err != nil {
+		t.Fatalf("adding symlink: %v", err)
+	}
+	hash := must(worktree.Commit("add symlink", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test"},
+	}))
+	commit := must(repo.CommitObject(hash))
+	tree := must(commit.Tree())
+	if got, ok, err := findPinnedStableToolchain(tree, ""); err != nil {
+		t.Fatalf("findPinnedStableToolchain: %v", err)
+	} else if got != "" || ok {
+		t.Errorf("findPinnedStableToolchain() = %q, %v; want %q, false", got, ok, "")
+	}
+}

--- a/pkg/rebuild/schema/schema_test.go
+++ b/pkg/rebuild/schema/schema_test.go
@@ -110,12 +110,13 @@ pypi_pure_wheel_build:
 				Ref:  "the_ref",
 				Repo: "the_repo",
 			},
-			RustVersion: "some_version",
+			RustVersion:       "some_version",
+			ToolchainResolved: true,
 			ExplicitLockfile: &cratesio.ExplicitLockfile{
 				LockfileBase64: "lock_base64",
 			},
 		},
-		jsonEncoded: `{"cratesio_cargo_package":{"repo":"the_repo","ref":"the_ref","dir":"the_dir","rust_version":"some_version","explicit_lockfile":{"lockfile_base64":"lock_base64"}}}`,
+		jsonEncoded: `{"cratesio_cargo_package":{"repo":"the_repo","ref":"the_ref","dir":"the_dir","rust_version":"some_version","toolchain_resolved":true,"explicit_lockfile":{"lockfile_base64":"lock_base64"}}}`,
 		yamlEncoded: `
 cratesio_cargo_package:
   location:
@@ -123,6 +124,7 @@ cratesio_cargo_package:
     ref: the_ref
     dir: the_dir
   rust_version: some_version
+  toolchain_resolved: true
   explicit_lockfile:
     lockfile_base64: lock_base64
 `,


### PR DESCRIPTION
A repository `rust-toolchain` file can override the toolchain recorded in an inferred strategy, so `cargo package` may run with a different Cargo version.

Resolve fully-qualified stable pins during inference when they request no additional setup and satisfy the publication-date, MSRV, manifest, lockfile, and MUSL constraints. For resolved pins, run `cargo package` from `/` with an explicit `RUSTUP_TOOLCHAIN` and absolute manifest path. Running from `/` also prevents repository `.cargo/config*` files from overriding the configured registry. Other declarations retain the current behavior.

Testing:
- `go test ./...`
- `go vet ./...`
- Verified with a fixture using Cargo 1.61.0 as the neutral default and Cargo 1.84.0 as the repository pin; the resolved invocation used 1.84.0 and produced identical package hashes in two runs.

Related: #1384