### PR TITLE
Change the scratch worker to be E2 compute nodes

### DIFF
--- a/deployments/scratch_startup.sh
+++ b/deployments/scratch_startup.sh
@@ -32,14 +32,6 @@ mkdir -p /etc/docker
 echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' > /etc/docker/daemon.json
 systemctl enable --now docker
 
-# Mount the local SSD at /var/lib/docker for IOPS.
-if [ -e /dev/nvme0n1 ]; then
-    mkfs.ext4 -F /dev/nvme0n1
-    mkdir -p /var/lib/docker
-    mount /dev/nvme0n1 /var/lib/docker
-    systemctl restart docker
-fi
-
 useradd --create-home --home-dir /home/builder --shell /bin/bash builder || true
 usermod -aG docker builder
 mkdir -p /opt/builder
@@ -79,7 +71,7 @@ ExecStart=/opt/builder/scratch-worker \\
     --caller-sa=${caller_sa} \\
     --audience=${audience} \\
     --docker-socket=/var/run/docker.sock \\
-    --disk-paths=/var/lib/docker,/home/builder \\
+    --disk-paths=/home/builder \\
     --listen=:8080
 Restart=on-failure
 RestartSec=5s

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -58,7 +58,7 @@ data "google_compute_zones" "scratch" {
 resource "google_compute_instance_template" "scratch-standard" {
   count        = var.enable_scratch ? 1 : 0
   name_prefix  = "${var.host}-scratch-standard-"
-  machine_type = "n2-standard-8"
+  machine_type = "e2-standard-8"
   region       = "us-central1"
 
   # NOTE: This block needs to be conditionally omitted to ensure an empty
@@ -75,14 +75,8 @@ resource "google_compute_instance_template" "scratch-standard" {
     source_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
     auto_delete  = true
     boot         = true
-    disk_size_gb = 50
-  }
-  disk {
-    type         = "SCRATCH"
-    disk_type    = "local-ssd"
-    auto_delete  = true
-    interface    = "NVME"
-    disk_size_gb = 375 # local SSD partitions are fixed at 375 GB on n2; add more disk blocks for more capacity.
+    disk_size_gb = 400
+    disk_type    = "pd-ssd"
   }
 
   network_interface {


### PR DESCRIPTION
The E2 compute nodes are much easier to reserve. This also adds pd
storage