### PR TITLE
Close consumed crates.io response bodies

### DIFF
--- a/pkg/registry/cratesio/cratesio.go
+++ b/pkg/registry/cratesio/cratesio.go
@@ -73,6 +73,9 @@ func (r HTTPRegistry) Crate(ctx context.Context, pkg string) (*Crate, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if resp.StatusCode != 200 {
 		return nil, errors.Wrap(errors.New(resp.Status), "fetching crate metadata")
 	}
@@ -101,6 +104,9 @@ func (r HTTPRegistry) Version(ctx context.Context, pkg, version string) (*CrateV
 	if err != nil {
 		return nil, err
 	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if resp.StatusCode != 200 {
 		return nil, errors.Wrap(errors.New(resp.Status), "fetching version")
 	}
@@ -128,6 +134,9 @@ func (r HTTPRegistry) Artifact(ctx context.Context, pkg string, version string) 
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
 		return nil, errors.Wrap(errors.New(resp.Status), "fetching artifact")
 	}
 	return resp.Body, nil

--- a/pkg/registry/cratesio/response_close_test.go
+++ b/pkg/registry/cratesio/response_close_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cratesio
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/oss-rebuild/internal/httpx/httpxtest"
+)
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestHTTPRegistryClosesConsumedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		url  string
+		body string
+		call func(HTTPRegistry) error
+	}{
+		{
+			name: "crate metadata",
+			url:  "https://crates.io/api/v1/crates/serde",
+			body: `{"crate":{"id":"serde"},"versions":[]}`,
+			call: func(r HTTPRegistry) error {
+				_, err := r.Crate(context.Background(), "serde")
+				return err
+			},
+		},
+		{
+			name: "version metadata",
+			url:  "https://crates.io/api/v1/crates/serde/1.0.150",
+			body: `{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download"}}`,
+			call: func(r HTTPRegistry) error {
+				_, err := r.Version(context.Background(), "serde", "1.0.150")
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := &closeTrackingBody{Reader: strings.NewReader(tc.body)}
+			client := &httpxtest.MockClient{
+				Calls: []httpxtest.Call{{
+					URL:      tc.url,
+					Response: &http.Response{StatusCode: http.StatusOK, Body: body},
+				}},
+				URLValidator: httpxtest.NewURLValidator(t),
+			}
+			if err := tc.call(HTTPRegistry{Client: client}); err != nil {
+				t.Fatal(err)
+			}
+			if !body.closed {
+				t.Fatal("response body was not closed")
+			}
+		})
+	}
+}
+
+func TestHTTPRegistryClosesFailedArtifactResponse(t *testing.T) {
+	metadataBody := &closeTrackingBody{Reader: strings.NewReader(`{"version":{"num":"1.0.150","dl_path":"/api/v1/crates/serde/1.0.150/download"}}`)}
+	artifactBody := &closeTrackingBody{Reader: strings.NewReader("error")}
+	client := &httpxtest.MockClient{
+		Calls: []httpxtest.Call{
+			{
+				URL:      "https://crates.io/api/v1/crates/serde/1.0.150",
+				Response: &http.Response{StatusCode: http.StatusOK, Body: metadataBody},
+			},
+			{
+				URL:      "https://crates.io/api/v1/crates/serde/1.0.150/download",
+				Response: &http.Response{StatusCode: http.StatusInternalServerError, Status: "Internal Server Error", Body: artifactBody},
+			},
+		},
+		URLValidator: httpxtest.NewURLValidator(t),
+	}
+	if _, err := (HTTPRegistry{Client: client}).Artifact(context.Background(), "serde", "1.0.150"); err == nil {
+		t.Fatal("Artifact() returned nil error")
+	}
+	if !metadataBody.closed {
+		t.Error("metadata response body was not closed")
+	}
+	if !artifactBody.closed {
+		t.Error("artifact response body was not closed")
+	}
+}


### PR DESCRIPTION
Crate and version metadata responses are fully consumed without being closed. Failed artifact downloads also return without closing their response body.

Close metadata response bodies after use, and close failed artifact responses before returning. Successful artifact responses remain caller-owned.

Testing:
- `go test ./pkg/registry/cratesio`
- `go test ./...`
- `go vet ./...`