### PR TITLE
Summarize per-version status on the package view

### DIFF
--- a/internal/api/dashboard/dashboard.css
+++ b/internal/api/dashboard/dashboard.css
@@ -89,3 +89,19 @@ pre {
 .session-meta { color: var(--muted); font-size: 0.85rem; }
 .session-summary { margin: 6px 0; color: var(--body); }
 .session table { margin-top: 8px; }
+
+/* Summary cards. */
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin-bottom: 8px;
+}
+.card {
+    background: #fff;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px;
+}
+.card-value { font-family: 'Merriweather', serif; font-size: 2rem; color: var(--heading); }
+.card-label { color: var(--secondary); font-size: 0.9rem; margin-top: 4px; }

--- a/internal/api/dashboard/package.go
+++ b/internal/api/dashboard/package.go
@@ -39,7 +39,8 @@ type PackageData struct {
 	Ecosystem      string
 	PackageName    string
 	EncodedPackage string
-	Events         []PackageEvent // rebuild attempsts and agent sessions, most-recent-first
+	Summary        PackageSummary // high-level per-package status shown at the top
+	Events         []PackageEvent // rebuild attempts and agent sessions, most-recent-first
 }
 
 func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData, error) {
@@ -69,6 +70,8 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 		}
 	}
 
+	summary := summarize(computeVersionStatuses(eco, req.Package, rebuilds, sessions))
+
 	// Intermingle rebuilds and sessions into a single timeline, most recent
 	// first, capped to the events window.
 	events := make([]PackageEvent, 0, len(rebuilds)+len(sessions))
@@ -92,6 +95,7 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 		Ecosystem:      req.Ecosystem,
 		PackageName:    req.Package,
 		EncodedPackage: et.Package,
+		Summary:        summary,
 		Events:         events,
 	}, nil
 }

--- a/internal/api/dashboard/package.gohtml
+++ b/internal/api/dashboard/package.gohtml
@@ -3,7 +3,30 @@
  SPDX-License-Identifier: Apache-2.0
 -->
 
-    <h2>History for {{.Ecosystem}}: {{.PackageName}}</h2>
+    <h2>{{.Ecosystem}}: {{.PackageName}}</h2>
+
+    <div class="cards">
+        <div class="card">
+            <div class="card-value">{{.Summary.VerifiedPct}}%</div>
+            <div class="card-label">verified of {{.Summary.Attempted}} attempted</div>
+        </div>
+        <div class="card">
+            <div class="card-value">{{.Summary.Verified}}</div>
+            <div class="card-label">verified</div>
+        </div>
+        <div class="card">
+            <div class="card-value">{{.Summary.Failed}}</div>
+            <div class="card-label">failed</div>
+        </div>
+        <div class="card">
+            <div class="card-value">{{.Summary.Running}}</div>
+            <div class="card-label">running</div>
+        </div>
+        <div class="card">
+            <div class="card-value">{{.Summary.AgentRuns}}</div>
+            <div class="card-label">agent runs</div>
+        </div>
+    </div>
     <table>
         <thead>
             <tr>

--- a/internal/api/dashboard/status.go
+++ b/internal/api/dashboard/status.go
@@ -1,0 +1,185 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"sort"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+// VersionState is the coarse status a version's attempts and agent sessions roll
+// up to. Detail (which failure phase, how many attempts, etc.) lives in the
+// per-version drill-down.
+type VersionState string
+
+const (
+	StateUntried  VersionState = "untried"
+	StateVerified VersionState = "verified"
+	StateFailed   VersionState = "failed"
+	StateRunning  VersionState = "running"
+)
+
+// AgentState summarizes agent activity on a version.
+type AgentState string
+
+const (
+	AgentNone    AgentState = ""
+	AgentRunning AgentState = "running"
+	AgentFixed   AgentState = "fixed"
+	AgentFailed  AgentState = "failed"
+)
+
+// VersionStatus is the aggregated status of a single package version across all
+// of its rebuild attempts and agent sessions.
+type VersionStatus struct {
+	Version  string
+	Encoded  rebuild.EncodedTarget
+	State    VersionState
+	Agent    AgentState
+	Attempts int
+	Sessions int
+}
+
+// PackageSummary is the high-level status shown at the top of the package view.
+type PackageSummary struct {
+	Attempted   int // versions with at least one attempt or session
+	Verified    int
+	Failed      int
+	Running     int
+	AgentRuns   int
+	VerifiedPct int
+}
+
+// isVerified reports whether an attempt reproduced upstream.
+func isVerified(rb rundex.Rebuild) bool {
+	return rb.Success
+}
+
+// computeVersionStatuses aggregates rebuilds + agent sessions into a per-version
+// status list covering the versions we've touched, most recently active first.
+// It is pure (no I/O) so it can be unit tested with canned data.
+func computeVersionStatuses(eco rebuild.Ecosystem, pkg string, rebuilds []rundex.Rebuild, sessions []schema.AgentSession) []VersionStatus {
+	type bucket struct {
+		attempts []rundex.Rebuild
+		sessions []schema.AgentSession
+		last     time.Time
+	}
+	byVer := map[string]*bucket{}
+	touch := func(v string, t time.Time) *bucket {
+		b := byVer[v]
+		if b == nil {
+			b = &bucket{}
+			byVer[v] = b
+		}
+		if t.After(b.last) {
+			b.last = t
+		}
+		return b
+	}
+	for _, rb := range rebuilds {
+		b := touch(rb.Version, rb.Created)
+		b.attempts = append(b.attempts, rb)
+	}
+	for i := range sessions {
+		s := sessions[i]
+		b := touch(s.Target.Version, s.Created)
+		b.sessions = append(b.sessions, s)
+	}
+
+	var order []string
+	for v := range byVer {
+		order = append(order, v)
+	}
+	sort.Slice(order, func(i, j int) bool { return byVer[order[i]].last.After(byVer[order[j]].last) })
+
+	out := make([]VersionStatus, 0, len(order))
+	for _, v := range order {
+		vs := VersionStatus{
+			Version: v,
+			Encoded: packagePathEncoding.Encode(rebuild.Target{Ecosystem: eco, Package: pkg, Version: v}),
+			State:   StateUntried,
+		}
+		if b := byVer[v]; b != nil {
+			vs.Attempts = len(b.attempts)
+			vs.Sessions = len(b.sessions)
+			classifyVersion(&vs, b.attempts, b.sessions)
+		}
+		out = append(out, vs)
+	}
+	return out
+}
+
+// classifyVersion sets State/Agent from a version's attempts+sessions.
+func classifyVersion(vs *VersionStatus, attempts []rundex.Rebuild, sessions []schema.AgentSession) {
+	var verified, running, failed bool
+	for _, a := range attempts {
+		if isVerified(a) {
+			verified = true
+		}
+		if a.Status == schema.RebuildStatusRunning {
+			running = true
+		}
+		if !isVerified(a) && a.Status != schema.RebuildStatusRunning {
+			failed = true
+		}
+	}
+	agent := AgentNone
+	for _, s := range sessions {
+		switch {
+		case s.Status == schema.AgentSessionStatusRunning || s.Status == schema.AgentSessionStatusInitializing:
+			running = true
+			if agent != AgentFixed {
+				agent = AgentRunning
+			}
+		case s.StopReason == schema.AgentCompleteReasonSuccess:
+			verified = true
+			agent = AgentFixed
+		case s.StopReason == schema.AgentCompleteReasonFailed || s.StopReason == schema.AgentCompleteReasonError:
+			failed = true
+			if agent == AgentNone {
+				agent = AgentFailed
+			}
+		}
+	}
+	vs.Agent = agent
+	switch {
+	case verified:
+		vs.State = StateVerified
+	case running:
+		vs.State = StateRunning
+	case failed:
+		vs.State = StateFailed
+	default:
+		vs.State = StateUntried
+	}
+}
+
+// summarize rolls up a version-status list into the package header summary.
+func summarize(statuses []VersionStatus) PackageSummary {
+	var s PackageSummary
+	for _, v := range statuses {
+		if v.Attempts > 0 || v.Sessions > 0 {
+			s.Attempted++
+		}
+		if v.Sessions > 0 {
+			s.AgentRuns += v.Sessions
+		}
+		switch v.State {
+		case StateVerified:
+			s.Verified++
+		case StateFailed:
+			s.Failed++
+		case StateRunning:
+			s.Running++
+		}
+	}
+	if s.Attempted > 0 {
+		s.VerifiedPct = int(100 * s.Verified / s.Attempted)
+	}
+	return s
+}

--- a/internal/api/dashboard/status_test.go
+++ b/internal/api/dashboard/status_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+func vsRebuild(version string, status schema.RebuildStatus, success bool, created time.Time) rundex.Rebuild {
+	return rundex.Rebuild{RebuildAttempt: schema.RebuildAttempt{
+		Ecosystem: "npm", Package: "p", Version: version,
+		Status: status, Success: success, Created: created,
+	}}
+}
+
+func sess(version, statusOrStop string, created time.Time) schema.AgentSession {
+	s := schema.AgentSession{Target: rebuild.Target{Ecosystem: "npm", Package: "p", Version: version}, Created: created}
+	switch statusOrStop {
+	case "running":
+		s.Status = schema.AgentSessionStatusRunning
+	case "success":
+		s.Status = schema.AgentSessionStatusCompleted
+		s.StopReason = schema.AgentCompleteReasonSuccess
+	case "failed":
+		s.Status = schema.AgentSessionStatusCompleted
+		s.StopReason = schema.AgentCompleteReasonFailed
+	}
+	return s
+}
+
+func statusByVersion(list []VersionStatus) map[string]VersionStatus {
+	m := make(map[string]VersionStatus, len(list))
+	for _, v := range list {
+		m[v.Version] = v
+	}
+	return m
+}
+
+func TestComputeVersionStatuses_Classification(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rebuilds := []rundex.Rebuild{
+		vsRebuild("3.0", schema.RebuildStatusSuccess, true, t0),
+		vsRebuild("2.0", schema.RebuildStatusError, false, t0),
+		vsRebuild("1.0", schema.RebuildStatusRunning, false, t0),
+	}
+	got := statusByVersion(computeVersionStatuses("npm", "p", rebuilds, nil))
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 versions, got %d", len(got))
+	}
+	checks := map[string]VersionState{"3.0": StateVerified, "2.0": StateFailed, "1.0": StateRunning}
+	for v, want := range checks {
+		if got[v].State != want {
+			t.Errorf("version %s: got cell %q, want %q", v, got[v].State, want)
+		}
+	}
+}
+
+func TestComputeVersionStatuses_Agent(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sessions := []schema.AgentSession{
+		sess("3.0", "success", t0),
+		sess("2.0", "running", t0),
+		sess("1.0", "failed", t0),
+	}
+	got := statusByVersion(computeVersionStatuses("npm", "p", nil, sessions))
+	if got["3.0"].State != StateVerified || got["3.0"].Agent != AgentFixed {
+		t.Errorf("3.0: cell=%q agent=%q, want verified/fixed", got["3.0"].State, got["3.0"].Agent)
+	}
+	if got["2.0"].State != StateRunning || got["2.0"].Agent != AgentRunning {
+		t.Errorf("2.0: cell=%q agent=%q, want running/running", got["2.0"].State, got["2.0"].Agent)
+	}
+	if got["1.0"].State != StateFailed || got["1.0"].Agent != AgentFailed {
+		t.Errorf("1.0: cell=%q agent=%q, want failed/failed", got["1.0"].State, got["1.0"].Agent)
+	}
+}
+
+func TestComputeVersionStatuses_RecencyOrder(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rebuilds := []rundex.Rebuild{
+		vsRebuild("1.0", schema.RebuildStatusSuccess, true, t0),
+		vsRebuild("2.0", schema.RebuildStatusSuccess, true, t0.Add(time.Hour)),
+	}
+	got := computeVersionStatuses("debian", "p", rebuilds, nil)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 attempted versions, got %d", len(got))
+	}
+	if got[0].Version != "2.0" {
+		t.Errorf("expected most-recent version first, got %q", got[0].Version)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	statuses := []VersionStatus{
+		{Version: "4.0", State: StateVerified, Attempts: 1},
+		{Version: "3.0", State: StateFailed, Attempts: 2},
+		{Version: "2.0", State: StateRunning, Sessions: 1},
+	}
+	s := summarize(statuses)
+	if s.Attempted != 3 || s.Verified != 1 || s.Failed != 1 || s.Running != 1 {
+		t.Errorf("unexpected summary counts: %+v", s)
+	}
+	if s.VerifiedPct != 33 { // 1 verified / 3 attempted
+		t.Errorf("VerifiedPct = %d, want 33", s.VerifiedPct)
+	}
+	if s.AgentRuns != 1 {
+		t.Errorf("AgentRuns = %d, want 1", s.AgentRuns)
+	}
+}


### PR DESCRIPTION
Collapses a package's attempts and agent sessions into one status per
version (verified, failed or running, with an agent overlay) and shows
an at-a-glance rollup as a colored grid above the chronological history.