### PR TITLE
Handle service-update overwrite without attestation

### DIFF
--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -366,7 +366,7 @@ func rebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 			// Allow overwrite but empty out the value to omit from the attestation.
 			req.OverwriteMode = schema.OverwriteMode("")
 		case schema.OverwriteServiceUpdate:
-			v.Message = api.AsStatus(codes.FailedPrecondition, errors.Wrap(err, "overwrite denied: no attestation to overwrite")).Error()
+			v.Message = api.AsStatus(codes.FailedPrecondition, errors.New("overwrite denied: no attestation to overwrite")).Error()
 			return &v, nil
 		}
 		// NOTE: This ensures racing rebuilds won't result in multiple attestations being written.

--- a/internal/api/apiservice/rebuild_test.go
+++ b/internal/api/apiservice/rebuild_test.go
@@ -55,6 +55,26 @@ func (FakeSigner) KeyID() (string, error) {
 	return "fake", nil
 }
 
+func TestRebuildPackageServiceUpdateWithoutBundle(t *testing.T) {
+	deps := &RebuildPackageDeps{
+		HTTPClient:       http.DefaultClient,
+		AttestationStore: rebuild.NewFilesystemAssetStore(memfs.New()),
+	}
+	verdict, err := rebuildPackage(context.Background(), schema.RebuildPackageRequest{
+		Ecosystem:     rebuild.CratesIO,
+		Package:       "example",
+		Version:       "1.0.0",
+		Artifact:      "example-1.0.0.crate",
+		OverwriteMode: schema.OverwriteServiceUpdate,
+	}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "overwrite denied: no attestation to overwrite"; !strings.Contains(verdict.Message, want) {
+		t.Fatalf("message = %q, want substring %q", verdict.Message, want)
+	}
+}
+
 // TODO: Add tests checking that inference properly handles artifacts once we have
 // a strategy type that's dependent on artifact.
 func TestRebuildPackage(t *testing.T) {


### PR DESCRIPTION
Service-update overwrite requests panic when no attestation bundle exists because the missing-bundle branch wraps a nil error before passing it to `api.AsStatus`.

Construct the `FailedPrecondition` error directly so the request returns the intended verdict.

Testing:
- `go test ./...`
- `go vet ./...`
- `go run ./ci -v check`