### PR TITLE
Write GCB auth tokens as raw text

### DIFF
--- a/pkg/build/gcb/auth_token_test.go
+++ b/pkg/build/gcb/auth_token_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gcb
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestAuthTokenUsesRawJQOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		tpl  *template.Template
+		args map[string]any
+	}{
+		{"standard build", gcbStandardBuildTpl, map[string]any{"TimewarpAuth": true}},
+		{"proxy build", gcbProxyBuildTpl, map[string]any{"ProxyAuth": true}},
+		{"asset upload", gcbAssetUploadTpl, map[string]any{"GSUtilAuth": true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if err := tt.tpl.Execute(&out, tt.args); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), "| jq -r .access_token > /tmp/token") {
+				t.Fatalf("rendered script does not extract the access token as raw text:\n%s", out.String())
+			}
+		})
+	}
+}

--- a/pkg/build/gcb/planner.go
+++ b/pkg/build/gcb/planner.go
@@ -326,7 +326,7 @@ var gcbStandardBuildTpl = template.Must(
 			TETRAGON_PID=$(docker inspect -f '{{printf "%s" "{{.State.Pid}}"}}' tetragon)
 			{{- end}}
 			{{- if or .TimewarpAuth .TetragonSysgraphAuth}}
-			apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq .access_token > /tmp/token
+			apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq -r .access_token > /tmp/token
 			(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 			{{- end}}
 			{{- if .UseSyscallMonitor}}
@@ -413,7 +413,7 @@ var gcbProxyBuildTpl = template.Must(
 			set -eux
 			echo 'Starting rebuild for {{.TargetStr}}'
 			{{- if or .ProxyAuth .TetragonSysgraphAuth}}
-			apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq .access_token > /tmp/token
+			apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq -r .access_token > /tmp/token
 			(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 			{{- end}}
 			curl {{if .ProxyAuth}}-H @/tmp/auth_header {{end -}} {{.ProxyURL}} > proxy
@@ -873,7 +873,7 @@ var gcbAssetUploadTpl = template.Must(
 		textwrap.Dedent(`
 			set -eux
 			{{- if .GSUtilAuth}}
-			apk add curl jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq .access_token > /tmp/token
+			apk add curl jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/{{.ServiceAccountEmail}}/token | jq -r .access_token > /tmp/token
 			(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 			curl -H @/tmp/auth_header {{.GSUtilURL}} > gsutil_writeonly
 			{{- else}}

--- a/pkg/build/gcb/planner_test.go
+++ b/pkg/build/gcb/planner_test.go
@@ -804,7 +804,7 @@ func TestGCBPlannerBuildScriptWithSysgraph(t *testing.T) {
 					export TID=$(docker run --name=tetragon --detach --pid=host --cgroupns=host --privileged -v=/workspace/tetragon/:/workspace/tetragon/ -v=/sys/kernel/btf/vmlinux:/var/lib/tetragon/btf quay.io/cilium/tetragon:v1.4.1 /usr/bin/tetragon --tracing-policy-dir=/workspace/tetragon/ --server-address=unix:///workspace/tetragon/tetragon.sock --rb-size=10M --rb-queue-size=10M --event-queue-size=10000000)
 					grep -q "Listening for events..." <(docker logs --follow $TID 2>&1) || (docker logs $TID && exit 1)
 					TETRAGON_PID=$(docker inspect -f '{{.State.Pid}}' tetragon)
-					apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/test@test.iam.gserviceaccount.com/token | jq .access_token > /tmp/token
+					apt install -y jq && curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/test@test.iam.gserviceaccount.com/token | jq -r .access_token > /tmp/token
 					(printf "Authorization: Bearer "; cat /tmp/token) > /tmp/auth_header
 					curl -H @/tmp/auth_header https://storage.googleapis.com/bucket/tetragon_sysgraph > tetragon_sysgraph
 					chmod +x tetragon_sysgraph


### PR DESCRIPTION
GCB auth-enabled build templates extract `access_token` with `jq`'s JSON output mode. The resulting token file includes quotes, producing invalid Bearer headers.

Use `jq -r` in all three templates so the token is written as raw text.

Testing:
- `go test ./...`
- `go vet ./...`
- `go run ./ci -v check`