### PR TITLE
Include all published versions in status strip

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -17,9 +17,11 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/google/oss-rebuild/internal/api/dashboard"
+	"github.com/google/oss-rebuild/internal/httpegress"
 	"github.com/google/oss-rebuild/internal/rundex"
 	"github.com/google/oss-rebuild/pkg/act/api"
 	"github.com/google/oss-rebuild/pkg/feed"
+	"github.com/google/oss-rebuild/pkg/rebuild/meta"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/tools/benchmark"
 )
@@ -33,10 +35,13 @@ var (
 	logsBucket      = flag.String("logs-bucket", "", "GCS bucket containing build logs")
 )
 
+var egressCfg httpegress.Config
+
 var (
 	successPat *regexp.Regexp
 	tracked    feed.TrackedPackageIndex
 	benchName  string
+	registry   rebuild.RegistryMux // built once at startup
 )
 
 func DashboardInit(ctx context.Context) (*dashboard.Deps, error) {
@@ -59,10 +64,12 @@ func DashboardInit(ctx context.Context) (*dashboard.Deps, error) {
 		Tracked:       tracked,
 		BenchmarkName: benchName,
 		SuccessRegex:  successPat,
+		Registry:      registry,
 	}, nil
 }
 
 func main() {
+	egressCfg.RegisterFlags(flag.CommandLine)
 	flag.Parse()
 	if *project == "" {
 		log.Fatal("Must provide -project")
@@ -77,6 +84,11 @@ func main() {
 			log.Fatalf("Failed to compile success regex: %v", err)
 		}
 	}
+	egressClient, err := httpegress.MakeClient(context.Background(), egressCfg)
+	if err != nil {
+		log.Fatalf("Failed to create egress client: %v", err)
+	}
+	registry = meta.NewRegistryMux(egressClient)
 	if (*bench != "") == (*trackedPackages != "") {
 		log.Fatalf("Must provide exactly one of -bench or -tracked-packages")
 	}

--- a/internal/api/dashboard/dashboard.css
+++ b/internal/api/dashboard/dashboard.css
@@ -139,6 +139,7 @@ pre {
     border: 1px solid rgba(0, 0, 0, 0.10);
 }
 .strip .state-untried { border-style: dashed; }
+.state-regressed { box-shadow: inset 0 0 0 2px var(--failure), 0 0 0 1px var(--failure); }
 .strip .cell:hover { outline: 2px solid var(--heading); outline-offset: 1px; }
 .legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 8px; font-size: 0.85rem; }
 .legend-item { display: inline-flex; align-items: center; gap: 6px; }
@@ -185,3 +186,4 @@ pre {
     color: #fff;
 }
 .badge.state-untried { color: var(--secondary); border: 1px solid var(--border); }
+.badge.state-regressed { background: transparent; color: var(--failure); border: 1px solid var(--failure); box-shadow: none; }

--- a/internal/api/dashboard/dashboard.go
+++ b/internal/api/dashboard/dashboard.go
@@ -78,6 +78,7 @@ type Deps struct {
 	Tracked       feed.TrackedPackageIndex
 	BenchmarkName string
 	SuccessRegex  *regexp.Regexp
+	Registry      rebuild.RegistryMux // enumerates published versions for status
 }
 
 type RebuildView struct {

--- a/internal/api/dashboard/dashboard_test.go
+++ b/internal/api/dashboard/dashboard_test.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/pkg/rebuild/meta"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/pkg/errors"
 )
 
 func TestRegisterAssets(t *testing.T) {
@@ -104,6 +106,16 @@ func (f *fakeReader) FetchRebuilds(context.Context, *rundex.FetchRebuildRequest)
 	return f.recent, nil
 }
 
+// failingClient stands in for the registry in tests that don't exercise version
+// enumeration. Its failures drive Package's degraded path.
+type failingClient struct{}
+
+func (failingClient) Do(*http.Request) (*http.Response, error) {
+	return nil, errors.New("no registry in tests")
+}
+
+func unreachableRegistry() rebuild.RegistryMux { return meta.NewRegistryMux(failingClient{}) }
+
 // fakeSessionReader is a rundex.SessionReader returning canned sessions.
 type fakeSessionReader struct {
 	sessions []schema.AgentSession
@@ -163,7 +175,7 @@ func TestPackageHandler(t *testing.T) {
 		{ID: "old-session", Target: rebuild.Target{Ecosystem: "npm", Package: "a", Version: "1"}, Status: schema.AgentSessionStatusCompleted, StopReason: schema.AgentCompleteReasonFailed, Created: t0},
 		{ID: "new-session", Target: rebuild.Target{Ecosystem: "npm", Package: "a", Version: "2"}, Status: schema.AgentSessionStatusCompleted, StopReason: schema.AgentCompleteReasonSuccess, Summary: "Build successful", Created: t2},
 	}}
-	deps := &Deps{Rundex: rebuilds, Sessions: sessions}
+	deps := &Deps{Rundex: rebuilds, Sessions: sessions, Registry: unreachableRegistry()}
 	got, err := Package(context.Background(), PackageRequest{Ecosystem: "npm", Package: "a"}, deps)
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +210,7 @@ func TestPackageHandlerNilSessions(t *testing.T) {
 	// A nil session reader should still render the page with only rebuilds.
 	deps := &Deps{Rundex: &fakeReader{recent: []rundex.Rebuild{
 		{RebuildAttempt: schema.RebuildAttempt{Ecosystem: "npm", Package: "a", Version: "1", RunID: "run1"}},
-	}}}
+	}}, Registry: unreachableRegistry()}
 	got, err := Package(context.Background(), PackageRequest{Ecosystem: "npm", Package: "a"}, deps)
 	if err != nil {
 		t.Fatal(err)
@@ -223,6 +235,7 @@ func TestPackageHandlerFilteredTimelines(t *testing.T) {
 		Sessions: &fakeSessionReader{sessions: []schema.AgentSession{
 			{ID: "s1", Target: rebuild.Target{Ecosystem: "npm", Package: "a", Version: "1"}, Status: schema.AgentSessionStatusCompleted, StopReason: schema.AgentCompleteReasonSuccess, Created: t0},
 		}},
+		Registry: unreachableRegistry(),
 	}
 	got, err := Package(context.Background(), PackageRequest{Ecosystem: "npm", Package: "a"}, deps)
 	if err != nil {
@@ -246,5 +259,35 @@ func TestPackageHandlerFilteredTimelines(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("rendered output missing %q", want)
 		}
+	}
+}
+
+func TestPackageHandlerVersionListingFailure(t *testing.T) {
+	// A failed lookup must be distinguishable from an ecosystem that has no
+	// lister, since only one of the two is worth telling the reader about.
+	deps := &Deps{
+		Rundex: &fakeReader{recent: []rundex.Rebuild{
+			{RebuildAttempt: schema.RebuildAttempt{Ecosystem: "npm", Package: "a", Version: "1", RunID: "run1"}},
+		}},
+		Registry: unreachableRegistry(),
+	}
+	got, err := Package(context.Background(), PackageRequest{Ecosystem: "npm", Package: "a"}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Warning == "" {
+		t.Error("expected a warning for a failed version lookup")
+	}
+	if got.Summary.Supported {
+		t.Error("a failed lookup must not report the version history as enumerable")
+	}
+
+	// An ecosystem with no lister degrades identically but stays quiet.
+	got, err = Package(context.Background(), PackageRequest{Ecosystem: "debian", Package: "curl"}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Warning != "" {
+		t.Errorf("no-lister case should not warn, got %q", got.Warning)
 	}
 }

--- a/internal/api/dashboard/package.go
+++ b/internal/api/dashboard/package.go
@@ -5,6 +5,7 @@ package dashboard
 
 import (
 	"context"
+	"log"
 	"slices"
 	"time"
 
@@ -72,6 +73,7 @@ type PackageData struct {
 	Events         []PackageEvent  // rebuilds and sessions intermingled, most-recent-first
 	RebuildEvents  []PackageEvent  // the same timeline restricted to rebuild attempts
 	SessionEvents  []PackageEvent  // the same timeline restricted to agent sessions
+	Warning        string          // set when the version lookup failed, not when the ecosystem lacks a lister
 }
 
 func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData, error) {
@@ -101,8 +103,24 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 		}
 	}
 
-	statuses := computeVersionStatuses(eco, req.Package, rebuilds, sessions)
-	summary := summarize(statuses)
+	// Per-version status aggregation over the published versions (or, where the
+	// ecosystem can't enumerate versions, the attempted set).
+	var supported bool
+	var warning string
+	axis, err := publishedVersions(ctx, deps.Registry, rebuild.Target{Ecosystem: eco, Package: req.Package})
+	switch {
+	case err == nil:
+		supported = true
+	case errors.Is(err, errNoVersionLister):
+		// An expected limitation, reported to the reader as such.
+	default:
+		// A failed lookup degrades the page the same way a missing lister does, so
+		// say which one happened rather than blaming the ecosystem.
+		log.Printf("Listing versions for %s %s: %v", eco, req.Package, err)
+		warning = "Version listing failed, showing attempted versions only."
+	}
+	statuses := computeVersionStatuses(eco, req.Package, axis, supported, rebuilds, sessions)
+	summary := summarize(statuses, supported)
 
 	// Window the version history for the strip.
 	pageSize := stripCols
@@ -151,6 +169,7 @@ func Package(ctx context.Context, req PackageRequest, deps *Deps) (*PackageData,
 		Events:         events,
 		RebuildEvents:  rebuildEvents,
 		SessionEvents:  sessionEvents,
+		Warning:        warning,
 	}
 	if total > 0 {
 		data.WindowFrom = off + 1

--- a/internal/api/dashboard/package.gohtml
+++ b/internal/api/dashboard/package.gohtml
@@ -8,7 +8,7 @@
     <div class="cards">
         <div class="card">
             <div class="card-value">{{.Summary.VerifiedPct}}%</div>
-            <div class="card-label">verified of {{.Summary.Attempted}} attempted</div>
+            <div class="card-label">verified{{if .Summary.Supported}} of {{.Summary.TotalVersions}} versions{{else}} of {{.Summary.Attempted}} attempted{{end}}</div>
         </div>
         <div class="card">
             <div class="card-value">{{.Summary.Verified}}</div>
@@ -23,6 +23,10 @@
             <div class="card-label">running</div>
         </div>
         <div class="card">
+            <div class="card-value">{{.Summary.NeedsAttention}}</div>
+            <div class="card-label">regressions</div>
+        </div>
+        <div class="card">
             <div class="card-value">{{.Summary.AgentRuns}}</div>
             <div class="card-label">agent runs</div>
         </div>
@@ -30,7 +34,7 @@
 
     {{if .Versions}}
     <div class="strip-head">
-        <span>Versions (most recently active first) &middot; {{.WindowFrom}}-{{.WindowTo}} of {{.Summary.Attempted}}</span>
+        <span>Versions ({{if .Summary.Supported}}newest to oldest{{else}}most recently active first{{end}}) &middot; {{.WindowFrom}}-{{.WindowTo}} of {{if .Summary.Supported}}{{.Summary.TotalVersions}}{{else}}{{.Summary.Attempted}}{{end}}</span>
         <span class="strip-nav">
             {{/* TODO: Move these client-side */}}
             {{if .Expanded}}<a href="?offset={{.Offset}}">Collapse</a>{{else}}<a href="?offset={{.Offset}}&expanded=1">Expand</a>{{end}}
@@ -40,16 +44,20 @@
     </div>
     <div class="strip{{if .Expanded}} expanded{{end}}">
         {{range .Versions}}
-        <a class="cell state-{{.State}}"
+        <a class="cell state-{{.State}}{{if .Regressed}} state-regressed{{end}}"
            href="/package/{{.Encoded.Ecosystem}}/{{.Encoded.Package}}/version/{{.Encoded.Version}}"
-           title="{{.Version}} &middot; {{.State}}{{if .Agent}} &middot; agent {{.Agent}}{{end}}"></a>
+           title="{{.Version}} &middot; {{.State}}{{if .Regressed}} (regressed){{end}}{{if .Agent}} &middot; agent {{.Agent}}{{end}}"></a>
         {{end}}
     </div>
     <div class="legend">
         <span class="legend-item"><span class="legend-swatch state-verified"></span>verified</span>
         <span class="legend-item"><span class="legend-swatch state-failed"></span>failed</span>
         <span class="legend-item"><span class="legend-swatch state-running"></span>running</span>
+        <span class="legend-item"><span class="legend-swatch state-untried"></span>untried</span>
+        <span class="legend-item"><span class="legend-swatch state-regressed"></span>regression</span>
     </div>
+    {{if .Warning}}<p class="hint">{{.Warning}}</p>
+    {{else if not .Summary.Supported}}<p class="hint">Version enumeration isn't available for this ecosystem, showing attempted versions only.</p>{{end}}
     {{end}}
 {{define "eventTable"}}
     {{if .}}
@@ -146,7 +154,7 @@
                     {{range .Versions}}
                     <tr>
                         <td><a href="/package/{{.Encoded.Ecosystem}}/{{.Encoded.Package}}/version/{{.Encoded.Version}}">{{.Version}}</a></td>
-                        <td><span class="badge state-{{.State}}">{{.State}}</span></td>
+                        <td><span class="badge state-{{.State}}">{{.State}}</span>{{if .Regressed}} <span class="badge state-regressed">regressed</span>{{end}}</td>
                         <td>{{if .Agent}}{{.Agent}}{{else}}-{{end}}</td>
                         <td>{{.Attempts}}</td>
                         <td>{{.Sessions}}</td>

--- a/internal/api/dashboard/status.go
+++ b/internal/api/dashboard/status.go
@@ -37,22 +37,26 @@ const (
 // VersionStatus is the aggregated status of a single package version across all
 // of its rebuild attempts and agent sessions.
 type VersionStatus struct {
-	Version  string
-	Encoded  rebuild.EncodedTarget
-	State    VersionState
-	Agent    AgentState
-	Attempts int
-	Sessions int
+	Version   string
+	Encoded   rebuild.EncodedTarget
+	State     VersionState
+	Agent     AgentState
+	Regressed bool // Failed while an older version is Verified.
+	Attempts  int
+	Sessions  int
 }
 
 // PackageSummary is the high-level status shown at the top of the package view.
 type PackageSummary struct {
-	Attempted   int // versions with at least one attempt or session
-	Verified    int
-	Failed      int
-	Running     int
-	AgentRuns   int
-	VerifiedPct int
+	Supported      bool // whether the version history was enumerable for this ecosystem
+	TotalVersions  int
+	Attempted      int
+	Verified       int
+	Failed         int
+	Running        int
+	AgentRuns      int
+	NeedsAttention int // regressions
+	VerifiedPct    int
 }
 
 // isVerified reports whether an attempt reproduced upstream.
@@ -61,9 +65,11 @@ func isVerified(rb rundex.Rebuild) bool {
 }
 
 // computeVersionStatuses aggregates rebuilds + agent sessions into a per-version
-// status list covering the versions we've touched, most recently active first.
+// status list. When `supported`, `axis` is every published version (newest-first)
+// and untried versions are included. Otherwise the list is derived from versions
+// we've actually touched, ordered by most-recent activity.
 // It is pure (no I/O) so it can be unit tested with canned data.
-func computeVersionStatuses(eco rebuild.Ecosystem, pkg string, rebuilds []rundex.Rebuild, sessions []schema.AgentSession) []VersionStatus {
+func computeVersionStatuses(eco rebuild.Ecosystem, pkg string, axis []string, supported bool, rebuilds []rundex.Rebuild, sessions []schema.AgentSession) []VersionStatus {
 	type bucket struct {
 		attempts []rundex.Rebuild
 		sessions []schema.AgentSession
@@ -92,10 +98,28 @@ func computeVersionStatuses(eco rebuild.Ecosystem, pkg string, rebuilds []rundex
 	}
 
 	var order []string
-	for v := range byVer {
-		order = append(order, v)
+	if supported {
+		order = append(order, axis...)
+		seen := make(map[string]bool, len(axis))
+		for _, v := range axis {
+			seen[v] = true
+		}
+		// Include any attempted version missing from the published axis (e.g. a
+		// pre-release we tried) so its data isn't dropped.
+		var extra []string
+		for v := range byVer {
+			if !seen[v] {
+				extra = append(extra, v)
+			}
+		}
+		sort.Slice(extra, func(i, j int) bool { return byVer[extra[i]].last.After(byVer[extra[j]].last) })
+		order = append(order, extra...)
+	} else {
+		for v := range byVer {
+			order = append(order, v)
+		}
+		sort.Slice(order, func(i, j int) bool { return byVer[order[i]].last.After(byVer[order[j]].last) })
 	}
-	sort.Slice(order, func(i, j int) bool { return byVer[order[i]].last.After(byVer[order[j]].last) })
 
 	out := make([]VersionStatus, 0, len(order))
 	for _, v := range order {
@@ -110,6 +134,10 @@ func computeVersionStatuses(eco rebuild.Ecosystem, pkg string, rebuilds []rundex
 			classifyVersion(&vs, b.attempts, b.sessions)
 		}
 		out = append(out, vs)
+	}
+	// Regression only makes sense on a semver-ordered axis.
+	if supported {
+		markRegressions(out)
 	}
 	return out
 }
@@ -159,9 +187,25 @@ func classifyVersion(vs *VersionStatus, attempts []rundex.Rebuild, sessions []sc
 	}
 }
 
+// markRegressions flags Failed versions that have a Verified *older* version
+// (list is newest-first).
+func markRegressions(vs []VersionStatus) {
+	sawVerifiedOlder := false
+	for i := len(vs) - 1; i >= 0; i-- {
+		switch vs[i].State {
+		case StateVerified:
+			sawVerifiedOlder = true
+		case StateFailed:
+			if sawVerifiedOlder {
+				vs[i].Regressed = true
+			}
+		}
+	}
+}
+
 // summarize rolls up a version-status list into the package header summary.
-func summarize(statuses []VersionStatus) PackageSummary {
-	var s PackageSummary
+func summarize(statuses []VersionStatus, supported bool) PackageSummary {
+	s := PackageSummary{Supported: supported, TotalVersions: len(statuses)}
 	for _, v := range statuses {
 		if v.Attempts > 0 || v.Sessions > 0 {
 			s.Attempted++
@@ -177,9 +221,16 @@ func summarize(statuses []VersionStatus) PackageSummary {
 		case StateRunning:
 			s.Running++
 		}
+		if v.Regressed {
+			s.NeedsAttention++
+		}
 	}
-	if s.Attempted > 0 {
-		s.VerifiedPct = int(100 * s.Verified / s.Attempted)
+	denom := s.Attempted
+	if supported {
+		denom = s.TotalVersions
+	}
+	if denom > 0 {
+		s.VerifiedPct = int(100 * s.Verified / denom)
 	}
 	return s
 }

--- a/internal/api/dashboard/status_test.go
+++ b/internal/api/dashboard/status_test.go
@@ -44,17 +44,18 @@ func statusByVersion(list []VersionStatus) map[string]VersionStatus {
 
 func TestComputeVersionStatuses_Classification(t *testing.T) {
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	axis := []string{"4.0", "3.0", "2.0", "1.0"} // newest-first; "4.0" is untried
 	rebuilds := []rundex.Rebuild{
 		vsRebuild("3.0", schema.RebuildStatusSuccess, true, t0),
 		vsRebuild("2.0", schema.RebuildStatusError, false, t0),
 		vsRebuild("1.0", schema.RebuildStatusRunning, false, t0),
 	}
-	got := statusByVersion(computeVersionStatuses("npm", "p", rebuilds, nil))
+	got := statusByVersion(computeVersionStatuses("npm", "p", axis, true, rebuilds, nil))
 
-	if len(got) != 3 {
-		t.Fatalf("expected 3 versions, got %d", len(got))
+	if len(got) != 4 {
+		t.Fatalf("expected 4 versions, got %d", len(got))
 	}
-	checks := map[string]VersionState{"3.0": StateVerified, "2.0": StateFailed, "1.0": StateRunning}
+	checks := map[string]VersionState{"4.0": StateUntried, "3.0": StateVerified, "2.0": StateFailed, "1.0": StateRunning}
 	for v, want := range checks {
 		if got[v].State != want {
 			t.Errorf("version %s: got cell %q, want %q", v, got[v].State, want)
@@ -64,12 +65,13 @@ func TestComputeVersionStatuses_Classification(t *testing.T) {
 
 func TestComputeVersionStatuses_Agent(t *testing.T) {
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	axis := []string{"3.0", "2.0", "1.0"}
 	sessions := []schema.AgentSession{
 		sess("3.0", "success", t0),
 		sess("2.0", "running", t0),
 		sess("1.0", "failed", t0),
 	}
-	got := statusByVersion(computeVersionStatuses("npm", "p", nil, sessions))
+	got := statusByVersion(computeVersionStatuses("npm", "p", axis, true, nil, sessions))
 	if got["3.0"].State != StateVerified || got["3.0"].Agent != AgentFixed {
 		t.Errorf("3.0: cell=%q agent=%q, want verified/fixed", got["3.0"].State, got["3.0"].Agent)
 	}
@@ -81,33 +83,71 @@ func TestComputeVersionStatuses_Agent(t *testing.T) {
 	}
 }
 
+func TestComputeVersionStatuses_Regression(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Newest-first: 3.0 & 2.0 fail, 1.0 verified => 2.0 and 3.0 are regressions.
+	axis := []string{"3.0", "2.0", "1.0"}
+	rebuilds := []rundex.Rebuild{
+		vsRebuild("3.0", schema.RebuildStatusError, false, t0),
+		vsRebuild("2.0", schema.RebuildStatusError, false, t0),
+		vsRebuild("1.0", schema.RebuildStatusSuccess, true, t0),
+	}
+	got := statusByVersion(computeVersionStatuses("npm", "p", axis, true, rebuilds, nil))
+	if !got["3.0"].Regressed || !got["2.0"].Regressed {
+		t.Errorf("expected 3.0 and 2.0 flagged as regressions: 3.0=%v 2.0=%v", got["3.0"].Regressed, got["2.0"].Regressed)
+	}
+	if got["1.0"].Regressed {
+		t.Error("1.0 (verified) should not be a regression")
+	}
+
+	// No older verified version => no regression.
+	rebuilds2 := []rundex.Rebuild{
+		vsRebuild("3.0", schema.RebuildStatusError, false, t0),
+		vsRebuild("2.0", schema.RebuildStatusError, false, t0),
+	}
+	got2 := statusByVersion(computeVersionStatuses("npm", "p", axis, true, rebuilds2, nil))
+	if got2["3.0"].Regressed || got2["2.0"].Regressed {
+		t.Error("no verified older version: nothing should be flagged as a regression")
+	}
+}
+
 func TestComputeVersionStatuses_RecencyOrder(t *testing.T) {
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// supported=false ignores the axis and orders attempted versions by recency.
 	rebuilds := []rundex.Rebuild{
 		vsRebuild("1.0", schema.RebuildStatusSuccess, true, t0),
 		vsRebuild("2.0", schema.RebuildStatusSuccess, true, t0.Add(time.Hour)),
 	}
-	got := computeVersionStatuses("debian", "p", rebuilds, nil)
+	got := computeVersionStatuses("debian", "p", []string{"ignored"}, false, rebuilds, nil)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 attempted versions, got %d", len(got))
 	}
-	if got[0].Version != "2.0" {
+	if got[0].Version != "2.0" { // most recent activity first
 		t.Errorf("expected most-recent version first, got %q", got[0].Version)
+	}
+	for _, v := range got {
+		if v.Regressed {
+			t.Errorf("regression should not be computed on unsupported (unordered) axis: %+v", v)
+		}
 	}
 }
 
 func TestSummarize(t *testing.T) {
 	statuses := []VersionStatus{
 		{Version: "4.0", State: StateVerified, Attempts: 1},
-		{Version: "3.0", State: StateFailed, Attempts: 2},
+		{Version: "3.0", State: StateFailed, Attempts: 2, Regressed: true},
 		{Version: "2.0", State: StateRunning, Sessions: 1},
+		{Version: "1.0", State: StateUntried},
 	}
-	s := summarize(statuses)
-	if s.Attempted != 3 || s.Verified != 1 || s.Failed != 1 || s.Running != 1 {
+	s := summarize(statuses, true)
+	if s.TotalVersions != 4 || s.Attempted != 3 || s.Verified != 1 || s.Failed != 1 || s.Running != 1 {
 		t.Errorf("unexpected summary counts: %+v", s)
 	}
-	if s.VerifiedPct != 33 { // 1 verified / 3 attempted
-		t.Errorf("VerifiedPct = %d, want 33", s.VerifiedPct)
+	if s.NeedsAttention != 1 {
+		t.Errorf("NeedsAttention = %d, want 1", s.NeedsAttention)
+	}
+	if s.VerifiedPct != 25 { // 1 verified / 4 total versions
+		t.Errorf("VerifiedPct = %d, want 25", s.VerifiedPct)
 	}
 	if s.AgentRuns != 1 {
 		t.Errorf("AgentRuns = %d, want 1", s.AgentRuns)

--- a/internal/api/dashboard/versions.go
+++ b/internal/api/dashboard/versions.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"context"
+	"sort"
+
+	"github.com/google/oss-rebuild/internal/semver"
+	"github.com/google/oss-rebuild/pkg/rebuild/cratesio"
+	"github.com/google/oss-rebuild/pkg/rebuild/npm"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+)
+
+// errNoVersionLister reports that an ecosystem has no way to enumerate published
+// versions. Callers should treat it as an expected limitation rather than a
+// failure, and must not confuse it with a lookup that errored.
+var errNoVersionLister = errors.New("ecosystem has no version lister")
+
+// publishedVersions returns a package's registry-published versions newest-first
+// by semver. Ecosystems that cannot enumerate versions return
+// errNoVersionLister.
+//
+// NOTE: The GetVersions helpers order by publish time, which is wrong for a
+// version history. A late backport to an old major would sort above the current
+// releases. Re-sorting by semver puts them in true version order.
+func publishedVersions(ctx context.Context, mux rebuild.RegistryMux, target rebuild.Target) ([]string, error) {
+	var versions []string
+	var err error
+	switch target.Ecosystem {
+	case rebuild.NPM:
+		versions, err = npm.GetVersions(ctx, target.Package, mux)
+	case rebuild.CratesIO:
+		versions, err = cratesio.GetVersions(ctx, target.Package, mux)
+	default:
+		return nil, errNoVersionLister
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "listing versions")
+	}
+	sortVersionsDesc(versions)
+	return versions, nil
+}
+
+// sortVersionsDesc orders versions newest-first by semver. Unparseable versions
+// sort after all valid ones so a stray non-semver tag can't displace a release.
+func sortVersionsDesc(versions []string) {
+	sort.SliceStable(versions, func(i, j int) bool {
+		vi, ei := semver.New(versions[i])
+		vj, ej := semver.New(versions[j])
+		switch {
+		case ei == nil && ej == nil:
+			return vi.Compare(vj) > 0
+		case ei == nil:
+			return true
+		case ej == nil:
+			return false
+		default:
+			return versions[i] > versions[j]
+		}
+	})
+}

--- a/internal/api/dashboard/versions_test.go
+++ b/internal/api/dashboard/versions_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/google/oss-rebuild/internal/httpx/httpxtest"
+	"github.com/google/oss-rebuild/pkg/rebuild/meta"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+)
+
+func TestSortVersionsDesc(t *testing.T) {
+	// 5.2.4 is the backport case. Publish time could float it to the top, but
+	// semver ordering must keep it below the newer majors.
+	got := []string{"5.2.4", "8.18.0", "7.5.13", "6.2.3", "8.5.0", "weird-tag"}
+	sortVersionsDesc(got)
+	want := []string{"8.18.0", "8.5.0", "7.5.13", "6.2.3", "5.2.4", "weird-tag"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sortVersionsDesc = %v, want %v", got, want)
+	}
+}
+
+func TestPublishedVersionsUnsupported(t *testing.T) {
+	// The mux is never consulted. Short-circuiting before any request is what
+	// keeps the sentinel distinguishable from a lookup failure.
+	mux := meta.NewRegistryMux(&httpxtest.MockClient{})
+	_, err := publishedVersions(context.Background(), mux, rebuild.Target{Ecosystem: rebuild.Debian, Package: "curl"})
+	if !errors.Is(err, errNoVersionLister) {
+		t.Errorf("publishedVersions(debian) error = %v, want errNoVersionLister", err)
+	}
+}


### PR DESCRIPTION
Previously, we were only rendering the versions we'd attempted but now
we can fetch from ground truth and use the data to provide a more
faithful view of the package's historical status. Additionally, with the
versions in release order, a newer version that fails while an older
one is verified can be flagged as a regression.

Notably, we've only hooked up version listing for npm and crates as they
already defined the testers but python and other ecosystems will be
added in later PRs.