### PR TITLE
Report asset upload finalization errors

### DIFF
--- a/pkg/build/gcb/asset_writer_close_test.go
+++ b/pkg/build/gcb/asset_writer_close_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package gcb
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+var errAssetClose = errors.New("asset close failed")
+
+type closeErrorWriter struct{ bytes.Buffer }
+
+func (*closeErrorWriter) Close() error { return errAssetClose }
+
+type closeErrorStore struct{}
+
+func (closeErrorStore) Reader(context.Context, rebuild.Asset) (io.ReadCloser, error) {
+	return nil, errors.New("unused")
+}
+
+func (closeErrorStore) Writer(context.Context, rebuild.Asset) (io.WriteCloser, error) {
+	return &closeErrorWriter{}, nil
+}
+
+func TestUploadHelpersReportCloseError(t *testing.T) {
+	e := &Executor{}
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"content", func() error {
+			return e.uploadContent(context.Background(), closeErrorStore{}, rebuild.Asset{}, []byte("data"))
+		}},
+		{"build info", func() error {
+			return e.uploadBuildInfo(context.Background(), closeErrorStore{}, rebuild.Asset{}, rebuild.BuildInfo{})
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); !errors.Is(err, errAssetClose) {
+				t.Fatalf("error = %v, want asset close error", err)
+			}
+		})
+	}
+}

--- a/pkg/build/gcb/executor.go
+++ b/pkg/build/gcb/executor.go
@@ -421,11 +421,11 @@ func (e *Executor) uploadBuildInfo(ctx context.Context, store rebuild.AssetStore
 	if err != nil {
 		return errors.Wrap(err, "failed to get asset store writer")
 	}
-	defer writer.Close()
 	if err := json.NewEncoder(writer).Encode(buildInfo); err != nil {
+		writer.Close()
 		return errors.Wrap(err, "failed to encode and write build info")
 	}
-	return nil
+	return errors.Wrap(writer.Close(), "committing asset")
 }
 
 // uploadContent uploads content directly to the asset store
@@ -434,11 +434,11 @@ func (e *Executor) uploadContent(ctx context.Context, store rebuild.AssetStore, 
 	if err != nil {
 		return errors.Wrap(err, "failed to get asset store writer")
 	}
-	defer writer.Close()
 	if _, err := writer.Write(content); err != nil {
+		writer.Close()
 		return errors.Wrap(err, "failed to write content to asset store")
 	}
-	return nil
+	return errors.Wrap(writer.Close(), "committing asset")
 }
 
 // copyBuildLogs copies build logs using the logs client to the asset store.

--- a/pkg/build/local/asset_writer_close_test.go
+++ b/pkg/build/local/asset_writer_close_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+var errLocalAssetClose = errors.New("asset close failed")
+
+type localCloseErrorWriter struct{ bytes.Buffer }
+
+func (*localCloseErrorWriter) Close() error { return errLocalAssetClose }
+
+type localCloseErrorStore struct{}
+
+func (localCloseErrorStore) Reader(context.Context, rebuild.Asset) (io.ReadCloser, error) {
+	return nil, errors.New("unused")
+}
+
+func (localCloseErrorStore) Writer(context.Context, rebuild.Asset) (io.WriteCloser, error) {
+	return &localCloseErrorWriter{}, nil
+}
+
+func TestUploadHelpersReportCloseError(t *testing.T) {
+	ctx := context.Background()
+	store := localCloseErrorStore{}
+	asset := rebuild.Asset{}
+	filePath := filepath.Join(t.TempDir(), "asset")
+	if err := os.WriteFile(filePath, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buildExecutor := &DockerBuildExecutor{}
+	runExecutor := &DockerRunExecutor{}
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"docker build content", func() error {
+			return buildExecutor.uploadContent(ctx, store, asset, []byte("data"))
+		}},
+		{"docker build file", func() error {
+			return buildExecutor.uploadFile(ctx, store, asset, filePath)
+		}},
+		{"docker run content", func() error {
+			return runExecutor.uploadContent(ctx, store, asset, []byte("data"))
+		}},
+		{"docker run file", func() error {
+			return runExecutor.uploadFile(ctx, store, asset, filePath)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); !errors.Is(err, errLocalAssetClose) {
+				t.Fatalf("error = %v, want asset close error", err)
+			}
+		})
+	}
+}

--- a/pkg/build/local/build_executor.go
+++ b/pkg/build/local/build_executor.go
@@ -395,11 +395,11 @@ func (e *DockerBuildExecutor) uploadFile(ctx context.Context, store rebuild.Asse
 	if err != nil {
 		return errors.Wrap(err, "failed to get asset store writer")
 	}
-	defer writer.Close()
 	if _, err := io.Copy(writer, file); err != nil {
+		writer.Close()
 		return errors.Wrap(err, "failed to upload file to asset store")
 	}
-	return nil
+	return errors.Wrap(writer.Close(), "committing asset")
 }
 
 // uploadContent uploads content directly to the asset store.
@@ -408,11 +408,11 @@ func (e *DockerBuildExecutor) uploadContent(ctx context.Context, store rebuild.A
 	if err != nil {
 		return errors.Wrap(err, "failed to get asset store writer")
 	}
-	defer writer.Close()
 	if _, err := writer.Write(content); err != nil {
+		writer.Close()
 		return errors.Wrap(err, "failed to write to asset store")
 	}
-	return nil
+	return errors.Wrap(writer.Close(), "committing asset")
 }
 
 // saveContainerImage saves the built container image as a gzipped tarball.

--- a/pkg/build/local/run_executor.go
+++ b/pkg/build/local/run_executor.go
@@ -316,11 +316,11 @@ func (e *DockerRunExecutor) uploadFile(ctx context.Context, store rebuild.AssetS
 	if err != nil {
 		return errors.Wrap(err, "failed to get asset store writer")
 	}
-	defer writer.Close()
 	if _, err := io.Copy(writer, file); err != nil {
+		writer.Close()
 		return errors.Wrap(err, "failed to upload file to asset store")
 	}
-	return nil
+	return errors.Wrap(writer.Close(), "committing asset")
 }
 
 // uploadContent uploads content directly to the asset store
@@ -329,11 +329,11 @@ func (e *DockerRunExecutor) uploadContent(ctx context.Context, store rebuild.Ass
 	if err != nil {
 		return errors.Wrap(err, "failed to get asset store writer")
 	}
-	defer writer.Close()
 	if _, err := writer.Write(content); err != nil {
+		writer.Close()
 		return errors.Wrap(err, "failed to write content to asset store")
 	}
-	return nil
+	return errors.Wrap(writer.Close(), "committing asset")
 }
 
 // exportContainer commits the container state to an image, saves it as a gzipped tarball, then removes the committed image.


### PR DESCRIPTION
GCS-backed asset writers can report upload failures from `Close`. The GCB, DockerBuild, and DockerRun upload helpers currently defer `Close` and return success after writing, discarding those errors.

Close each writer explicitly after a successful write and return its finalization error. Preserve the original write error on failure.

Testing:
- `go test ./pkg/build/gcb ./pkg/build/local`
- `go test -race ./pkg/build/gcb ./pkg/build/local`
- `go test ./...`
- `go vet ./...`