### PR TITLE
Propagate benchmark options to asynchronous requests

### DIFF
--- a/tools/benchmark/run/run.go
+++ b/tools/benchmark/run/run.go
@@ -366,6 +366,11 @@ func RunBenchAsync(ctx context.Context, set benchmark.PackageSet, opts RunBenchO
 				Version:           v,
 				ID:                opts.RunID,
 				UseRepoDefinition: opts.UseRepoDefinition,
+				UseSyscallMonitor: opts.UseSyscallMonitor,
+				UseNetworkProxy:   opts.UseNetworkProxy,
+				OverwriteMode:     opts.OverwriteMode,
+				ExecutionHint:     p.Execution,
+				SizeHint:          p.Size,
 			}
 			if len(p.Artifacts) > 0 {
 				req.Artifact = p.Artifacts[i]

--- a/tools/benchmark/run/run_test.go
+++ b/tools/benchmark/run/run_test.go
@@ -51,17 +51,19 @@ func TestRunBenchAsync(t *testing.T) {
 						Ecosystem: "npm",
 						Name:      "package_name",
 						Versions:  []string{"1.0.0", "1.1.0"},
+						Execution: schema.ExtendedExecution,
+						Size:      schema.JumboSize,
 					},
 				},
 			},
 			expected: []queueCall{
 				{
 					"https://example.com/rebuild",
-					"ecosystem=npm&id=runid&package=package_name&version=1.0.0",
+					"ecosystem=npm&executionhint=EXTENDED&id=runid&overwritemode=FORCE&package=package_name&sizehint=JUMBO&usenetworkproxy=true&userepodefinition=true&usesyscallmonitor=true&version=1.0.0",
 				},
 				{
 					"https://example.com/rebuild",
-					"ecosystem=npm&id=runid&package=package_name&version=1.1.0",
+					"ecosystem=npm&executionhint=EXTENDED&id=runid&overwritemode=FORCE&package=package_name&sizehint=JUMBO&usenetworkproxy=true&userepodefinition=true&usesyscallmonitor=true&version=1.1.0",
 				},
 			},
 		},
@@ -70,7 +72,14 @@ func TestRunBenchAsync(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			queue := &mockQueue{}
 			url := urlx.MustParse("https://example.com")
-			if err := RunBenchAsync(context.Background(), tc.set, RunBenchOpts{Mode: tc.mode, RunID: "runid"}, url, queue); err != nil {
+			if err := RunBenchAsync(context.Background(), tc.set, RunBenchOpts{
+				Mode:              tc.mode,
+				RunID:             "runid",
+				UseSyscallMonitor: true,
+				UseNetworkProxy:   true,
+				UseRepoDefinition: true,
+				OverwriteMode:     schema.OverwriteForce,
+			}, url, queue); err != nil {
 				t.Error(errors.Wrap(err, "RunBenchAsync"))
 			}
 			if diff := cmp.Diff(queue.calls, tc.expected); diff != "" {

--- a/tools/ctl/command/runbenchmark/runbenchmark.go
+++ b/tools/ctl/command/runbenchmark/runbenchmark.go
@@ -269,7 +269,10 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 		if err := benchrun.RunBenchAsync(ctx, set, benchrun.RunBenchOpts{
 			Mode:              cfg.ExecutionMode,
 			RunID:             runID,
+			UseSyscallMonitor: cfg.UseSyscallMonitor,
+			UseNetworkProxy:   cfg.UseNetworkProxy,
 			UseRepoDefinition: cfg.UseRepoDefinition,
+			OverwriteMode:     schema.OverwriteMode(cfg.OverwriteMode),
 		}, apiURL, queue); err != nil {
 			return nil, errors.Wrap(err, "adding benchmark to queue")
 		}


### PR DESCRIPTION
The asynchronous benchmark path currently drops the network proxy, syscall monitor, overwrite mode, execution hint, and size hint. Queued rebuilds can therefore use different settings from the requested benchmark.

Carry the run-level options into `RunBenchAsync` and copy them with the per-package hints into each `RebuildPackageRequest`.

Testing:
- `go test ./...`
- `go vet ./...`