### PR TITLE
Report GCB run sentinel failures

### DIFF
--- a/pkg/build/gcb/executor.go
+++ b/pkg/build/gcb/executor.go
@@ -271,6 +271,9 @@ func (e *Executor) executeBuild(ctx context.Context, handle *gcbHandle, cloudBui
 	// (preamble, image build, timeout) aborts before it, leaving no record.
 	var timings *rebuild.BuildTimings
 	runFailed := stepExitCode(buildResult, 0) == runFailureExitCode
+	if runFailed && buildErr == nil {
+		buildErr = errors.Errorf("GCB build run step failed with exit code %d", runFailureExitCode)
+	}
 	if (buildErr == nil || runFailed) && buildInfo.BuildID != "" && plan.timingStep() >= 0 {
 		var err error
 		timings, err = e.extractTimings(ctx, buildInfo.BuildID, plan, buildResult, runFailed)

--- a/pkg/build/gcb/executor_test.go
+++ b/pkg/build/gcb/executor_test.go
@@ -628,6 +628,22 @@ func TestExecutorTimings(t *testing.T) {
 			},
 		},
 		{
+			// An allowed nonzero exit still represents a failed rebuild even
+			// when later steps make the overall Cloud Build successful.
+			name:     "SentinelRunFailureWithSuccessfulBuild",
+			stepLog:  goodStepLog,
+			status:   "SUCCESS",
+			exitCode: runFailureExitCode,
+			wantErr:  true,
+			want: &rebuild.BuildTimings{
+				Setup:    durPtr(10 * time.Second),
+				Source:   durPtr(20 * time.Second),
+				Deps:     durPtr(40 * time.Second),
+				Build:    durPtr(24 * time.Second),
+				FailedIn: rebuild.PhaseBuild,
+			},
+		},
+		{
 			// Any other main-step failure aborts before the timing step.
 			name:    "OtherFailureUnmeasured",
 			stepLog: goodStepLog,

--- a/pkg/build/gcb/plan.go
+++ b/pkg/build/gcb/plan.go
@@ -17,8 +17,8 @@ const timingStepID = "timing"
 // runFailureExitCode is the sentinel indicating a failed docker run.
 // In main build script, Build.AllowExitCodes is configured for this value
 // which lets the build proceed to the timing step with the image and exited
-// container intact. The build will still fail on artifact copy but after
-// timing is extracted. Any other main-step exit aborts the build.
+// container intact. The executor still reports the sentinel as a failed
+// rebuild even if a later artifact copy succeeds.
 const runFailureExitCode = 43
 
 // Plan represents a Google Cloud Build execution plan

--- a/pkg/build/gcb/planner.go
+++ b/pkg/build/gcb/planner.go
@@ -639,9 +639,9 @@ func (p *Planner) generateSteps(target rebuild.Target, dockerfile string, reqs r
 	// Timing observation step: reads clocks the build's log stream cannot
 	// affect. Placed before extract so it also observes builds whose docker
 	// run exited with the allowed sentinel: the image and exited container
-	// hold complete clocks, and extract then fails on the missing artifact,
-	// so this step cannot mask the failure. Any other main-step exit still
-	// aborts the build here, leaving no record.
+	// hold complete clocks. The executor reports the sentinel as a failure even
+	// if extract succeeds on a file left by the failed run. Any other main-step
+	// exit still aborts the build here, leaving no record.
 	// NOTE: No -e and || true throughout so a flaking inspect cannot fail a
 	// successful rebuild.
 	// NOTE: The proxied daemon forwards to the step-shared docker socket, so


### PR DESCRIPTION
When timing collection is enabled, the main build step maps a failed docker run to an allowed sentinel exit so timing collection can continue. If the failed run leaves a file at the output path, artifact extraction can still succeed and Cloud Build reports success, causing the executor to return a successful rebuild.

Treat the sentinel exit as a rebuild failure while retaining timing extraction.

Testing:
- `go test ./pkg/build/gcb`
- `go test -race ./pkg/build/gcb`
- `go test ./...`
- `go vet ./...`
- Reproduced in Cloud Build with overall `SUCCESS`, main step `FAILURE`/43, and successful timing, extraction, and partial-artifact verification