### PR TITLE
Attach contexts to rebuild HTTP requests

### DIFF
--- a/pkg/rebuild/rebuild/http.go
+++ b/pkg/rebuild/rebuild/http.go
@@ -30,6 +30,7 @@ func UserAgent(host string) string {
 
 // DoContext attempts to make an external HTTP request using the gateway client, if configured.
 func DoContext(ctx context.Context, req *http.Request) (*http.Response, error) {
+	req = req.WithContext(ctx)
 	if c, ok := ctx.Value(HTTPBasicClientID).(httpx.BasicClient); ok && c != nil {
 		return c.Do(req)
 	}

--- a/pkg/rebuild/rebuild/http_context_test.go
+++ b/pkg/rebuild/rebuild/http_context_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package rebuild
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+type contextKey struct{}
+
+type contextCapturingClient struct {
+	ctx context.Context
+}
+
+func (c *contextCapturingClient) Do(req *http.Request) (*http.Response, error) {
+	c.ctx = req.Context()
+	return nil, errors.New("stop after capture")
+}
+
+func TestDoContextAttachesContextToRequest(t *testing.T) {
+	client := &contextCapturingClient{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "attached")
+	ctx = context.WithValue(ctx, HTTPBasicClientID, client)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DoContext(ctx, req); err == nil {
+		t.Fatal("DoContext() error = nil, want capture sentinel")
+	}
+	if got := client.ctx.Value(contextKey{}); got != "attached" {
+		t.Fatalf("request context value = %v, want attached", got)
+	}
+}


### PR DESCRIPTION
`DoContext` selects an HTTP client from the supplied context, but sends the request with its original context. Canceling artifact verification therefore does not cancel the upstream request.

Attach the supplied context before sending the request.

Testing:
- `go test ./pkg/rebuild/rebuild`
- `go test ./...`
- `go vet ./...`