### PR TITLE
Reject invalid gzip checksums during stabilization

### DIFF
--- a/pkg/stabilize/finalization_test.go
+++ b/pkg/stabilize/finalization_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package stabilize
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/oss-rebuild/pkg/archive"
+)
+
+var errFinalWrite = errors.New("final write failed")
+
+type finalWriteError struct{}
+
+func (finalWriteError) Write([]byte) (int, error) {
+	return 0, errFinalWrite
+}
+
+type gzipTrailerError struct{}
+
+func (gzipTrailerError) Write(p []byte) (int, error) {
+	if len(p) == 8 {
+		return 0, errFinalWrite
+	}
+	return len(p), nil
+}
+
+func TestStabilizeReportsArchiveFinalizationError(t *testing.T) {
+	for _, format := range []archive.Format{
+		archive.ZipFormat,
+		archive.TarFormat,
+	} {
+		t.Run(fmt.Sprint(format), func(t *testing.T) {
+			err := Stabilize(finalWriteError{}, bytes.NewReader(emptyArchive(t, format)), format)
+			if !errors.Is(err, errFinalWrite) {
+				t.Fatalf("Stabilize() error = %v, want %v", err, errFinalWrite)
+			}
+		})
+	}
+}
+
+func TestStabilizeReportsGzipTrailerError(t *testing.T) {
+	for _, format := range []archive.Format{
+		archive.GzipFormat,
+		archive.TarGzFormat,
+	} {
+		t.Run(fmt.Sprint(format), func(t *testing.T) {
+			err := Stabilize(gzipTrailerError{}, bytes.NewReader(emptyArchive(t, format)), format)
+			if !errors.Is(err, errFinalWrite) {
+				t.Fatalf("Stabilize() error = %v, want %v", err, errFinalWrite)
+			}
+		})
+	}
+}
+
+func emptyArchive(t *testing.T, format archive.Format) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	switch format {
+	case archive.ZipFormat:
+		w := zip.NewWriter(&buf)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	case archive.TarFormat:
+		w := tar.NewWriter(&buf)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	case archive.GzipFormat:
+		w := gzip.NewWriter(&buf)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	case archive.TarGzFormat:
+		gw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gw)
+		if err := tw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := gw.Close(); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		t.Fatalf("unsupported format %v", format)
+	}
+	return buf.Bytes()
+}

--- a/pkg/stabilize/stabilizer.go
+++ b/pkg/stabilize/stabilizer.go
@@ -186,6 +186,10 @@ func stabilizeWithCtx(dst io.Writer, src io.Reader, f archive.Format, ctx *Stabi
 			_ = gzw.Close()
 			return errors.Wrap(err, "stabilizing tar.gz")
 		}
+		if _, err := io.Copy(io.Discard, gzr); err != nil {
+			_ = gzw.Close()
+			return errors.Wrap(err, "validating gzip stream")
+		}
 		if err := gzw.Close(); err != nil {
 			return errors.Wrap(err, "finalizing tar.gz")
 		}

--- a/pkg/stabilize/stabilizer.go
+++ b/pkg/stabilize/stabilizer.go
@@ -167,7 +167,6 @@ func stabilizeWithCtx(dst io.Writer, src io.Reader, f archive.Format, ctx *Stabi
 			return errors.Wrap(err, "initializing zip reader")
 		}
 		zw := zip.NewWriter(dst)
-		defer zw.Close()
 		err = StabilizeZip(zr, zw, ctx)
 		if err != nil {
 			return errors.Wrap(err, "stabilizing zip")
@@ -182,10 +181,13 @@ func stabilizeWithCtx(dst io.Writer, src io.Reader, f archive.Format, ctx *Stabi
 		if err != nil {
 			return errors.Wrap(err, "initializing gzip writer")
 		}
-		defer gzw.Close()
 		err = StabilizeTar(tar.NewReader(gzr), tar.NewWriter(gzw), ctx)
 		if err != nil {
+			_ = gzw.Close()
 			return errors.Wrap(err, "stabilizing tar.gz")
+		}
+		if err := gzw.Close(); err != nil {
+			return errors.Wrap(err, "finalizing tar.gz")
 		}
 	case archive.GzipFormat:
 		gzr, err := gzip.NewReader(src)
@@ -197,7 +199,6 @@ func stabilizeWithCtx(dst io.Writer, src io.Reader, f archive.Format, ctx *Stabi
 		if err != nil {
 			return errors.Wrap(err, "stabilizing gzip")
 		}
-		defer gzw.Close()
 		// NOTE: Memory-intensive. Buffers the full decompressed payload so GzipContentFn stabilizers can operate on it as a whole.
 		content, err := io.ReadAll(gzr)
 		if err != nil {
@@ -209,7 +210,11 @@ func stabilizeWithCtx(dst io.Writer, src io.Reader, f archive.Format, ctx *Stabi
 			}
 		}
 		if _, err := gzw.Write(content); err != nil {
+			_ = gzw.Close()
 			return errors.Wrap(err, "writing gzip content")
+		}
+		if err := gzw.Close(); err != nil {
+			return errors.Wrap(err, "finalizing gzip")
 		}
 	case archive.TarFormat:
 		err := StabilizeTar(tar.NewReader(src), tar.NewWriter(dst), ctx)

--- a/pkg/stabilize/tar.go
+++ b/pkg/stabilize/tar.go
@@ -136,8 +136,12 @@ var StabilizeCargoVCSHash = Stabilizer{
 }))
 
 // StabilizeTar strips volatile metadata and re-writes the provided archive in a standard form.
-func StabilizeTar(tr *tar.Reader, tw *tar.Writer, ctx *StabilizationContext) error {
-	defer tw.Close()
+func StabilizeTar(tr *tar.Reader, tw *tar.Writer, ctx *StabilizationContext) (retErr error) {
+	defer func() {
+		if err := tw.Close(); retErr == nil && err != nil {
+			retErr = errors.Wrap(err, "finalizing tar")
+		}
+	}()
 	var ents []*archive.TarEntry
 	for header, err := range iterx.ToSeq2(tr, io.EOF) {
 		if err != nil {

--- a/pkg/stabilize/targz_checksum_test.go
+++ b/pkg/stabilize/targz_checksum_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package stabilize
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	"github.com/google/oss-rebuild/pkg/archive"
+)
+
+func TestTarGzStabilizationRejectsInvalidGzipChecksum(t *testing.T) {
+	var input bytes.Buffer
+	gz := gzip.NewWriter(&input)
+	tw := tar.NewWriter(gz)
+	body := []byte("content")
+	if err := tw.WriteHeader(&tar.Header{Name: "file", Mode: 0o644, Size: int64(len(body))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := append([]byte(nil), input.Bytes()...)
+	corrupt[len(corrupt)-8] ^= 0xff
+	var output bytes.Buffer
+	if err := StabilizeWithOpts(&output, bytes.NewReader(corrupt), archive.TarGzFormat, StabilizeOpts{}); err == nil {
+		t.Fatal("StabilizeWithOpts error = nil for invalid gzip checksum")
+	}
+}

--- a/pkg/stabilize/zip.go
+++ b/pkg/stabilize/zip.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/pkg/archive"
+	"github.com/pkg/errors"
 )
 
 var zipFormats = []archive.Format{archive.ZipFormat}
@@ -105,8 +106,12 @@ var StableZipMisc = Stabilizer{
 }))
 
 // StabilizeZip strips volatile metadata and rewrites the provided archive in a standard form.
-func StabilizeZip(zr *zip.Reader, zw *zip.Writer, ctx *StabilizationContext) error {
-	defer zw.Close()
+func StabilizeZip(zr *zip.Reader, zw *zip.Writer, ctx *StabilizationContext) (retErr error) {
+	defer func() {
+		if err := zw.Close(); retErr == nil && err != nil {
+			retErr = errors.Wrap(err, "finalizing zip")
+		}
+	}()
 	mr := archive.NewMutableReader(zr)
 	// TODO: This ordering is inefficient as it lacks reuse for entryCtx
 	for _, s := range ctx.Stabilizers {


### PR DESCRIPTION
A TAR reader can stop at the TAR end markers before the outer GZIP stream reaches EOF. Since the GZIP checksum is verified at EOF, TAR.GZ stabilization can currently accept an invalid checksum.

Drain the remaining GZIP stream after TAR stabilization so checksum errors are returned.

Parents: #1450

Testing:
- `go test ./pkg/stabilize`
- `go test ./...`
- `go vet ./...`