### PR TITLE
Restrict Cargo VCS hash stabilization to package roots

### DIFF
--- a/pkg/stabilize/tar.go
+++ b/pkg/stabilize/tar.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/fs"
+	"path"
 	"slices"
 	"strings"
 	"time"
@@ -118,7 +119,8 @@ var AllCrateStabilizers = []Stabilizer{
 var StabilizeCargoVCSHash = Stabilizer{
 	Name: "cargo-vcs-hash",
 }.WithFn(TarEntryFn(func(e *archive.TarEntry) {
-	if strings.HasSuffix(e.Name, ".cargo_vcs_info.json") {
+	parts := strings.Split(path.Clean(e.Name), "/")
+	if len(parts) <= 2 && parts[len(parts)-1] == ".cargo_vcs_info.json" {
 		var vcsInfo map[string]any
 		if err := json.Unmarshal(e.Body, &vcsInfo); err != nil {
 			return // Skip if invalid JSON

--- a/pkg/stabilize/tar_test.go
+++ b/pkg/stabilize/tar_test.go
@@ -118,6 +118,26 @@ func TestStabilizeCargoVCSHash(t *testing.T) {
 			stabilizers: AllCrateStabilizers,
 		},
 		{
+			test: "nested cargo_vcs_info.json unchanged",
+			input: []*archive.TarEntry{
+				{Header: &tar.Header{Name: "some-crate-1.0.0/vendor/.cargo_vcs_info.json", Typeflag: tar.TypeReg}, Body: []byte(`{"git":{"sha1":"fa8197f11d79a079fcb1f6ef67fa9119ce6939b9"}}`)},
+			},
+			expected: []*archive.TarEntry{
+				{Header: &tar.Header{Name: "some-crate-1.0.0/vendor/.cargo_vcs_info.json", Typeflag: tar.TypeReg}, Body: []byte(`{"git":{"sha1":"fa8197f11d79a079fcb1f6ef67fa9119ce6939b9"}}`)},
+			},
+			stabilizers: AllCrateStabilizers,
+		},
+		{
+			test: "suffix-only file unchanged",
+			input: []*archive.TarEntry{
+				{Header: &tar.Header{Name: "some-crate-1.0.0/not.cargo_vcs_info.json", Typeflag: tar.TypeReg}, Body: []byte(`{"git":{"sha1":"fa8197f11d79a079fcb1f6ef67fa9119ce6939b9"}}`)},
+			},
+			expected: []*archive.TarEntry{
+				{Header: &tar.Header{Name: "some-crate-1.0.0/not.cargo_vcs_info.json", Typeflag: tar.TypeReg}, Body: []byte(`{"git":{"sha1":"fa8197f11d79a079fcb1f6ef67fa9119ce6939b9"}}`)},
+			},
+			stabilizers: AllCrateStabilizers,
+		},
+		{
 			test: "non-cargo_vcs_info.json file unchanged",
 			input: []*archive.TarEntry{
 				{Header: &tar.Header{Name: "Cargo.toml", Typeflag: tar.TypeReg}, Body: []byte(`[package]


### PR DESCRIPTION
The Cargo VCS stabilizer currently matches every path ending in `.cargo_vcs_info.json`. Published crates can include nested files with that name as ordinary package content; `bitnet 0.31.5` contains `bitcoin-0.31.0/.cargo_vcs_info.json`. Differences in that file are currently removed during stabilization.

Limit the stabilizer to the generated sidecar at the package root. Nested and suffix-only files remain unchanged.

Testing:
- `go test ./...`
- `go vet ./...`