### PR TITLE
Fix crates.io benchmark generator lifecycle

### DIFF
--- a/tools/benchmark/generate/generator_lifecycle_test.go
+++ b/tools/benchmark/generate/generator_lifecycle_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type countingBody struct {
+	io.Reader
+	closed *atomic.Int64
+}
+
+func (b countingBody) Close() error {
+	b.closed.Add(1)
+	return nil
+}
+
+type cratesRoundTripper struct {
+	pageRequests atomic.Int64
+	pageClosed   atomic.Int64
+	cancel       context.CancelFunc
+}
+
+func (rt *cratesRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if rt.cancel != nil {
+		rt.cancel()
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	}
+	var body string
+	var responseBody io.ReadCloser
+	if req.URL.Path == "/api/v1/crates" {
+		rt.pageRequests.Add(1)
+		page, err := strconv.Atoi(req.URL.Query().Get("page"))
+		if err != nil {
+			return nil, err
+		}
+		var items []string
+		for i := 0; i < 100; i++ {
+			items = append(items, fmt.Sprintf(`{"id":"crate-%d-%d"}`, page, i))
+		}
+		body = `{"crates":[` + strings.Join(items, ",") + `]}`
+		responseBody = countingBody{Reader: strings.NewReader(body), closed: &rt.pageClosed}
+	} else {
+		name := strings.TrimPrefix(req.URL.Path, "/api/v1/crates/")
+		body = fmt.Sprintf(`{"crate":{"id":%q},"versions":[{"num":"1.0.0","created_at":"2026-08-01T00:00:00Z"}]}`, name)
+		responseBody = io.NopCloser(strings.NewReader(body))
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Body:       responseBody,
+		Request:    req,
+	}, nil
+}
+
+func TestCratesIOGeneratorClosesResponses(t *testing.T) {
+	rt := &cratesRoundTripper{}
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: rt}
+	defer func() { http.DefaultClient = oldClient }()
+
+	got := cratesioTop2000.Generator(t.Context())
+	if len(got.Packages) != maxPackages {
+		t.Fatalf("packages = %d, want %d", len(got.Packages), maxPackages)
+	}
+	if got.Count != maxPackages {
+		t.Fatalf("count = %d, want %d", got.Count, maxPackages)
+	}
+	if got, want := rt.pageClosed.Load(), rt.pageRequests.Load(); got != want {
+		t.Fatalf("closed page responses = %d, want %d", got, want)
+	}
+}
+
+func TestCratesIOGeneratorCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	rt := &cratesRoundTripper{cancel: cancel}
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: rt}
+	defer func() { http.DefaultClient = oldClient }()
+
+	got := cratesioTop2000.Generator(ctx)
+	if len(got.Packages) != 0 {
+		t.Fatalf("packages = %d, want 0", len(got.Packages))
+	}
+}

--- a/tools/benchmark/generate/main.go
+++ b/tools/benchmark/generate/main.go
@@ -72,29 +72,47 @@ var cratesioTop2000 = RebuildBenchmark{
 		now := time.Now()
 		ageThreshold := now.Add(-1 * maxAge)
 		crates := make(chan cratesio.Metadata, 100)
+		producerCtx, cancelProducer := context.WithCancel(ctx)
+		producerDone := make(chan struct{})
+		defer func() {
+			cancelProducer()
+			<-producerDone
+		}()
 		// Get download-ordered crates from crates.io.
 		go func() {
-			for page := 1; len(ps.Packages) < maxPackages; page++ {
+			defer close(producerDone)
+			defer close(crates)
+			for page := 1; ; page++ {
 				url := fmt.Sprintf("https://crates.io/api/v1/crates?page=%d&per_page=100&sort=downloads", page)
-				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				req, err := http.NewRequestWithContext(producerCtx, http.MethodGet, url, nil)
 				if err != nil {
 					log.Fatalf("error creating request for download-ordered page %d: %v", page, err)
 				}
 				resp, err := client.Do(req)
 				if err != nil {
+					if producerCtx.Err() != nil {
+						return
+					}
 					log.Fatalf("error fetching download-ordered page %d: %v", page, err)
 				}
 				if resp.StatusCode != 200 {
+					resp.Body.Close()
 					log.Fatalf("error from registry fetching download-ordered page %d: %s", page, resp.Status)
 				}
 				var ms struct {
 					Metadata []cratesio.Metadata `json:"crates"`
 				}
-				if derr := json.NewDecoder(resp.Body).Decode(&ms); derr != nil {
-					log.Fatalf("decoding error on download-ordered page %d: %v", page, err)
+				derr := json.NewDecoder(resp.Body).Decode(&ms)
+				resp.Body.Close()
+				if derr != nil {
+					log.Fatalf("decoding error on download-ordered page %d: %v", page, derr)
 				}
 				for _, m := range ms.Metadata {
-					crates <- m
+					select {
+					case crates <- m:
+					case <-producerCtx.Done():
+						return
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
The crates.io benchmark generator reads package state concurrently with the consumer and leaves paginated registry responses open.

Use a dedicated producer context, handle its cancellation as normal completion, wait for it to stop, and close each page response after decoding.

Testing:
- `go test -race ./tools/benchmark/generate`
- `go test ./...`
- `go vet ./...`
