### PR TITLE
Propagate container save options in GCB executor

### DIFF
--- a/pkg/build/gcb/executor.go
+++ b/pkg/build/gcb/executor.go
@@ -112,11 +112,13 @@ func (e *Executor) Start(ctx context.Context, input rebuild.Input, opts build.Op
 	}
 	// Generate the execution plan
 	planOpts := build.PlanOptions{
-		UseTimewarp:       opts.UseTimewarp,
-		UseNetworkProxy:   opts.UseNetworkProxy,
-		UseSyscallMonitor: opts.UseSyscallMonitor,
-		Resources:         opts.Resources,
-		RecordTimings:     opts.RecordTimings,
+		UseTimewarp:            opts.UseTimewarp,
+		UseNetworkProxy:        opts.UseNetworkProxy,
+		UseSyscallMonitor:      opts.UseSyscallMonitor,
+		Resources:              opts.Resources,
+		SaveContainerImage:     opts.SaveContainerImage,
+		SavePostBuildContainer: opts.SavePostBuildContainer,
+		RecordTimings:          opts.RecordTimings,
 	}
 	plan, err := e.planner.GeneratePlan(ctx, input, planOpts)
 	if err != nil {

--- a/pkg/build/gcb/executor_options_test.go
+++ b/pkg/build/gcb/executor_options_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gcb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/oss-rebuild/pkg/build"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+type captureSavePlanOptions struct {
+	got build.PlanOptions
+}
+
+func (p *captureSavePlanOptions) GeneratePlan(_ context.Context, _ rebuild.Input, opts build.PlanOptions) (*Plan, error) {
+	p.got = opts
+	return nil, errors.New("stop after capture")
+}
+
+func TestExecutorPropagatesSaveOptions(t *testing.T) {
+	planner := &captureSavePlanOptions{}
+	e := &Executor{planner: planner}
+	_, err := e.Start(context.Background(), rebuild.Input{}, build.Options{
+		BuildID:                "save-options",
+		SaveContainerImage:     true,
+		SavePostBuildContainer: true,
+	})
+	if err == nil {
+		t.Fatal("Start() error = nil, want capture sentinel")
+	}
+	if !planner.got.SaveContainerImage {
+		t.Error("PlanOptions.SaveContainerImage = false, want true")
+	}
+	if !planner.got.SavePostBuildContainer {
+		t.Error("PlanOptions.SavePostBuildContainer = false, want true")
+	}
+}


### PR DESCRIPTION
The GCB planner supports `SaveContainerImage` and `SavePostBuildContainer`, but `Executor.Start` does not pass them through, so requested save and export steps are omitted.

Copy both values into `build.PlanOptions`.

Testing:
- `go test ./pkg/build/gcb`
- `go test ./...`
- `go vet ./...`