### PR TITLE
Add per-version drill-down page

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -112,6 +112,14 @@ func main() {
 			Package:   t.Package,
 		}, nil
 	}, api.HTMLHandler(DashboardInit, api.WithTimeout(30*time.Second, dashboard.Package), dashboard.PackageTmpl)))
+	http.HandleFunc("/package/{ecosystem}/{package}/version/{version}", api.Translate(func(r *http.Request) (dashboard.VersionRequest, error) {
+		t := encoding.New(rebuild.Ecosystem(r.PathValue("ecosystem")), r.PathValue("package"), r.PathValue("version"), "").Decode()
+		return dashboard.VersionRequest{
+			Ecosystem: string(t.Ecosystem),
+			Package:   t.Package,
+			Version:   t.Version,
+		}, nil
+	}, api.HTMLHandler(DashboardInit, api.WithTimeout(30*time.Second, dashboard.Version), dashboard.VersionTmpl)))
 	http.HandleFunc("/attempt/{ecosystem}/{package}/{version}/{artifact}/{runid}", api.Translate(func(r *http.Request) (dashboard.AttemptRequest, error) {
 		t := encoding.New(
 			rebuild.Ecosystem(r.PathValue("ecosystem")),

--- a/internal/api/dashboard/dashboard.css
+++ b/internal/api/dashboard/dashboard.css
@@ -79,3 +79,13 @@ pre {
 .bg-green { background-color: var(--accent); color: #fff; }
 .bg-red { background-color: var(--mismatch); color: #fff; }
 .bg-gray { background-color: var(--fill); color: var(--muted); }
+
+/* Sessions and running status */
+.hint { color: var(--muted); font-size: 0.85rem; margin: 4px 0 0; }
+.status-running { color: var(--failure); font-weight: 600; }
+.session { border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; margin-bottom: 12px; background: #fff; }
+.session-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.session-id { font-family: ui-monospace, monospace; font-size: 0.85rem; color: var(--secondary); }
+.session-meta { color: var(--muted); font-size: 0.85rem; }
+.session-summary { margin: 6px 0; color: var(--body); }
+.session table { margin-top: 8px; }

--- a/internal/api/dashboard/dashboard.go
+++ b/internal/api/dashboard/dashboard.go
@@ -24,6 +24,8 @@ var (
 	indexHTML string
 	//go:embed package.gohtml
 	packageHTML string
+	//go:embed version.gohtml
+	versionHTML string
 	//go:embed attempt.gohtml
 	attemptHTML string
 	//go:embed logs.gohtml
@@ -53,6 +55,7 @@ func RegisterAssets(mux *http.ServeMux) {
 var (
 	IndexTmpl   *template.Template
 	PackageTmpl *template.Template
+	VersionTmpl *template.Template
 	AttemptTmpl *template.Template
 	LogsTmpl    *template.Template
 )
@@ -60,6 +63,7 @@ var (
 func init() {
 	IndexTmpl = template.Must(template.New("index").Parse(headerHTML + indexHTML))
 	PackageTmpl = template.Must(template.New("package").Parse(headerHTML + packageHTML))
+	VersionTmpl = template.Must(template.New("version").Parse(headerHTML + versionHTML))
 	AttemptTmpl = template.Must(template.New("attempt").Parse(headerHTML + attemptHTML))
 	LogsTmpl = template.Must(template.New("logs").Parse(logsHTML))
 }
@@ -104,7 +108,8 @@ func applySuccessRegex(successRegex *regexp.Regexp, rebuilds []rundex.Rebuild) {
 // dashboard links (e.g. to the package page).
 type SessionView struct {
 	schema.AgentSession
-	Encoded rebuild.EncodedTarget
+	Encoded    rebuild.EncodedTarget
+	Iterations []schema.AgentIteration // NOTE: Only populated by pages where it's required
 }
 
 func NewSessionView(s schema.AgentSession) SessionView {

--- a/internal/api/dashboard/dashboard_test.go
+++ b/internal/api/dashboard/dashboard_test.go
@@ -100,6 +100,9 @@ func (f *fakeReader) RecentRebuilds(context.Context) ([]rundex.Rebuild, error) {
 func (f *fakeReader) RecentPackageRebuilds(context.Context, rebuild.Ecosystem, string) ([]rundex.Rebuild, error) {
 	return f.recent, nil
 }
+func (f *fakeReader) FetchRebuilds(context.Context, *rundex.FetchRebuildRequest) ([]rundex.Rebuild, error) {
+	return f.recent, nil
+}
 
 // fakeSessionReader is a rundex.SessionReader returning canned sessions.
 type fakeSessionReader struct {

--- a/internal/api/dashboard/version.go
+++ b/internal/api/dashboard/version.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"context"
+	"slices"
+
+	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/pkg/act/api"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/pkg/errors"
+)
+
+var _ api.HandlerFn[VersionRequest, VersionData, *Deps] = Version
+
+type VersionRequest struct {
+	Ecosystem string
+	Package   string
+	Version   string
+}
+
+func (VersionRequest) Validate() error { return nil }
+
+type VersionData struct {
+	Ecosystem      string
+	PackageName    string
+	Version        string
+	EncodedPackage string
+	// Attempts are this version's rebuild attempts (across artifacts), newest-first.
+	Attempts []RebuildView
+	// Sessions are this version's agent sessions with their iterations, newest-first.
+	Sessions []SessionView
+}
+
+// Version aggregates every rebuild attempt and agent session (with iterations)
+// for a single package version.
+func Version(ctx context.Context, req VersionRequest, deps *Deps) (*VersionData, error) {
+	target := rebuild.Target{Ecosystem: rebuild.Ecosystem(req.Ecosystem), Package: req.Package, Version: req.Version}
+
+	rebuilds, err := deps.Rundex.FetchRebuilds(ctx, &rundex.FetchRebuildRequest{
+		Target: &target,
+		Opts:   rundex.FetchRebuildOpts{IncludePending: true},
+		Limit:  200,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching attempts")
+	}
+	slices.SortFunc(rebuilds, func(a, b rundex.Rebuild) int { return b.Created.Compare(a.Created) })
+	attempts := make([]RebuildView, 0, len(rebuilds))
+	for _, rb := range rebuilds {
+		attempts = append(attempts, NewRebuildView(rb))
+	}
+
+	var sessions []SessionView
+	if deps.Sessions != nil {
+		ss, err := deps.Sessions.FetchSessions(ctx, &rundex.FetchSessionsReq{PartialTarget: &target})
+		if err != nil {
+			return nil, errors.Wrap(err, "fetching agent sessions")
+		}
+		slices.SortFunc(ss, func(a, b schema.AgentSession) int { return b.Created.Compare(a.Created) })
+		for i := range ss {
+			// Iterations are best-effort. A failure to load them shouldn't sink the page.
+			iters, _ := deps.Sessions.FetchIterations(ctx, &rundex.FetchIterationsReq{SessionID: ss[i].ID})
+			slices.SortFunc(iters, func(a, b schema.AgentIteration) int { return a.Number - b.Number })
+			view := NewSessionView(ss[i])
+			view.Iterations = iters
+			sessions = append(sessions, view)
+		}
+	}
+
+	et := packagePathEncoding.Encode(target)
+	return &VersionData{
+		Ecosystem:      req.Ecosystem,
+		PackageName:    req.Package,
+		Version:        req.Version,
+		EncodedPackage: et.Package,
+		Attempts:       attempts,
+		Sessions:       sessions,
+	}, nil
+}

--- a/internal/api/dashboard/version.gohtml
+++ b/internal/api/dashboard/version.gohtml
@@ -1,0 +1,75 @@
+<!--
+ Copyright 2026 Google LLC
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+    <h2><a href="/package/{{.Ecosystem}}/{{.EncodedPackage}}">{{.Ecosystem}}: {{.PackageName}}</a> @ {{.Version}}</h2>
+
+    <h3>Rebuild attempts</h3>
+    {{if .Attempts}}
+    <table>
+        <thead>
+            <tr>
+                <th>Artifact</th>
+                <th>Status</th>
+                <th>Message</th>
+                <th>Reference</th>
+                <th>Created</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Attempts}}
+            <tr>
+                <td>{{.Artifact}}</td>
+                <td>
+                    {{if .Success}}<span class="status-success">Success</span>
+                    {{else if eq (printf "%s" .Status) "RUNNING"}}<span class="status-running">Running</span>
+                    {{else}}<span class="status-fail">Failed</span>{{end}}
+                </td>
+                <td><small>{{.Message}}</small></td>
+                <td><a href="/attempt/{{.Encoded.Ecosystem}}/{{.Encoded.Package}}/{{.Encoded.Version}}/{{.Encoded.Artifact}}/{{.RunID}}">{{.RunID}}</a></td>
+                <td>{{.Created.Format "2006-01-02 15:04:05"}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+    {{else}}
+    <p class="hint">No rebuild attempts recorded for this version.</p>
+    {{end}}
+
+    <h3>Agent sessions</h3>
+    {{if .Sessions}}
+    {{range .Sessions}}
+    <div class="session">
+        <div class="session-head">
+            <span class="session-id">{{.ID}}</span>
+            {{if eq .StopReason "SUCCESS"}}<span class="status-success">Success</span>
+            {{else if .StopReason}}<span class="status-fail">{{.StopReason}}</span>
+            {{else if eq .Status "RUNNING"}}<span class="status-running">Running</span>
+            {{else}}<span>{{.Status}}</span>{{end}}
+            <span class="session-meta">{{.Target.Artifact}} · {{.Created.Format "2006-01-02 15:04:05"}}{{if .ExecutionName}} · hosted{{else}} · local{{end}}</span>
+        </div>
+        {{if .Summary}}<div class="session-summary"><small>{{.Summary}}</small></div>{{end}}
+        {{if .Iterations}}
+        <table>
+            <thead><tr><th>#</th><th>Status</th><th>Build</th><th>Result</th></tr></thead>
+            <tbody>
+                {{range .Iterations}}
+                <tr>
+                    <td>{{.Number}}</td>
+                    <td>{{.Status}}</td>
+                    <td><small>{{.ObliviousID}}</small></td>
+                    <td><small>{{if .Result}}{{if .Result.BuildSuccess}}build ok{{else}}{{.Result.ErrorMessage}}{{end}}{{end}}</small></td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+        {{end}}
+    </div>
+    {{end}}
+    {{else}}
+    <p class="hint">No agent sessions recorded for this version.</p>
+    {{end}}
+
+</body>
+</html>

--- a/internal/api/dashboard/version_test.go
+++ b/internal/api/dashboard/version_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+func TestVersionHandler(t *testing.T) {
+	rebuilds := &fakeReader{recent: []rundex.Rebuild{
+		{RebuildAttempt: schema.RebuildAttempt{Ecosystem: "npm", Package: "a", Version: "1", Artifact: "a-1.tgz", RunID: "run1", Success: true}},
+	}}
+	sessions := &fakeSessionReader{sessions: []schema.AgentSession{
+		{ID: "s1", Target: rebuild.Target{Ecosystem: "npm", Package: "a", Version: "1"}, Status: schema.AgentSessionStatusCompleted, StopReason: schema.AgentCompleteReasonSuccess, Summary: "fixed it"},
+	}}
+	deps := &Deps{Rundex: rebuilds, Sessions: sessions}
+
+	got, err := Version(context.Background(), VersionRequest{Ecosystem: "npm", Package: "a", Version: "1"}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Attempts) != 1 || got.Attempts[0].RunID != "run1" {
+		t.Errorf("unexpected attempts: %+v", got.Attempts)
+	}
+	if len(got.Sessions) != 1 || got.Sessions[0].ID != "s1" {
+		t.Errorf("unexpected sessions: %+v", got.Sessions)
+	}
+
+	var buf strings.Builder
+	if err := VersionTmpl.Execute(&buf, got); err != nil {
+		t.Fatalf("rendering version template: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Rebuild attempts", "Agent sessions", "run1", "s1", "fixed it"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered version page missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Adds /package/{ecosystem}/{package}/version/{version}: every rebuild attempt
for a single version alongside that version's agent sessions and their
iterations. The package view links to it in a follow-up change.