### PR TITLE
Bump the health timeout on scratch creation to 3 minutes

### DIFF
--- a/internal/api/agentapiservice/scratch.go
+++ b/internal/api/agentapiservice/scratch.go
@@ -211,7 +211,7 @@ func ScratchDelete(ctx context.Context, req schema.ScratchDeleteRequest, deps *S
 func waitHealthy(ctx context.Context, deps *ScratchCreateDeps, ip string) error {
 	timeout := deps.HealthTimeout
 	if timeout <= 0 {
-		timeout = 90 * time.Second
+		timeout = 3 * time.Minute
 	}
 	interval := deps.HealthInterval
 	if interval <= 0 {


### PR DESCRIPTION
I was seeing very frequent timeouts with only 90 seconds (maybe like
40% of the time?)