### PR TITLE
Add Cargo version floors for older editions

### DIFF
--- a/pkg/rebuild/cratesio/hints.go
+++ b/pkg/rebuild/cratesio/hints.go
@@ -25,13 +25,25 @@ var (
 	docExamplesRegex = regexp.MustCompile(`(?m)^\s*doc-scrape-examples\s*=\s*(true|false)\s*$`)
 )
 
-func hasPackageEdition2024(cargoTomlText string) bool {
+func packageEditionFloor(cargoTomlText string) string {
 	var manifest struct {
 		Package struct {
 			Edition string `toml:"edition"`
 		} `toml:"package"`
 	}
-	return toml.Unmarshal([]byte(cargoTomlText), &manifest) == nil && manifest.Package.Edition == "2024"
+	if toml.Unmarshal([]byte(cargoTomlText), &manifest) != nil {
+		return ""
+	}
+	switch manifest.Package.Edition {
+	case "2015", "2018":
+		return "1.30.0"
+	case "2021":
+		return "1.56.0"
+	case "2024":
+		return "1.85.0"
+	default:
+		return ""
+	}
 }
 
 // hasInlineMultiElementArray reports whether Cargo.toml contains an inline
@@ -89,8 +101,8 @@ func detectRustVersionBounds(cargoTomlText string) (lo, hi string) {
 	if hi == "999" {
 		hi = ""
 	}
-	if hasPackageEdition2024(cargoTomlText) {
-		lo = max("1.85.0", lo)
+	if editionLo := packageEditionFloor(cargoTomlText); editionLo != "" {
+		lo = max(editionLo, lo)
 		if hi != "" && semver.Cmp(hi, lo) < 0 {
 			hi = ""
 		}

--- a/pkg/rebuild/cratesio/hints_test.go
+++ b/pkg/rebuild/cratesio/hints_test.go
@@ -30,8 +30,8 @@ func TestDetectRustVersionBounds(t *testing.T) {
 edition = "2021"
 name = "my-crate"
 `,
-			wantLo: "1.55.0", // Cargo 1.56-1.63 can emit this shape without a resolver
-			wantHi: "",       // hi remains "999" and gets cleared
+			wantLo: "1.56.0",
+			wantHi: "", // hi remains "999" and gets cleared
 		},
 		{
 			name: "Old Header Without Resolver",
@@ -40,8 +40,35 @@ name = "my-crate"
 edition = "2018"
 name = "my-crate"
 `,
-			wantLo: "",
+			wantLo: "1.30.0",
 			wantHi: "1.54.0", // Cargo 1.51-1.54 can emit this shape without a resolver
+		},
+		{
+			name: "Edition 2015 floor",
+			cargoToml: `[package]
+name = "my-crate"
+edition = "2015"
+`,
+			wantLo: "1.30.0",
+			wantHi: "1.54.0",
+		},
+		{
+			name: "Edition 2018 floor",
+			cargoToml: `[package]
+name = "my-crate"
+edition = "2018"
+`,
+			wantLo: "1.30.0",
+			wantHi: "1.54.0",
+		},
+		{
+			name: "Edition 2021 overrides older upper bounds",
+			cargoToml: `[package]
+name = "my-crate"
+edition = "2021"
+`,
+			wantLo: "1.56.0",
+			wantHi: "",
 		},
 		{
 			name: "Edition 2024 overrides older upper bounds",

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -30,18 +30,18 @@ const (
 	pre150CargoTOML  = `# to registry (e.g., crates.io) dependencies`
 )
 
-func TestHasPackageEdition2024(t *testing.T) {
+func TestPackageEditionFloor(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		manifest string
-		want     bool
+		want     string
 	}{
 		{
 			name: "package edition",
 			manifest: `[package]
 edition = "2024" # supported since Cargo 1.85
 `,
-			want: true,
+			want: "1.85.0",
 		},
 		{
 			name: "metadata is not package edition",
@@ -65,11 +65,12 @@ edition = "2024"
 			manifest: `[package]
 edition = "2021"
 `,
+			want: "1.56.0",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := hasPackageEdition2024(tc.manifest); got != tc.want {
-				t.Errorf("hasPackageEdition2024() = %v, want %v", got, tc.want)
+			if got := packageEditionFloor(tc.manifest); got != tc.want {
+				t.Errorf("packageEditionFloor() = %q, want %q", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Edition fields require Cargo 1.30 for Editions 2015 and 2018, and Cargo 1.56 for Edition 2021. Current inference only applies the Edition 2024 floor.

Parse the package edition once and apply the corresponding lower bound. Edition-like values outside the package table remain ignored.

Testing:
- `go test ./...`
- `go vet ./...`
- Verified the acceptance boundaries with Cargo 1.29/1.30 and 1.55/1.56.