### PR TITLE
fix(stabilize): keep archive entries when ExcludePath globs error

### DIFF
--- a/pkg/stabilize/custom.go
+++ b/pkg/stabilize/custom.go
@@ -176,6 +176,11 @@ func (ep *ExcludePath) Validate() error {
 	if slices.Contains(ep.Paths, "") {
 		return errors.New("invalid path")
 	}
+	for _, p := range ep.Paths {
+		if _, err := glob.Match(p, "x"); err != nil {
+			return errors.Wrap(err, "bad path pattern")
+		}
+	}
 	return nil
 }
 
@@ -184,7 +189,9 @@ func (ep *ExcludePath) Stabilizer(name string) Stabilizer {
 	tarfn := TarArchiveFn(func(ta *archive.TarArchive) {
 		var files []*archive.TarEntry
 		for _, f := range ta.Files {
-			if match, err := multiMatch(ep.Paths, f.Name); err != nil || match {
+			// Keep the entry if the glob is malformed. Dropping on error emptied both
+			// archives and made ArtifactEquivalence attestations vacuous.
+			if match, err := multiMatch(ep.Paths, f.Name); err == nil && match {
 				continue
 			}
 			files = append(files, f)
@@ -199,7 +206,7 @@ func (ep *ExcludePath) Stabilizer(name string) Stabilizer {
 		archive.ZipFormat: ZipArchiveFn(func(mzr *archive.MutableZipReader) {
 			var files []*archive.MutableZipFile
 			for _, f := range mzr.File {
-				if match, err := multiMatch(ep.Paths, f.Name); err != nil || match {
+				if match, err := multiMatch(ep.Paths, f.Name); err == nil && match {
 					continue
 				}
 				files = append(files, f)

--- a/pkg/stabilize/custom_test.go
+++ b/pkg/stabilize/custom_test.go
@@ -190,6 +190,30 @@ func TestExcludePath_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "no path provided",
 		},
+		{
+			name: "two globstars",
+			ep: ExcludePath{
+				Paths: []string{"**/tests/**"},
+			},
+			wantErr: true,
+			errMsg:  "bad path pattern: invalid pattern: only one '**' is permitted",
+		},
+		{
+			name: "unterminated class",
+			ep: ExcludePath{
+				Paths: []string{"pkg/te[st.py"},
+			},
+			wantErr: true,
+			errMsg:  "bad path pattern: syntax error in pattern",
+		},
+		{
+			name: "globstar not slash delimited",
+			ep: ExcludePath{
+				Paths: []string{"**tests"},
+			},
+			wantErr: true,
+			errMsg:  "bad path pattern: invalid pattern: '**' must be surrounded by slashes or be at start/end of pattern",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -318,6 +342,31 @@ func TestExcludePath_Stabilizer(t *testing.T) {
 				t.Errorf("Stabilizer() impl type = %T, want %T", fn, tt.wantFunc)
 			}
 		})
+	}
+}
+
+func TestExcludePath_MalformedPatternKeepsEntries(t *testing.T) {
+	var zipFile bytes.Buffer
+	{
+		zw := zip.NewWriter(&zipFile)
+		for _, name := range []string{"pkg/index.js", "pkg/tests/a.js"} {
+			orDie((&archive.ZipEntry{FileHeader: &zip.FileHeader{Name: name}, Body: []byte(name)}).WriteTo(zw))
+		}
+		orDie(zw.Close())
+	}
+	// Bypass Validate so a slipped-through malformed glob still cannot empty the archive.
+	stab := (&ExcludePath{Paths: []string{"**/tests/**"}}).Stabilizer("test")
+	zr := must(zip.NewReader(bytes.NewReader(zipFile.Bytes()), int64(zipFile.Len())))
+	var output bytes.Buffer
+	zw := zip.NewWriter(&output)
+	orDie(StabilizeZip(zr, zw, NewContext(archive.ZipFormat).WithStabilizers([]Stabilizer{stab})))
+	got := must(zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len())))
+	var names []string
+	for _, f := range got.File {
+		names = append(names, f.Name)
+	}
+	if diff := cmp.Diff([]string{"pkg/index.js", "pkg/tests/a.js"}, names); diff != "" {
+		t.Errorf("entries (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
`ExcludePath` treated a glob error as a match (`err != nil || match` then drop). A malformed pattern such as `**/tests/**` (two globstars, rejected by `internal/glob`) therefore dropped every archive entry. Gzip framing and the tar/zip trailers are fully normalized, so both the rebuilt and upstream artifacts could stabilize to the same empty archive and `stabilizedMatch` would still pass.

`ReplacePattern`, `wheel.go`, and `jar.go` already keep the entry when `multiMatch` errors. This PR matches that convention and compiles the globs in `ExcludePath.Validate()` so `CreateCustomStabilizers` rejects a bad pattern at config time.

No in-tree definition currently hits this. The one shipping `exclude_path` (`*/AUTHORS`) is valid. This is a latent fail-open, not an active exploit.

## Test plan
- [x] `go test ./pkg/stabilize/` (package green)
- [x] `TestExcludePath_Validate` rejects `**/tests/**`, unterminated class, and non-delimited `**`
- [x] `TestExcludePath_MalformedPatternKeepsEntries` keeps both zip entries when `Stabilizer` is built with a bad glob (Validate bypassed)


Made with [Cursor](https://cursor.com)