### PR TITLE
Reject unsupported instrumentation in local run-one

### DIFF
--- a/tools/ctl/command/runone/runone.go
+++ b/tools/ctl/command/runone/runone.go
@@ -93,6 +93,12 @@ func (c Config) Validate() error {
 	if c.UseRepoDefinition && c.Local {
 		return errors.New("--use-repo-definition is not supported in local mode")
 	}
+	if c.Local && c.UseNetworkProxy {
+		return errors.New("--use-network-proxy is not supported in local mode")
+	}
+	if c.Local && c.UseSyscallMonitor {
+		return errors.New("--use-syscall-monitor is not supported in local mode")
+	}
 	if c.UseRepoDefinition && mode != schema.AttestMode {
 		return errors.New("--use-repo-definition is only supported in attest mode")
 	}

--- a/tools/ctl/command/runone/runone_test.go
+++ b/tools/ctl/command/runone/runone_test.go
@@ -7,6 +7,36 @@ import (
 	"testing"
 )
 
+func TestValidationRejectsUnsupportedLocalInstrumentation(t *testing.T) {
+	base := Config{
+		Local:            true,
+		BootstrapBucket:  "bucket",
+		BootstrapVersion: "version",
+		Ecosystem:        "cratesio",
+		Package:          "package",
+		Version:          "1.0.0",
+		Mode:             "attest",
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("Config.Validate() failed without instrumentation: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		edit func(*Config)
+	}{
+		{"network proxy", func(c *Config) { c.UseNetworkProxy = true }},
+		{"syscall monitor", func(c *Config) { c.UseSyscallMonitor = true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.edit(&cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatal("Config.Validate() succeeded for an unsupported local option")
+			}
+		})
+	}
+}
+
 func TestValidation(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
`run-one` accepts `--use-network-proxy` and `--use-syscall-monitor` in local mode, but local execution does not propagate either option.

Reject them during validation instead of continuing without the requested instrumentation.

Testing:
- `go test ./...`
- `go vet ./...`
- `go run ./ci -v check`