### PR TITLE
Quote crates.io package directories

### DIFF
--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -66,6 +66,7 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 			Uses: "cargo/build/package",
 			With: map[string]string{
 				"dir":             b.Location.Dir,
+				"quotedDir":       shellQuote(b.Location.Dir),
 				"rustVersion":     b.RustVersion,
 				"excludeLockfile": fmt.Sprintf("%t", b.ExcludeLockfile),
 				"registryCommit":  b.RegistryCommit,
@@ -79,6 +80,10 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 // GenerateFor generates the instructions for a CratesIOCargoPackage.
 func (b *CratesIOCargoPackage) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
 	return b.ToWorkflow().GenerateFor(t, be)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 func init() {
@@ -129,7 +134,7 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
 				export CARGO_TARGET_DIR="$PWD/target"
-				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.dir}} && {{end -}}
+				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.quotedDir}} && {{end -}}
 				/root/.cargo/bin/cargo package --no-verify{{if eq .With.excludeLockfile "true"}} --exclude-lockfile{{end}}
 				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}`)[1:],
 			Needs: []string{"rustup"},

--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -65,6 +65,7 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 			Uses: "cargo/build/package",
 			With: map[string]string{
 				"dir":            b.Location.Dir,
+				"quotedDir":      shellQuote(b.Location.Dir),
 				"rustVersion":    b.RustVersion,
 				"registryCommit": b.RegistryCommit,
 				"useGitIndex":    fmt.Sprintf("%t", len(b.PackageNames) > 0),
@@ -77,6 +78,10 @@ func (b *CratesIOCargoPackage) ToWorkflow() *rebuild.WorkflowStrategy {
 // GenerateFor generates the instructions for a CratesIOCargoPackage.
 func (b *CratesIOCargoPackage) GenerateFor(t rebuild.Target, be rebuild.BuildEnv) (rebuild.Instructions, error) {
 	return b.ToWorkflow().GenerateFor(t, be)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 func init() {
@@ -127,7 +132,7 @@ var toolkit = []*flow.Tool{
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
 				export CARGO_TARGET_DIR="$PWD/target"
-				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.dir}} && {{end -}}
+				{{if and (ne .Location.Dir ".") (ne .Location.Dir "")}}(cd {{.With.quotedDir}} && {{end -}}
 				/root/.cargo/bin/cargo package --no-verify
 				{{- if and (ne .Location.Dir ".") (ne .Location.Dir "")}}){{end}}`)[1:],
 			Needs: []string{"rustup"},

--- a/pkg/rebuild/cratesio/strategy_dir_shell_test.go
+++ b/pkg/rebuild/cratesio/strategy_dir_shell_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package cratesio
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+func TestCratesIOCargoPackageQuotesDirectory(t *testing.T) {
+	for _, dir := range []string{"package with spaces", "package's source"} {
+		t.Run(dir, func(t *testing.T) {
+			root := t.TempDir()
+			want := filepath.Join(root, dir)
+			if err := os.MkdirAll(want, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			strategy := &CratesIOCargoPackage{
+				Location:    rebuild.Location{Dir: dir},
+				RustVersion: "1.77.0",
+			}
+			if got := strategy.ToWorkflow().Build[0].With["dir"]; got != dir {
+				t.Fatalf("dir = %q, want raw value %q", got, dir)
+			}
+			instructions, err := strategy.GenerateFor(rebuild.Target{Artifact: "test.crate"}, rebuild.BuildEnv{HasRepo: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := strings.Replace(instructions.Build, "/root/.cargo/bin/cargo package --no-verify", "pwd", 1)
+			cmd := exec.Command("sh", "-c", script)
+			cmd.Dir = root
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("build script failed: %v\n%s", err, output)
+			}
+			if got := strings.TrimSpace(string(output)); got != want {
+				t.Fatalf("pwd = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -4,11 +4,48 @@
 package cratesio
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 )
+
+func TestCratesIOCargoPackageQuotesDirectory(t *testing.T) {
+	for _, dir := range []string{"package with spaces", "package's source"} {
+		t.Run(dir, func(t *testing.T) {
+			root := t.TempDir()
+			want := filepath.Join(root, dir)
+			if err := os.MkdirAll(want, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			strategy := &CratesIOCargoPackage{
+				Location:    rebuild.Location{Dir: dir},
+				RustVersion: "1.77.0",
+			}
+			if got := strategy.ToWorkflow().Build[0].With["dir"]; got != dir {
+				t.Fatalf("dir = %q, want raw value %q", got, dir)
+			}
+			instructions, err := strategy.GenerateFor(rebuild.Target{Artifact: "test.crate"}, rebuild.BuildEnv{HasRepo: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := strings.Replace(instructions.Build, "/root/.cargo/bin/cargo package --no-verify", "pwd", 1)
+			cmd := exec.Command("sh", "-c", script)
+			cmd.Dir = root
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("build script failed: %v\n%s", err, output)
+			}
+			if got := strings.TrimSpace(string(output)); got != want {
+				t.Fatalf("pwd = %q, want %q", got, want)
+			}
+		})
+	}
+}
 
 func TestCratesIOCargoPackage(t *testing.T) {
 
@@ -36,7 +73,7 @@ func TestCratesIOCargoPackage(t *testing.T) {
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -57,7 +94,7 @@ func TestCratesIOCargoPackage(t *testing.T) {
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.87.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify --exclude-lockfile)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify --exclude-lockfile)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -135,7 +172,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 /usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -159,7 +196,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -183,7 +220,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 /usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -203,7 +240,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.55.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -228,7 +265,7 @@ wget -O - --header "X-Package-Names: serde,tokio" "http://cargogitarchive:abc123
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config.toml`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -254,7 +291,7 @@ wget -O - --header "X-Package-Names: serde,tokio" "http://cargogitarchive:abc123
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -276,7 +313,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-lo
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "sparse+http://cargosparse:abc1234@localhost:8081/"\n' > /.cargo/config.toml`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -36,7 +36,7 @@ func TestCratesIOCargoPackage(t *testing.T) {
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -114,7 +114,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 /usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -138,7 +138,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -162,7 +162,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 /usr/bin/rustup-init -y --profile minimal --default-toolchain 1.77.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -182,7 +182,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregist
 				Deps: `/usr/bin/rustup-init -y --profile minimal --default-toolchain 1.55.0
 # NOTE: Using current crates.io registry`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -207,7 +207,7 @@ wget -O - --header "X-Package-Names: serde,tokio" "http://cargogitarchive:abc123
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config.toml`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -233,7 +233,7 @@ wget -O - --header "X-Package-Names: serde,tokio" "http://cargogitarchive:abc123
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-local]\nregistry = "file:///cargo-index"\n' > /.cargo/config`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},
@@ -255,7 +255,7 @@ printf '[source.crates-io]\nreplace-with = "timewarp-local"\n[source.timewarp-lo
 mkdir -p /.cargo
 printf '[source.crates-io]\nreplace-with = "timewarp"\n[source.timewarp]\nregistry = "sparse+http://cargosparse:abc1234@localhost:8081/"\n' > /.cargo/config.toml`,
 				Build: `export CARGO_TARGET_DIR="$PWD/target"
-(cd the_dir && /root/.cargo/bin/cargo package --no-verify)`,
+(cd 'the_dir' && /root/.cargo/bin/cargo package --no-verify)`,
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "rustup"},
 				},


### PR DESCRIPTION
`cargo/build/package` inserts the inferred package directory into a `cd` command without shell quoting. Published crates do use such paths: `dontuse-this-002` 0.1.1 has a `path_in_vcs` of `The Rust Programming Language - 2nd Try/ch14_publish-crate`, causing the generated command to fail before Cargo starts.

Keep the raw directory available to the workflow and shell-quote only the `cd` operand.

Testing:
- `go test ./pkg/rebuild/cratesio`
- `go test ./...`
- `go vet ./...`