### PR TITLE
Reject timewarp upstream server errors

### DIFF
--- a/internal/timewarp/cargo.go
+++ b/internal/timewarp/cargo.go
@@ -136,9 +136,12 @@ func (h Handler) addPackageToIndex(fs billy.Filesystem, indexCommit, packageName
 		return errors.Wrap(err, "fetching index file")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		log.Printf("Package %s not found in index at commit %s", packageName, indexCommit)
+		return nil
+	}
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("Package %s not found in index at commit %s (status %d)", packageName, indexCommit, resp.StatusCode)
-		return nil // skip missing file
+		return errors.Errorf("fetching index file: unexpected HTTP status %d", resp.StatusCode)
 	}
 	// Ensure directory exists
 	if err := fs.MkdirAll(path.Dir(indexPath), 0755); err != nil {

--- a/internal/timewarp/cargo_status_test.go
+++ b/internal/timewarp/cargo_status_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package timewarp
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/internal/httpx/httpxtest"
+)
+
+func TestAddPackageToIndexRejectsUpstreamServerError(t *testing.T) {
+	client := &httpxtest.MockClient{
+		Calls: []httpxtest.Call{{
+			Response: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+			},
+		}},
+		SkipURLValidation: true,
+	}
+	err := (Handler{Client: client}).addPackageToIndex(memfs.New(), "0123456789abcdef", "foo")
+	if err == nil {
+		t.Fatal("addPackageToIndex() error = nil for upstream HTTP 500")
+	}
+}
+
+func TestAddPackageToIndexSkipsMissingPackage(t *testing.T) {
+	client := &httpxtest.MockClient{
+		Calls: []httpxtest.Call{{
+			Response: &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+			},
+		}},
+		SkipURLValidation: true,
+	}
+	if err := (Handler{Client: client}).addPackageToIndex(memfs.New(), "0123456789abcdef", "foo"); err != nil {
+		t.Fatalf("addPackageToIndex() error = %v for upstream HTTP 404", err)
+	}
+}

--- a/internal/timewarp/timewarp_test.go
+++ b/internal/timewarp/timewarp_test.go
@@ -620,6 +620,58 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			name:      "cargogitarchive missing package",
+			url:       "http://localhost:8081/index.git.tar",
+			basicAuth: "cargogitarchive:abc1234",
+			headers: map[string]string{
+				"X-Package-Names": "serde",
+			},
+			client: &httpxtest.MockClient{
+				URLValidator: httpxtest.NewURLValidator(t),
+				Calls: []httpxtest.Call{
+					{
+						Method: "GET",
+						URL:    "https://raw.githubusercontent.com/rust-lang/crates.io-index/abc1234/se/rd/serde",
+						Response: &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       http.NoBody,
+						},
+					},
+				},
+			},
+			want: &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/x-tar"},
+				},
+			},
+		},
+		{
+			name:      "cargogitarchive upstream server error",
+			url:       "http://localhost:8081/index.git.tar",
+			basicAuth: "cargogitarchive:abc1234",
+			headers: map[string]string{
+				"X-Package-Names": "serde",
+			},
+			client: &httpxtest.MockClient{
+				URLValidator: httpxtest.NewURLValidator(t),
+				Calls: []httpxtest.Call{
+					{
+						Method: "GET",
+						URL:    "https://raw.githubusercontent.com/rust-lang/crates.io-index/abc1234/se/rd/serde",
+						Response: &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       http.NoBody,
+						},
+					},
+				},
+			},
+			want: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error\n")),
+			},
+		},
+		{
 			name:      "cargogitarchive invalid path",
 			url:       "http://localhost:8081/wrong-path",
 			basicAuth: "cargogitarchive:abc1234",


### PR DESCRIPTION
Cargo timewarp currently treats every unsuccessful upstream index response as a missing package. A server error can therefore produce an incomplete index archive instead of failing the request.

Keep HTTP 404 as package absence and return an error for other unsuccessful statuses.

Testing:
- `go test ./internal/timewarp`
- `go test ./...`
- `go vet ./...`