### PR TITLE
Add the version status strip to the package view

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -107,9 +108,13 @@ func main() {
 	http.HandleFunc("/", api.HTMLHandler(DashboardInit, api.WithTimeout(30*time.Second, dashboard.Index), dashboard.IndexTmpl))
 	http.HandleFunc("/package/{ecosystem}/{package}", api.Translate(func(r *http.Request) (dashboard.PackageRequest, error) {
 		t := encoding.New(rebuild.Ecosystem(r.PathValue("ecosystem")), r.PathValue("package"), "", "").Decode()
+		// TODO: Make this param and field name more precise.
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 		return dashboard.PackageRequest{
 			Ecosystem: string(t.Ecosystem),
 			Package:   t.Package,
+			Offset:    offset,
+			Expanded:  r.URL.Query().Get("expanded") != "",
 		}, nil
 	}, api.HTMLHandler(DashboardInit, api.WithTimeout(30*time.Second, dashboard.Package), dashboard.PackageTmpl)))
 	http.HandleFunc("/package/{ecosystem}/{package}/version/{version}", api.Translate(func(r *http.Request) (dashboard.VersionRequest, error) {

--- a/internal/api/dashboard/dashboard.css
+++ b/internal/api/dashboard/dashboard.css
@@ -105,3 +105,41 @@ pre {
 }
 .card-value { font-family: 'Merriweather', serif; font-size: 2rem; color: var(--heading); }
 .card-label { color: var(--secondary); font-size: 0.9rem; margin-top: 4px; }
+
+/* Version status strip. */
+
+/* Per-version status colors, shared by strip cells and legend swatches. */
+.state-verified { background: var(--accent); }
+.state-failed   { background: var(--mismatch); }
+.state-running  { background: var(--failure); }
+.state-untried  { background: var(--fill); }
+
+.strip-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin: 18px 0 6px;
+    color: var(--secondary);
+    font-size: 0.9rem;
+}
+.strip-nav a { margin-left: 12px; }
+/* The strip is a fixed-column grid; cells fill each column (1fr) so a row always
+   fits the width without a scrollbar. Collapsed, the server renders one row's
+   worth of cells. Expanded, several rows. Keep the column count in sync with
+   stripCols in package.go. */
+.strip {
+    display: grid;
+    grid-template-columns: repeat(50, 1fr);
+    gap: 3px;
+    margin-bottom: 10px;
+}
+.strip .cell {
+    aspect-ratio: 1;
+    border-radius: 3px;
+    border: 1px solid rgba(0, 0, 0, 0.10);
+}
+.strip .state-untried { border-style: dashed; }
+.strip .cell:hover { outline: 2px solid var(--heading); outline-offset: 1px; }
+.legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 8px; font-size: 0.85rem; }
+.legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.legend-swatch { width: 12px; height: 12px; border-radius: 3px; display: inline-block; }

--- a/internal/api/dashboard/package.go
+++ b/internal/api/dashboard/package.go
@@ -17,12 +17,23 @@ import (
 
 var _ api.HandlerFn[PackageRequest, PackageData, *Deps] = Package
 
+// The status strip is a grid of stripCols columns. Collapsed it shows one row.
+// Expanded it shows a bounded matrix of stripExpandedRows rows. The page size
+// (and thus how far older/newer paginate) follows the current mode. stripCols
+// must match the grid-template-columns count in dashboard.css.
+const (
+	stripCols         = 50
+	stripExpandedRows = 4
+)
+
 // eventsWindow caps how many recent events the timeline renders.
 const eventsWindow = 100
 
 type PackageRequest struct {
 	Ecosystem string
 	Package   string
+	Offset    int  // render strip scroll-back into the version history, 0 = newest
+	Expanded  bool // render strip as a multi-row grid rather than a single row
 }
 
 func (PackageRequest) Validate() error { return nil }
@@ -39,8 +50,17 @@ type PackageData struct {
 	Ecosystem      string
 	PackageName    string
 	EncodedPackage string
-	Summary        PackageSummary // high-level per-package status shown at the top
-	Events         []PackageEvent // rebuild attempts and agent sessions, most-recent-first
+	Summary        PackageSummary  // high-level per-package status shown at the top
+	Versions       []VersionStatus // windowed slice of the version history shown in the strip
+	Expanded       bool            // strip shown as a multi-row grid
+	Offset         int             // current window offset (for building toggle links)
+	HasPrev        bool            // a newer window exists (scroll toward newest)
+	HasNext        bool            // an older window exists (scroll back in time)
+	PrevOffset     int             // offset the newer-window link jumps to
+	NextOffset     int             // offset the older-window link jumps to
+	WindowFrom     int             // 1-based index of the first shown version (for the caption)
+	WindowTo       int             // 1-based index of the last shown version
+	Events         []PackageEvent  // rebuild attempts and agent sessions, most-recent-first
 }
 
 func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData, error) {
@@ -70,7 +90,21 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 		}
 	}
 
-	summary := summarize(computeVersionStatuses(eco, req.Package, rebuilds, sessions))
+	statuses := computeVersionStatuses(eco, req.Package, rebuilds, sessions)
+	summary := summarize(statuses)
+
+	// Window the version history for the strip.
+	pageSize := stripCols
+	if req.Expanded {
+		pageSize = stripCols * stripExpandedRows
+	}
+	total := len(statuses)
+	off := req.Offset
+	if off < 0 || off >= total {
+		off = 0
+	}
+	end := min(off+pageSize, total)
+	window := statuses[off:end]
 
 	// Intermingle rebuilds and sessions into a single timeline, most recent
 	// first, capped to the events window.
@@ -91,11 +125,27 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 
 	et := packagePathEncoding.Encode(rebuild.Target{Ecosystem: eco, Package: req.Package})
 
-	return &PackageData{
+	data := &PackageData{
 		Ecosystem:      req.Ecosystem,
 		PackageName:    req.Package,
 		EncodedPackage: et.Package,
 		Summary:        summary,
+		Versions:       window,
+		Expanded:       req.Expanded,
+		Offset:         off,
 		Events:         events,
-	}, nil
+	}
+	if total > 0 {
+		data.WindowFrom = off + 1
+		data.WindowTo = end
+	}
+	if off > 0 {
+		data.HasPrev = true
+		data.PrevOffset = max(0, off-pageSize)
+	}
+	if end < total {
+		data.HasNext = true
+		data.NextOffset = end
+	}
+	return data, nil
 }

--- a/internal/api/dashboard/package.gohtml
+++ b/internal/api/dashboard/package.gohtml
@@ -27,6 +27,30 @@
             <div class="card-label">agent runs</div>
         </div>
     </div>
+
+    {{if .Versions}}
+    <div class="strip-head">
+        <span>Versions (most recently active first) &middot; {{.WindowFrom}}-{{.WindowTo}} of {{.Summary.Attempted}}</span>
+        <span class="strip-nav">
+            {{/* TODO: Move these client-side */}}
+            {{if .Expanded}}<a href="?offset={{.Offset}}">Collapse</a>{{else}}<a href="?offset={{.Offset}}&expanded=1">Expand</a>{{end}}
+            {{if .HasPrev}}<a href="?offset={{.PrevOffset}}{{if .Expanded}}&expanded=1{{end}}">newer</a>{{end}}
+            {{if .HasNext}}<a href="?offset={{.NextOffset}}{{if .Expanded}}&expanded=1{{end}}">older</a>{{end}}
+        </span>
+    </div>
+    <div class="strip{{if .Expanded}} expanded{{end}}">
+        {{range .Versions}}
+        <a class="cell state-{{.State}}"
+           href="/package/{{.Encoded.Ecosystem}}/{{.Encoded.Package}}/version/{{.Encoded.Version}}"
+           title="{{.Version}} &middot; {{.State}}{{if .Agent}} &middot; agent {{.Agent}}{{end}}"></a>
+        {{end}}
+    </div>
+    <div class="legend">
+        <span class="legend-item"><span class="legend-swatch state-verified"></span>verified</span>
+        <span class="legend-item"><span class="legend-swatch state-failed"></span>failed</span>
+        <span class="legend-item"><span class="legend-swatch state-running"></span>running</span>
+    </div>
+    {{end}}
     <table>
         <thead>
             <tr>


### PR DESCRIPTION
Renders the per-version statuses as a grid of one cell per version, so a
package's shape is visible at a glance rather than by reading a table. The
strip shows one row by default and can be expanded to a bounded matrix, with
paging for packages whose history exceeds the window.

Cells link to the per-version drill-down.