### PR TITLE
Retry transient model API failures

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -136,6 +136,7 @@ func main() {
 		MetadataBucket: *metadataBucket,
 		LogsBucket:     *logsBucket,
 		RegistryClient: regclient,
+		Retrier:        agent.NewRetrier(),
 	}
 	if mode == schema.AgentExecutionModeScratch {
 		stubs := scratch.Stubs{

--- a/internal/agent/retrier.go
+++ b/internal/agent/retrier.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"time"
+
+	"github.com/google/oss-rebuild/internal/ratex"
+	"github.com/google/oss-rebuild/pkg/llm"
+)
+
+const (
+	llmMinInterval = 1 * time.Second // base retry interval, grows with each retriable failure
+	llmMaxInterval = 2 * time.Minute // ceiling on the interval however long throttling lasts
+	llmAttempts    = 12              // total will exceed 60s, the Vertex quota window
+)
+
+// NewRetrier returns the default model-call retrier for one agent process.
+func NewRetrier() ratex.Retrier {
+	return ratex.Retrier{
+		Limiter:   ratex.NewBackoffLimiter(llmMinInterval, llmMaxInterval),
+		Attempts:  llmAttempts,
+		Retryable: llm.IsTransient,
+	}
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -13,6 +13,7 @@ import (
 
 	gcs "cloud.google.com/go/storage"
 	"github.com/google/oss-rebuild/internal/httpx"
+	"github.com/google/oss-rebuild/internal/ratex"
 	"github.com/google/oss-rebuild/pkg/act/api"
 	"github.com/google/oss-rebuild/pkg/llm"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -58,6 +59,7 @@ type RunSessionDeps struct {
 	SessionsBucket string
 	MetadataBucket string
 	LogsBucket     string
+	Retrier        ratex.Retrier     // Paces and retries model calls. Zero value calls the model once.
 	RegistryClient httpx.BasicClient // Upstream registry requests via the session's identified egress path.
 	ScratchRunner  *ScratchRunner    // When set, each iteration builds on the scratch VM. Only verified successes reach the iteration API, as GCB confirmations.
 }
@@ -143,7 +145,7 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) *sch
 		ScratchRunner:  deps.ScratchRunner,
 	})
 	var err error
-	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, llm.GeminiPro, config, &llm.ChatOpts{Tools: a.getTools()})
+	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, llm.GeminiPro, config, &llm.ChatOpts{Tools: a.getTools(), Retrier: deps.Retrier})
 	if err != nil {
 		return &schema.AgentCompleteRequest{
 			StopReason: schema.AgentCompleteReasonError,
@@ -160,20 +162,35 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) *sch
 		}
 		iterNum = 1
 	}
+	var transientErrs, buildAttempts int // tracks whether model made real progress or was throttled
 	for {
 		iterNum++
 		if iterNum > req.MaxIterations {
-			return &schema.AgentCompleteRequest{
-				StopReason: schema.AgentCompleteReasonFailed,
-				Summary:    fmt.Sprintf("Maximum iterations (%d) reached", req.MaxIterations),
+			reason, summary := schema.AgentCompleteReasonFailed, fmt.Sprintf("Maximum iterations (%d) reached", req.MaxIterations)
+			if buildAttempts == 0 && transientErrs > 0 {
+				// No progress was made on the package.
+				reason = schema.AgentCompleteReasonThrottled
+				summary = fmt.Sprintf("Session throttled: %d transient LLM failures with no completed build attempts", transientErrs)
 			}
+			return &schema.AgentCompleteRequest{StopReason: reason, Summary: summary}
 		}
 		log.Printf("Session %s Iteration %d", req.SessionID, iterNum)
 		iteration, err := doIteration(ctx, req.SessionID, iterNum, a, deps)
 		if err != nil {
 			log.Printf("Doing iteration: %v", err)
+			// A dead context fails every subsequent iteration the same way.
+			if ctx.Err() != nil {
+				return &schema.AgentCompleteRequest{
+					StopReason: schema.AgentCompleteReasonError,
+					Summary:    fmt.Sprintf("Session context ended: %v", ctx.Err()),
+				}
+			}
+			if llm.IsTransient(err) {
+				transientErrs++
+			}
 			continue
 		}
+		buildAttempts++
 		log.Printf("%#v", iteration)
 		if iteration != nil && iteration.Result != nil && !iteration.Result.BuildSuccess {
 			log.Printf("Build failed: %s", iteration.Result.ErrorMessage)

--- a/internal/api/dashboard/status.go
+++ b/internal/api/dashboard/status.go
@@ -28,10 +28,11 @@ const (
 type AgentState string
 
 const (
-	AgentNone    AgentState = ""
-	AgentRunning AgentState = "running"
-	AgentFixed   AgentState = "fixed"
-	AgentFailed  AgentState = "failed"
+	AgentNone      AgentState = ""
+	AgentRunning   AgentState = "running"
+	AgentFixed     AgentState = "fixed"
+	AgentFailed    AgentState = "failed"
+	AgentThrottled AgentState = "throttled"
 )
 
 // VersionStatus is the aggregated status of a single package version across all
@@ -171,6 +172,10 @@ func classifyVersion(vs *VersionStatus, attempts []rundex.Rebuild, sessions []sc
 			failed = true
 			if agent == AgentNone {
 				agent = AgentFailed
+			}
+		case s.StopReason == schema.AgentCompleteReasonThrottled:
+			if agent == AgentNone {
+				agent = AgentThrottled
 			}
 		}
 	}

--- a/internal/api/dashboard/status_test.go
+++ b/internal/api/dashboard/status_test.go
@@ -30,6 +30,9 @@ func sess(version, statusOrStop string, created time.Time) schema.AgentSession {
 	case "failed":
 		s.Status = schema.AgentSessionStatusCompleted
 		s.StopReason = schema.AgentCompleteReasonFailed
+	case "throttled":
+		s.Status = schema.AgentSessionStatusCompleted
+		s.StopReason = schema.AgentCompleteReasonThrottled
 	}
 	return s
 }
@@ -65,11 +68,12 @@ func TestComputeVersionStatuses_Classification(t *testing.T) {
 
 func TestComputeVersionStatuses_Agent(t *testing.T) {
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	axis := []string{"3.0", "2.0", "1.0"}
+	axis := []string{"3.0", "2.0", "1.0", "0.9"}
 	sessions := []schema.AgentSession{
 		sess("3.0", "success", t0),
 		sess("2.0", "running", t0),
 		sess("1.0", "failed", t0),
+		sess("0.9", "throttled", t0),
 	}
 	got := statusByVersion(computeVersionStatuses("npm", "p", axis, true, nil, sessions))
 	if got["3.0"].State != StateVerified || got["3.0"].Agent != AgentFixed {
@@ -80,6 +84,10 @@ func TestComputeVersionStatuses_Agent(t *testing.T) {
 	}
 	if got["1.0"].State != StateFailed || got["1.0"].Agent != AgentFailed {
 		t.Errorf("1.0: cell=%q agent=%q, want failed/failed", got["1.0"].State, got["1.0"].Agent)
+	}
+	// Throttled is neither a failure nor an absence of agent activity.
+	if got["0.9"].State != StateUntried || got["0.9"].Agent != AgentThrottled {
+		t.Errorf("0.9: cell=%q agent=%q, want untried/throttled", got["0.9"].State, got["0.9"].Agent)
 	}
 }
 

--- a/internal/ratex/backoff.go
+++ b/internal/ratex/backoff.go
@@ -9,66 +9,68 @@ import (
 	"time"
 )
 
-// BackoffLimiter provides a threadsafe exponential backoff rate limiter
+// BackoffLimiter provides a threadsafe exponential backoff rate limiter.
+// Permits are spaced by the current period, which grows on Backoff and decays
+// on Success within [minimum, maximum]. The first permit is immediate.
 type BackoffLimiter struct {
-	mu            sync.Mutex
-	currentPeriod time.Duration
-	minimum       time.Duration
-	ch            chan struct{}
+	waitMu  sync.Mutex // serializes waiters
+	mu      sync.Mutex // guards the fields below
+	period  time.Duration
+	minimum time.Duration
+	maximum time.Duration
+	last    time.Time // when the last permit was granted
 }
 
-func NewBackoffLimiter(minimum time.Duration) *BackoffLimiter {
-	l := &BackoffLimiter{
-		currentPeriod: minimum,
-		minimum:       minimum,
-		ch:            make(chan struct{}),
-	}
-	go func() {
-		for {
-			l.tick()
-		}
-	}()
-	return l
-}
-
-func (l *BackoffLimiter) tick() {
-	l.mu.Lock()
-	duration := l.currentPeriod
-	l.mu.Unlock()
-	// If we want the in-flight sleep period to be interrupted, we can implement this with a time.AfterFunc(), and cancel the in-flight timer when the period is updated.
-	time.Sleep(duration)
-	l.ch <- struct{}{}
+func NewBackoffLimiter(minimum, maximum time.Duration) *BackoffLimiter {
+	return &BackoffLimiter{period: minimum, minimum: minimum, maximum: max(maximum, minimum)}
 }
 
 // Wait blocks until the limiter permits another event to happen.
 // If ctx becomes Done(), Wait will return an error.
 func (l *BackoffLimiter) Wait(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-l.ch:
-		return nil
+	if err := ctx.Err(); err != nil {
+		return err
 	}
+	l.waitMu.Lock()
+	defer l.waitMu.Unlock()
+	l.mu.Lock()
+	var wait time.Duration
+	if !l.last.IsZero() {
+		wait = l.period - time.Since(l.last)
+	}
+	l.mu.Unlock()
+	if wait > 0 {
+		// Period changes made during this sleep only affect later waits.
+		t := time.NewTimer(wait)
+		defer t.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+		}
+	}
+	l.mu.Lock()
+	l.last = time.Now()
+	l.mu.Unlock()
+	return nil
 }
 
-// Backoff will increase the period by 33%.
-// This will not take effect until the next period.
+// Backoff will increase the period by 33%, up to the maximum.
 func (l *BackoffLimiter) Backoff() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.currentPeriod = l.currentPeriod * 4 / 3
+	l.period = min(l.period*4/3, l.maximum)
 }
 
-// Success will decrease the period by 10%.
-// This will not take effect until the next period.
+// Success will decrease the period by 10%, down to the minimum.
 func (l *BackoffLimiter) Success() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.currentPeriod = max(l.currentPeriod*9/10, l.minimum)
+	l.period = max(l.period*9/10, l.minimum)
 }
 
 func (l *BackoffLimiter) CurrentPeriod() time.Duration {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.currentPeriod
+	return l.period
 }

--- a/internal/ratex/backoff_test.go
+++ b/internal/ratex/backoff_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package ratex
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWaitFirstPermitImmediate(t *testing.T) {
+	l := NewBackoffLimiter(time.Hour, 2*time.Hour)
+	start := time.Now()
+	if err := l.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() = %v", err)
+	}
+	if d := time.Since(start); d > time.Second {
+		t.Errorf("first Wait took %v, want immediate", d)
+	}
+}
+
+func TestWaitUsesCurrentPeriod(t *testing.T) {
+	// A Backoff between permits must apply to the very next wait, not lag
+	// behind by one.
+	l := NewBackoffLimiter(10*time.Millisecond, time.Second)
+	if err := l.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() = %v", err)
+	}
+	for range 3 {
+		l.Backoff() // 10ms -> ~23.7ms
+	}
+	start := time.Now()
+	if err := l.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() = %v", err)
+	}
+	if d := time.Since(start); d < 20*time.Millisecond {
+		t.Errorf("second Wait took %v, want at least the backed-off period (~23ms)", d)
+	}
+}
+
+func TestWaitAbortsOnDoneContext(t *testing.T) {
+	l := NewBackoffLimiter(time.Hour, 2*time.Hour)
+	if err := l.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() = %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := l.Wait(ctx); err == nil {
+		t.Error("Wait() = nil, want context error instead of sleeping out the period")
+	}
+}
+
+func TestBackoffCapsAtMaximum(t *testing.T) {
+	l := NewBackoffLimiter(time.Millisecond, 3*time.Millisecond)
+	for range 20 {
+		l.Backoff()
+	}
+	if got := l.CurrentPeriod(); got != 3*time.Millisecond {
+		t.Errorf("period = %v, want capped at 3ms", got)
+	}
+}
+
+func TestSuccessFloorsAtMinimum(t *testing.T) {
+	l := NewBackoffLimiter(time.Millisecond, time.Second)
+	l.Backoff()
+	for range 20 {
+		l.Success()
+	}
+	if got := l.CurrentPeriod(); got != time.Millisecond {
+		t.Errorf("period = %v, want floored at 1ms", got)
+	}
+}

--- a/internal/ratex/retry.go
+++ b/internal/ratex/retry.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package ratex
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// Retrier retries work under a BackoffLimiter.
+type Retrier struct {
+	Limiter   *BackoffLimiter  // how long to wait when retrying
+	Attempts  int              // max attempts, <=1 meaning no retries
+	Retryable func(error) bool // whether an error should be retried, nil meaning all are
+}
+
+// Do calls fn until it succeeds, returns an error not configured to retry, or
+// runs out of attempts. The last fn invocation's error is returned unwrapped.
+// A context cancellation during wait is returned wrapped.
+func (r Retrier) Do(ctx context.Context, fn func() error) error {
+	if r.Limiter == nil { // no limiter configured
+		return fn()
+	}
+	attempts := max(r.Attempts, 1)
+	var err error
+	for range attempts {
+		if werr := r.Limiter.Wait(ctx); werr != nil {
+			return errors.Wrap(werr, "awaiting rate limiter")
+		}
+		if err = fn(); err == nil {
+			r.Limiter.Success()
+			return nil
+		}
+		if r.Retryable != nil && !r.Retryable(err) {
+			return err
+		}
+		r.Limiter.Backoff()
+	}
+	return err
+}

--- a/internal/ratex/retry_test.go
+++ b/internal/ratex/retry_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package ratex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var errTerminal = errors.New("terminal")
+
+func newTestRetrier(attempts int, retryable func(error) bool) Retrier {
+	return Retrier{Limiter: NewBackoffLimiter(time.Nanosecond, time.Millisecond), Attempts: attempts, Retryable: retryable}
+}
+
+func TestDo(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		attempts  int
+		retryable func(error) bool
+		errs      []error // returned by fn in order, nil means success
+		wantCalls int
+		wantErr   bool
+	}{
+		{"SucceedsFirstTry", 3, nil, []error{nil}, 1, false},
+		{"RetriesThenSucceeds", 3, nil, []error{errTerminal, errTerminal, nil}, 3, false},
+		{"GivesUpAfterAttempts", 3, nil, []error{errTerminal, errTerminal, errTerminal}, 3, true},
+		{
+			name:      "StopsOnNonRetryable",
+			attempts:  3,
+			retryable: func(error) bool { return false },
+			errs:      []error{errTerminal},
+			wantCalls: 1,
+			wantErr:   true,
+		},
+		// Attempts is a count, not a retry budget, so a non-positive value must
+		// still run the work once rather than skipping it.
+		{"NonPositiveAttemptsRunsOnce", 0, nil, []error{errTerminal}, 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			err := newTestRetrier(tc.attempts, tc.retryable).Do(context.Background(), func() error {
+				calls++
+				return tc.errs[min(calls-1, len(tc.errs)-1)]
+			})
+			if calls != tc.wantCalls {
+				t.Errorf("fn called %d times, want %d", calls, tc.wantCalls)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDoReturnsWorkErrorUnwrapped(t *testing.T) {
+	// Callers classify the returned error, so it must survive the round trip.
+	err := newTestRetrier(2, nil).Do(context.Background(), func() error { return errTerminal })
+	if !errors.Is(err, errTerminal) {
+		t.Errorf("err = %v, want it to wrap errTerminal", err)
+	}
+}
+
+func TestDoAbortsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var calls int
+	err := newTestRetrier(3, nil).Do(ctx, func() error {
+		calls++
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if calls != 0 {
+		t.Errorf("fn called %d times, want 0 (pacing must gate the first attempt too)", calls)
+	}
+}
+
+func TestDoFeedsLimiter(t *testing.T) {
+	// A retryable failure must widen the period. Otherwise the retry does
+	// nothing about the condition that caused it.
+	r := Retrier{Limiter: NewBackoffLimiter(time.Millisecond, time.Second), Attempts: 2}
+	before := r.Limiter.CurrentPeriod()
+	_ = r.Do(context.Background(), func() error { return errTerminal })
+	if got := r.Limiter.CurrentPeriod(); got <= before {
+		t.Errorf("period %v did not widen from %v after a retryable failure", got, before)
+	}
+}
+
+func TestDoWithoutLimiter(t *testing.T) {
+	// The zero Retrier is what a caller gets by leaving the field unset, so it
+	// must run the work rather than panicking or looping on it.
+	var calls int
+	err := Retrier{Attempts: 3}.Do(context.Background(), func() error {
+		calls++
+		return errTerminal
+	})
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+	if !errors.Is(err, errTerminal) {
+		t.Errorf("err = %v, want errTerminal", err)
+	}
+}

--- a/pkg/llm/chat.go
+++ b/pkg/llm/chat.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"slices"
 
+	"github.com/google/oss-rebuild/internal/ratex"
 	"github.com/pkg/errors"
 	"google.golang.org/genai"
 )
@@ -24,6 +25,14 @@ type ChatOpts struct {
 	// MaxIterations sets the maximum number of send/receive cycles.
 	// If zero or less, a default value (defaultMaxToolIterations) is used.
 	MaxToolIterations int
+	// Retrier paces and reattempts sends. Zero value sends exactly once.
+	// NOTE: Retry policy lives here, not in genai's HTTPOptions.RetryOptions
+	// (added in v1.67). That layer would nest blind per-request HTTP backoff
+	// inside each attempt here and lacks shared retry logic, transience
+	// classification, and session throttle accounting. RetryOptions also lacks
+	// handling for server-provided RetryInfo (which we don't observe either).
+	// Keep it unset when upgrading genai.
+	Retrier ratex.Retrier
 }
 
 // Chat manages the state of an ongoing conversation with a generative model,
@@ -35,6 +44,7 @@ type Chat struct {
 	session   *genai.Chat
 	toolImpls map[string]Function
 	maxIter   int
+	retrier   ratex.Retrier
 	usage     []*genai.GenerateContentResponseUsageMetadata
 }
 
@@ -50,10 +60,12 @@ func NewChat(ctx context.Context, client *genai.Client, model string, config *ge
 	}
 	maxIter := defaultMaxToolIterations
 	toolImpls := make(map[string]Function)
+	var retrier ratex.Retrier
 	if opts != nil {
 		if opts.MaxToolIterations > 0 {
 			maxIter = opts.MaxToolIterations
 		}
+		retrier = opts.Retrier
 		config = WithTools(config, opts.Tools)
 		for _, def := range opts.Tools {
 			if def != nil {
@@ -78,6 +90,7 @@ func NewChat(ctx context.Context, client *genai.Client, model string, config *ge
 		session:   session,
 		toolImpls: toolImpls,
 		maxIter:   maxIter,
+		retrier:   retrier,
 	}, nil
 }
 
@@ -114,7 +127,13 @@ func (cm *Chat) SendMessageStream(ctx context.Context, parts ...*genai.Part) ite
 			if !yield(&genai.Content{Parts: currentParts, Role: UserRole}, nil) {
 				return
 			}
-			resp, err := cm.session.Send(ctx, currentParts...)
+			// NOTE: Re-sending the same parts is safe because genai's Chat.Send
+			// records history only on success.
+			var resp *genai.GenerateContentResponse
+			err := cm.retrier.Do(ctx, func() (err error) {
+				resp, err = cm.session.Send(ctx, currentParts...)
+				return err
+			})
 			if err != nil {
 				yield(nil, errors.Wrap(err, "sending message"))
 				return

--- a/pkg/llm/retry.go
+++ b/pkg/llm/retry.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package llm
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/genai"
+)
+
+// retryableCodes are the HTTP status codes worth retrying.
+var retryableCodes = map[int]bool{
+	http.StatusRequestTimeout:      true,
+	http.StatusTooManyRequests:     true, // quota and rate limits
+	http.StatusInternalServerError: true,
+	http.StatusBadGateway:          true,
+	http.StatusServiceUnavailable:  true, // also how overload is reported
+	http.StatusGatewayTimeout:      true,
+}
+
+// retryableStatuses are the gRPC status names backends set in place of a code.
+var retryableStatuses = []string{"RESOURCE_EXHAUSTED", "UNAVAILABLE", "DEADLINE_EXCEEDED", "INTERNAL", "ABORTED"}
+
+// providerPhrases is transient vocabulary with no HTTP status text behind it.
+var providerPhrases = []string{
+	"rate limit", "resource exhausted", "resource_exhausted",
+	"unavailable", "quota", "overloaded", "try again",
+	"deadline exceeded", "connection reset", "temporarily",
+}
+
+// transientPhrases match errors whose type is no longer inspectable but whose
+// message still names a transient condition from retryableCodes.
+var transientPhrases = func() []string {
+	out := slices.Clone(providerPhrases)
+	for code := range retryableCodes {
+		out = append(out, strings.ToLower(http.StatusText(code)))
+	}
+	return out
+}()
+
+// IsTransient reports whether err is provider throttling or a temporary server
+// error, as opposed to a bad request or a model refusal.
+// NOTE: Prefer false positives here to bias failures towards retries rather
+// than giving up on transient failures.
+func IsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Caller cancellation is not a provider condition and must not be retried,
+	// even though "deadline exceeded" appears in the transient vocabulary.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var apiErr genai.APIError
+	if errors.As(err, &apiErr) {
+		if retryableCodes[apiErr.Code] {
+			return true
+		}
+		if slices.Contains(retryableStatuses, strings.ToUpper(apiErr.Status)) {
+			return true
+		}
+	}
+	// Fall back to matching the message for wrapped or opaque errors.
+	msg := strings.ToLower(err.Error())
+	return slices.ContainsFunc(transientPhrases, func(p string) bool { return strings.Contains(msg, p) })
+}

--- a/pkg/llm/retry_test.go
+++ b/pkg/llm/retry_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package llm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"google.golang.org/genai"
+)
+
+func TestIsTransient(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"Nil", nil, false},
+		{"ContextCanceled", context.Canceled, false},
+		{"WrappedContextDeadline", errors.Wrap(context.DeadlineExceeded, "sending message"), false},
+		{"Code429", genai.APIError{Code: 429}, true},
+		{"Code503", genai.APIError{Code: 503}, true},
+		{"Code400", genai.APIError{Code: 400}, false},
+		{"ResourceExhaustedStatus", genai.APIError{Status: "RESOURCE_EXHAUSTED"}, true},
+		{"Wrapped429", errors.Wrap(genai.APIError{Code: 429}, "sending message"), true},
+		{"RateLimitText", errors.New("upstream returned rate limit exceeded"), true},
+		{"OverloadedText", errors.New("model is overloaded, try again later"), true},
+		{"InvalidArgumentText", errors.New("invalid argument: bad prompt"), false},
+		// Status texts come from net/http, so they track retryableCodes.
+		{"DerivedStatusText", errors.New("upstream returned Service Unavailable"), true},
+		{"DerivedTimeoutText", errors.New("gateway timeout while streaming"), true},
+		// NOTE: Bare status numbers go unmatched on purpose. See retry.go.
+		{"BareStatusNumberInProse", errors.New("request consumed 500 tokens"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTransient(tc.err); got != tc.want {
+				t.Errorf("IsTransient(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -562,9 +562,10 @@ type AgentBuildResult struct {
 
 // Agent session complete reasons
 const (
-	AgentCompleteReasonSuccess = "SUCCESS"
-	AgentCompleteReasonFailed  = "FAILED"
-	AgentCompleteReasonError   = "ERROR"
+	AgentCompleteReasonSuccess   = "SUCCESS"
+	AgentCompleteReasonFailed    = "FAILED"
+	AgentCompleteReasonError     = "ERROR"
+	AgentCompleteReasonThrottled = "THROTTLED"
 )
 
 // AgentCompleteRequest finalizes session with results

--- a/tools/benchmark/artifact_backfill/main.go
+++ b/tools/benchmark/artifact_backfill/main.go
@@ -71,12 +71,12 @@ func backfillArtifacts(dataPath string) error {
 	mux := meta.NewRegistryMux(httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{}))
 	// Create rate limiters per ecosystem (matching benchmark defaults)
 	limiters := map[rebuild.Ecosystem]*ratex.BackoffLimiter{
-		rebuild.Debian:   ratex.NewBackoffLimiter(1000 * time.Millisecond),
-		rebuild.PyPI:     ratex.NewBackoffLimiter(200 * time.Millisecond),
-		rebuild.NPM:      ratex.NewBackoffLimiter(200 * time.Millisecond),
-		rebuild.Maven:    ratex.NewBackoffLimiter(700 * time.Millisecond),
-		rebuild.CratesIO: ratex.NewBackoffLimiter(1500 * time.Millisecond),
-		rebuild.OCI:      ratex.NewBackoffLimiter(1000 * time.Millisecond),
+		rebuild.Debian:   ratex.NewBackoffLimiter(1000*time.Millisecond, time.Minute),
+		rebuild.PyPI:     ratex.NewBackoffLimiter(200*time.Millisecond, time.Minute),
+		rebuild.NPM:      ratex.NewBackoffLimiter(200*time.Millisecond, time.Minute),
+		rebuild.Maven:    ratex.NewBackoffLimiter(700*time.Millisecond, time.Minute),
+		rebuild.CratesIO: ratex.NewBackoffLimiter(1500*time.Millisecond, time.Minute),
+		rebuild.OCI:      ratex.NewBackoffLimiter(1000*time.Millisecond, time.Minute),
 	}
 	// Count total work needed
 	totalWork := 0

--- a/tools/benchmark/run/run.go
+++ b/tools/benchmark/run/run.go
@@ -291,15 +291,15 @@ func (w *inferenceWorker) ProcessOne(ctx context.Context, p benchmark.Package, o
 
 func defaultLimiters() map[string]*ratex.BackoffLimiter {
 	return map[string]*ratex.BackoffLimiter{
-		"debian": ratex.NewBackoffLimiter(time.Second),
-		"pypi":   ratex.NewBackoffLimiter(time.Second),
-		"npm":    ratex.NewBackoffLimiter(2 * time.Second),
-		"maven":  ratex.NewBackoffLimiter(2 * time.Second),
+		"debian": ratex.NewBackoffLimiter(time.Second, time.Minute),
+		"pypi":   ratex.NewBackoffLimiter(time.Second, time.Minute),
+		"npm":    ratex.NewBackoffLimiter(2*time.Second, time.Minute),
+		"maven":  ratex.NewBackoffLimiter(2*time.Second, time.Minute),
 		// NOTE: cratesio needs to be especially slow given our registry API
 		// constraint of 1QPS. At minimum, we expect to make 4 calls per test.
-		"cratesio": ratex.NewBackoffLimiter(8 * time.Second),
-		"rubygems": ratex.NewBackoffLimiter(time.Second),
-		"oci":      ratex.NewBackoffLimiter(time.Second),
+		"cratesio": ratex.NewBackoffLimiter(8*time.Second, time.Minute),
+		"rubygems": ratex.NewBackoffLimiter(time.Second, time.Minute),
+		"oci":      ratex.NewBackoffLimiter(time.Second, time.Minute),
 	}
 }
 

--- a/tools/benchmark/run/run_test.go
+++ b/tools/benchmark/run/run_test.go
@@ -44,7 +44,7 @@ func TestAttestWorkerPreservesResultReturnedWithError(t *testing.T) {
 	w := attestWorker{workerConfig: workerConfig{
 		execService: resultWithErrorService{},
 		limiters: map[string]*ratex.BackoffLimiter{
-			"cratesio": ratex.NewBackoffLimiter(time.Nanosecond),
+			"cratesio": ratex.NewBackoffLimiter(time.Nanosecond, time.Millisecond),
 		},
 	}}
 	out := make(chan schema.Verdict, 1)

--- a/tools/ctl/command/localagent/localagent.go
+++ b/tools/ctl/command/localagent/localagent.go
@@ -174,6 +174,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 		SessionsBucket: "", // TODO: Add this once it's being used.
 		MetadataBucket: cfg.MetadataBucket,
 		LogsBucket:     cfg.LogsBucket,
+		Retrier:        agent.NewRetrier(),
 	}
 	req := agent.RunSessionReq{
 		SessionID:        sessionID,


### PR DESCRIPTION
Agent sessions were dying to provider throttling and transient 5xx, which
surfaced as genuine build failures. Wrap genai calls in exponential
backoff retrying transient errors.