### PR TITLE
Hide timewarp authorization headers from shell tracing

### DIFF
--- a/pkg/build/local/run_planner.go
+++ b/pkg/build/local/run_planner.go
@@ -45,7 +45,13 @@ var dockerRunPhaseTpls = template.Must(
 			{{.PackageManager.UpdateCmd}}
 			{{.PackageManager.InstallCommand (list "curl" "netcat-openbsd")}}
 			{{- end}}
-			curl {{if .TimewarpAuth}}-H "$AUTH_HEADER" {{end}}{{.TimewarpURL}} > /timewarp
+			{{- if .TimewarpAuth}}
+			set +x
+			curl -H "$AUTH_HEADER" {{.TimewarpURL}} > /timewarp
+			set -x
+			{{- else}}
+			curl {{.TimewarpURL}} > /timewarp
+			{{- end}}
 			chmod +x /timewarp
 			{{- end}}
 			{{.PackageManager.UpdateCmd}}

--- a/pkg/build/local/run_planner_test.go
+++ b/pkg/build/local/run_planner_test.go
@@ -226,6 +226,32 @@ func TestDockerRunPlanner(t *testing.T) {
 	}
 }
 
+func TestDockerRunPlannerHidesTimewarpAuthFromShellTrace(t *testing.T) {
+	plan, err := NewDockerRunPlanner().GeneratePlan(context.Background(), rebuild.Input{
+		Target: rebuild.Target{Ecosystem: rebuild.CratesIO, Package: "example", Version: "1.0.0"},
+		Strategy: &rebuild.ManualStrategy{
+			Location:   rebuild.Location{Repo: "https://example.com/repo", Ref: "v1.0.0"},
+			Deps:       "true",
+			Build:      "true",
+			OutputPath: "example-1.0.0.crate",
+		},
+	}, build.PlanOptions{
+		UseTimewarp: true,
+		Resources: build.Resources{
+			BaseImageConfig:  build.BaseImageConfig{Default: "alpine:3.19"},
+			ToolURLs:         map[build.ToolType]string{build.TimewarpTool: "https://example.com/timewarp"},
+			ToolAuthRequired: []string{"https://example.com/"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GeneratePlan() error: %v", err)
+	}
+	want := "set +x\ncurl -H \"$AUTH_HEADER\" https://example.com/timewarp > /timewarp\nset -x"
+	if !strings.Contains(plan.Setup, want) {
+		t.Fatalf("authenticated timewarp setup = %q, want trace disabled around header", plan.Setup)
+	}
+}
+
 func TestDockerRunPlanPhases(t *testing.T) {
 	plan := &DockerRunPlan{Setup: "s1", Source: "s2", Deps: "s3", Build: "s4"}
 	want := []Phase{{"setup", "s1"}, {"source", "s2"}, {"deps", "s3"}, {"build", "s4"}}


### PR DESCRIPTION
Local DockerRun phases execute with shell tracing enabled. When the timewarp download requires authentication, the expanded authorization header is therefore written to the build log.

Disable tracing only around the authenticated download and restore it immediately afterward.

Testing:
- `go test ./pkg/build/local`
- `go test ./...`
- `go vet ./...`