### PR TITLE
Convert scratch VMs from Ubuntu to COS

### DIFF
--- a/deployments/scratch_cloudinit.yaml
+++ b/deployments/scratch_cloudinit.yaml
@@ -1,0 +1,58 @@
+#cloud-config
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# COS scratch VMs init: Write and starts a systemd unit that runs the fetched
+# worker binary. Reruns every boot as /etc on COS is stateless.
+# NOTE: "#cloud-config" must remain the first line.
+#
+# Template parameters:
+#   cli_image: Digest-pinned upstream image ref
+#   caller_sa: Service account email permitted to contact the worker
+
+write_files:
+  - path: /etc/systemd/system/scratch-worker.service
+    permissions: "0644"
+    owner: root
+    content: |
+      [Unit]
+      Description=Scratch worker
+      Wants=docker.service
+      After=docker.service
+      # Start attempts will fail until the startup script finishes. Otherwise,
+      # systemd's default rate limit would give up after a few failures.
+      StartLimitIntervalSec=0
+
+      [Service]
+      # Block until the startup script has fetched the worker binary. Starting
+      # earlier would make docker create the missing bind source below as an
+      # empty directory. /run is wiped at boot, so subsequent boots will wait
+      # for their respective fetch.
+      ExecStartPre=/bin/sh -c 'test -e /run/scratch-worker-ready'
+      # Ensure a previous attempt didn't leave our container name claimed.
+      ExecStartPre=-/usr/bin/docker rm -f scratch-worker
+      # The worker stages builds under /home/builder and passes those paths
+      # to the host daemon as -v sources for build containers. The daemon
+      # resolves them on the host, so the worker must see /home/builder at
+      # the same path the host does.
+      # NOTE: With host networking $(hostname) resolves to the instance name.
+      ExecStart=/usr/bin/docker run --rm --name=scratch-worker \
+          --network=host \
+          -v /home/builder:/home/builder \
+          -v /var/lib/toolbox/scratch-worker:/scratch-worker:ro \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          ${cli_image} \
+          /bin/sh -c 'exec /scratch-worker --caller-sa=${caller_sa} --audience="https://builder/$(hostname)" --docker-socket=/var/run/docker.sock --disk-paths=/home/builder --listen=:8080'
+      ExecStop=/usr/bin/docker stop scratch-worker
+      Restart=always
+      # Retry cadence for the marker wait above and for worker crashes.
+      RestartSec=5
+
+runcmd:
+  # NOTE: COS's host firewall drops inbound traffic by default. Open only the
+  # worker's listener reflecting the scratch-worker-ingress VPC rule.
+  - iptables -w -A INPUT -p tcp --dport 8080 -j ACCEPT
+  # Fire and forget: a plain start would report failure whenever the
+  # startup script has not finished yet; systemd retries regardless.
+  - systemctl daemon-reload
+  - systemctl start --no-block scratch-worker.service

--- a/deployments/scratch_startup.sh
+++ b/deployments/scratch_startup.sh
@@ -2,83 +2,47 @@
 # Copyright 2026 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# Worker VM startup script.
-#
-# The worker process makes no GCP calls of its own; agent-api drives it
-# over private-IP HTTP using an ID token. The bootstrap fetch of the
-# worker binary is the only step that may need GCP credentials:
-#   - On public deployments the VM needs no attached service account as
-#     the bootstrap-tools bucket is public-readable.
-#   - On private deployments a narrowly-scoped SA with objectViewer on
-#     the bootstrap-tools bucket is attached. We detect the SA presence
-#     via the metadata server and authenticate the storage fetch with its
-#     access token.
+# COS scratch VM startup script executed on the host. The worker is docker-run
+# by the cloud-init scratch-worker.service (see scratch_cloudinit.yaml), which
+# waits for the marker this script writes as its last step.
 #
 # Templated by Terraform with:
-#   worker_binary_uri - gs://... full URI to the scratch-worker binary
-#   caller_sa         - email of the SA that calls the worker (agent-api's)
-#   audience          - expected ID-token audience for inbound requests
+#   worker_binary_uri: gs://... full URI to the scratch-worker binary
 
 set -euxo pipefail
 
-DEBIAN_FRONTEND=noninteractive apt-get update -y
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    docker.io \
-    docker-buildx \
-    curl \
-    jq \
-    ca-certificates
-mkdir -p /etc/docker
-echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' > /etc/docker/daemon.json
-systemctl enable --now docker
+# Merge the gcr mirror into COS's shipped daemon.json.
+python3 -c 'import json,sys; print(json.dumps(json.loads(sys.argv[1] or "{}") | {"registry-mirrors": ["https://mirror.gcr.io"]}))' \
+    "$(cat /etc/docker/daemon.json 2>/dev/null)" > /etc/docker/daemon.json
+systemctl restart docker
 
-useradd --create-home --home-dir /home/builder --shell /bin/bash builder || true
-usermod -aG docker builder
-mkdir -p /opt/builder
-chown -R builder:builder /opt/builder /home/builder
+# Docker binds inherit source-mount flags and build containers execute
+# files from staging under /home/builder, so drop COS's noexec on /home.
+mkdir -p /home/builder
+mount -o remount,bind,nosuid,nodev,exec /home
 
+# Fetch the worker binary into /var/lib/toolbox, the writable path COS
+# mounts exec. With no SA attached, the metadata token endpoint 404s and the
+# fetch is attempted unauthenticated.
 WORKER_BINARY_URI='${worker_binary_uri}'
 WORKER_BINARY_URL="https://storage.googleapis.com/$${WORKER_BINARY_URI#gs://}"
-
-# If an SA is bound to this VM (private deployments), mint an access
-# token from the metadata server and use it to authenticate the
-# bootstrap fetch. On public deployments no SA is attached, the
-# metadata endpoint 404s, and the fetch is anonymous.
 CURL_AUTH=()
 if curl -fsS -H "Metadata-Flavor: Google" \
        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" 2>/dev/null \
-       | jq -re .access_token > /tmp/sa_token 2>/dev/null && [ -s /tmp/sa_token ]; then
+       | python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])' > /tmp/sa_token 2>/dev/null; then
   (printf "Authorization: Bearer "; cat /tmp/sa_token) > /tmp/sa_auth_header
   chmod 600 /tmp/sa_auth_header /tmp/sa_token
   CURL_AUTH=(-H "@/tmp/sa_auth_header")
 fi
-
-curl -fsSL "$${CURL_AUTH[@]}" -o /opt/builder/scratch-worker "$WORKER_BINARY_URL"
-chmod +x /opt/builder/scratch-worker
+mkdir -p /var/lib/toolbox
+curl -fsSL "$${CURL_AUTH[@]}" -o /var/lib/toolbox/scratch-worker "$WORKER_BINARY_URL"
+chmod +x /var/lib/toolbox/scratch-worker
 rm -f /tmp/sa_token /tmp/sa_auth_header
 
-cat >/etc/systemd/system/scratch-worker.service <<EOF
-[Unit]
-Description=Scratch worker
-After=docker.service
-Requires=docker.service
+# On tmpfs, so the marker is only ever true for the boot that wrote it.
+touch /run/scratch-worker-ready
 
-[Service]
-Type=simple
-User=builder
-WorkingDirectory=/home/builder
-ExecStart=/opt/builder/scratch-worker \\
-    --caller-sa=${caller_sa} \\
-    --audience=${audience} \\
-    --docker-socket=/var/run/docker.sock \\
-    --disk-paths=/home/builder \\
-    --listen=:8080
-Restart=on-failure
-RestartSec=5s
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-systemctl daemon-reload
-systemctl enable --now scratch-worker.service
+# Nudge the unit to retry now rather than in 5s, permitting a failure if
+# cloud-init hasn't yet written the unit. --no-block: waiting on another unit
+# from inside google-startup-scripts.service invites a systemd job deadlock.
+systemctl restart --no-block scratch-worker.service || true

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -52,9 +52,9 @@ data "google_compute_zones" "scratch" {
 }
 
 # Instance template for scratch VMs. The startup script fetches and runs the
-# scratch-worker binary; agent-api drives the worker over private-IP HTTP with
-# an ID token. Conditionally attach a service account for private instances to
-# access (the bootstrap-tools bucket is public-readable).
+# scratch-worker binary as a systemd service. agent-api drives the worker over
+# private-IP HTTP with an ID token. Conditionally attach a service account for
+# private instances to access bootstrap tools.
 resource "google_compute_instance_template" "scratch-standard" {
   count        = var.enable_scratch ? 1 : 0
   name_prefix  = "${var.host}-scratch-standard-"
@@ -72,7 +72,7 @@ resource "google_compute_instance_template" "scratch-standard" {
   }
 
   disk {
-    source_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+    source_image = "cos-cloud/cos-stable"
     auto_delete  = true
     boot         = true
     disk_size_gb = 400
@@ -88,10 +88,13 @@ resource "google_compute_instance_template" "scratch-standard" {
   labels = { purpose = "scratch" }
 
   metadata = {
+    user-data = templatefile("${path.module}/scratch_cloudinit.yaml", {
+      // NOTE: The official docker distribution is alpine-based.
+      cli_image = "docker:29.5-cli@sha256:11e1133c30f3ceb73c6bdc7dfb78b3f9ed8e8e0d1d0400e91c5ec2eb240bf2ff"
+      caller_sa = google_service_account.orchestrator.email
+    })
     startup-script = templatefile("${path.module}/scratch_startup.sh", {
       worker_binary_uri = "gs://${google_storage_bucket.bootstrap-tools.name}/${module.prebuild_images["scratch-worker"].image_version}/scratch-worker"
-      caller_sa         = google_service_account.orchestrator.email
-      audience          = "https://builder/$${HOSTNAME}"
     })
   }
 


### PR DESCRIPTION
The Ubuntu scratch template apt-installed docker at boot which resulted
in a substantial delay to provisioning. Booting from a container on COS
drops this installation step by using the host COS's own docker daemon,
and a cloud-init-written systemd unit to run the worker. The worker
binary is fetched from the bootstrap-tools bucket the same as before.

COS mounts its writable paths noexec and docker binds inherit the source
mount's flags, so the worker binary is written to /var/lib/toolbox (the
exec-mounted exception) and /home/builder is remounted exec for the
build containers executing files from bind-mounts.