### PR TITLE
Tab the package view and new by-version table

### DIFF
--- a/internal/api/dashboard/dashboard.css
+++ b/internal/api/dashboard/dashboard.css
@@ -143,3 +143,45 @@ pre {
 .legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 8px; font-size: 0.85rem; }
 .legend-item { display: inline-flex; align-items: center; gap: 6px; }
 .legend-swatch { width: 12px; height: 12px; border-radius: 3px; display: inline-block; }
+
+/* Tabs (pure CSS via hidden radios). */
+.tabbed { margin-top: 20px; }
+.tab-radio { position: absolute; opacity: 0; width: 0; height: 0; }
+.tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 14px;
+}
+.tab {
+    padding: 8px 16px;
+    cursor: pointer;
+    color: var(--muted);
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    font-weight: 600;
+}
+.tab:hover { color: var(--secondary); }
+.tab-panel { display: none; }
+#tab-events:checked ~ #panel-events { display: block; }
+#tab-rebuilds:checked ~ #panel-rebuilds { display: block; }
+#tab-sessions:checked ~ #panel-sessions { display: block; }
+#tab-versions:checked ~ #panel-versions { display: block; }
+#tab-events:checked ~ .tabs label[for="tab-events"],
+#tab-rebuilds:checked ~ .tabs label[for="tab-rebuilds"],
+#tab-sessions:checked ~ .tabs label[for="tab-sessions"],
+#tab-versions:checked ~ .tabs label[for="tab-versions"] {
+    color: var(--heading);
+    border-bottom-color: var(--accent);
+}
+
+/* Status badges in the by-version table. */
+.badge {
+    display: inline-block;
+    padding: 1px 9px;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #fff;
+}
+.badge.state-untried { color: var(--secondary); border: 1px solid var(--border); }

--- a/internal/api/dashboard/dashboard_test.go
+++ b/internal/api/dashboard/dashboard_test.go
@@ -211,3 +211,40 @@ func TestPackageHandlerNilSessions(t *testing.T) {
 		t.Fatalf("rendering package template: %v", err)
 	}
 }
+
+func TestPackageHandlerFilteredTimelines(t *testing.T) {
+	// The per-kind tabs are the merged timeline filtered, so each must carry only
+	// its own kind and together they must account for every event.
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	deps := &Deps{
+		Rundex: &fakeReader{recent: []rundex.Rebuild{
+			{RebuildAttempt: schema.RebuildAttempt{Ecosystem: "npm", Package: "a", Version: "1", RunID: "run1", Created: t0.Add(time.Hour)}},
+		}},
+		Sessions: &fakeSessionReader{sessions: []schema.AgentSession{
+			{ID: "s1", Target: rebuild.Target{Ecosystem: "npm", Package: "a", Version: "1"}, Status: schema.AgentSessionStatusCompleted, StopReason: schema.AgentCompleteReasonSuccess, Created: t0},
+		}},
+	}
+	got, err := Package(context.Background(), PackageRequest{Ecosystem: "npm", Package: "a"}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.RebuildEvents) != 1 || got.RebuildEvents[0].Rebuild == nil || got.RebuildEvents[0].Session != nil {
+		t.Errorf("RebuildEvents should hold only rebuilds: %+v", got.RebuildEvents)
+	}
+	if len(got.SessionEvents) != 1 || got.SessionEvents[0].Session == nil || got.SessionEvents[0].Rebuild != nil {
+		t.Errorf("SessionEvents should hold only sessions: %+v", got.SessionEvents)
+	}
+	if len(got.Events) != len(got.RebuildEvents)+len(got.SessionEvents) {
+		t.Errorf("merged timeline missed events: %d, want %d", len(got.Events), len(got.RebuildEvents)+len(got.SessionEvents))
+	}
+	var buf strings.Builder
+	if err := PackageTmpl.Execute(&buf, got); err != nil {
+		t.Fatalf("rendering package template: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"panel-rebuilds", "panel-sessions", ">Rebuilds<", ">Agent sessions<"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q", want)
+		}
+	}
+}

--- a/internal/api/dashboard/package.go
+++ b/internal/api/dashboard/package.go
@@ -26,8 +26,17 @@ const (
 	stripExpandedRows = 4
 )
 
-// eventsWindow caps how many recent events the timeline renders.
+// eventsWindow caps how many recent events each timeline renders. The timelines
+// are windowed separately so a busy stream of one kind can't crowd the other out
+// of its own tab.
 const eventsWindow = 100
+
+func windowEvents(events []PackageEvent) []PackageEvent {
+	if len(events) > eventsWindow {
+		return events[:eventsWindow]
+	}
+	return events
+}
 
 type PackageRequest struct {
 	Ecosystem string
@@ -43,7 +52,7 @@ func (PackageRequest) Validate() error { return nil }
 type PackageEvent struct {
 	Created time.Time
 	Rebuild *RebuildView
-	Session *schema.AgentSession
+	Session *SessionView
 }
 
 type PackageData struct {
@@ -60,7 +69,9 @@ type PackageData struct {
 	NextOffset     int             // offset the older-window link jumps to
 	WindowFrom     int             // 1-based index of the first shown version (for the caption)
 	WindowTo       int             // 1-based index of the last shown version
-	Events         []PackageEvent  // rebuild attempts and agent sessions, most-recent-first
+	Events         []PackageEvent  // rebuilds and sessions intermingled, most-recent-first
+	RebuildEvents  []PackageEvent  // the same timeline restricted to rebuild attempts
+	SessionEvents  []PackageEvent  // the same timeline restricted to agent sessions
 }
 
 func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData, error) {
@@ -106,22 +117,26 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 	end := min(off+pageSize, total)
 	window := statuses[off:end]
 
-	// Intermingle rebuilds and sessions into a single timeline, most recent
-	// first, capped to the events window.
-	events := make([]PackageEvent, 0, len(rebuilds)+len(sessions))
+	// Intermingle rebuilds and sessions into a single timeline, most recent first,
+	// keeping per-kind timelines for the filtered tabs.
+	rebuildEvents := make([]PackageEvent, 0, len(rebuilds))
 	for _, rb := range rebuilds {
 		view := NewRebuildView(rb)
-		events = append(events, PackageEvent{Created: rb.Created, Rebuild: &view})
+		rebuildEvents = append(rebuildEvents, PackageEvent{Created: rb.Created, Rebuild: &view})
 	}
-	for i := range sessions {
-		events = append(events, PackageEvent{Created: sessions[i].Created, Session: &sessions[i]})
+	sessionEvents := make([]PackageEvent, 0, len(sessions))
+	for _, s := range sessions {
+		view := NewSessionView(s)
+		sessionEvents = append(sessionEvents, PackageEvent{Created: s.Created, Session: &view})
 	}
-	slices.SortFunc(events, func(a, b PackageEvent) int {
-		return b.Created.Compare(a.Created)
-	})
-	if len(events) > eventsWindow {
-		events = events[:eventsWindow]
-	}
+	events := slices.Concat(rebuildEvents, sessionEvents)
+	byNewest := func(a, b PackageEvent) int { return b.Created.Compare(a.Created) }
+	slices.SortFunc(events, byNewest)
+	slices.SortFunc(rebuildEvents, byNewest)
+	slices.SortFunc(sessionEvents, byNewest)
+	events = windowEvents(events)
+	rebuildEvents = windowEvents(rebuildEvents)
+	sessionEvents = windowEvents(sessionEvents)
 
 	et := packagePathEncoding.Encode(rebuild.Target{Ecosystem: eco, Package: req.Package})
 
@@ -134,6 +149,8 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 		Expanded:       req.Expanded,
 		Offset:         off,
 		Events:         events,
+		RebuildEvents:  rebuildEvents,
+		SessionEvents:  sessionEvents,
 	}
 	if total > 0 {
 		data.WindowFrom = off + 1

--- a/internal/api/dashboard/package.gohtml
+++ b/internal/api/dashboard/package.gohtml
@@ -51,6 +51,8 @@
         <span class="legend-item"><span class="legend-swatch state-running"></span>running</span>
     </div>
     {{end}}
+{{define "eventTable"}}
+    {{if .}}
     <table>
         <thead>
             <tr>
@@ -64,7 +66,7 @@
             </tr>
         </thead>
         <tbody>
-            {{range .Events}}
+            {{range .}}
             {{if .Session}}
             {{with .Session}}
             <tr>
@@ -81,7 +83,7 @@
                     {{end}}
                 </td>
                 <td><small>{{.Summary}}</small></td>
-                <td><small>{{.ID}}</small></td>
+                <td><a href="/package/{{.Encoded.Ecosystem}}/{{.Encoded.Package}}/version/{{.Encoded.Version}}">{{.ID}}</a></td>
                 <td>{{.Created.Format "2006-01-02 15:04:05"}}</td>
             </tr>
             {{end}}
@@ -107,5 +109,52 @@
             {{end}}
         </tbody>
     </table>
+    {{else}}
+    <p class="hint">Nothing recorded yet.</p>
+    {{end}}
+{{end}}
+
+    <section class="tabbed">
+        <input type="radio" id="tab-events" name="pkgtab" class="tab-radio" checked>
+        <input type="radio" id="tab-rebuilds" name="pkgtab" class="tab-radio">
+        <input type="radio" id="tab-sessions" name="pkgtab" class="tab-radio">
+        <input type="radio" id="tab-versions" name="pkgtab" class="tab-radio">
+        <div class="tabs">
+            <label for="tab-events" class="tab">Recent events</label>
+            <label for="tab-rebuilds" class="tab">Rebuilds</label>
+            <label for="tab-sessions" class="tab">Agent sessions</label>
+            <label for="tab-versions" class="tab">By version</label>
+        </div>
+
+        <div id="panel-events" class="tab-panel">{{template "eventTable" .Events}}</div>
+        <div id="panel-rebuilds" class="tab-panel">{{template "eventTable" .RebuildEvents}}</div>
+        <div id="panel-sessions" class="tab-panel">{{template "eventTable" .SessionEvents}}</div>
+
+
+        <div id="panel-versions" class="tab-panel">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Version</th>
+                        <th>Status</th>
+                        <th>Agent</th>
+                        <th>Attempts</th>
+                        <th>Sessions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{range .Versions}}
+                    <tr>
+                        <td><a href="/package/{{.Encoded.Ecosystem}}/{{.Encoded.Package}}/version/{{.Encoded.Version}}">{{.Version}}</a></td>
+                        <td><span class="badge state-{{.State}}">{{.State}}</span></td>
+                        <td>{{if .Agent}}{{.Agent}}{{else}}-{{end}}</td>
+                        <td>{{.Attempts}}</td>
+                        <td>{{.Sessions}}</td>
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+    </section>
 </body>
 </html>


### PR DESCRIPTION
The event timeline and the per-version status answer different questions, so
put them behind tabs rather than stacking them. Rebuilds and agent sessions
each get their own tab as well, since scanning one kind is awkward when the
other is interleaved. Every tab renders through one shared table definition.

The by-version tab lists each version with its status, agent state and attempt
and session counts, which is the readable form of what the strip shows
graphically.