### PR TITLE
Upgrade to Gemini 3.7 Flash and 3.1 Pro

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	project         = flag.String("project", "", "GCP Project ID for resource usage")
-	location        = flag.String("location", "", "GCP location for resource usage")
+	location        = flag.String("location", "global", "GCP location for resource usage")
 	sessionID       = flag.String("session-id", "", "Session ID for this agent run")
 	agentAPIURL     = flag.String("agent-api-url", "", "URL of the agent API service")
 	sessionsBucket  = flag.String("sessions-bucket", "", "GCS bucket for session data")

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -40,6 +40,7 @@ import (
 var (
 	project               = flag.String("project", "", "GCP Project ID for storage and build resources")
 	location              = flag.String("location", "", "GCP location for resources")
+	aiLocation            = flag.String("ai-location", "global", "Vertex AI location for agent model calls (Gemini 3.x models only serve from 'global')")
 	buildRemoteIdentity   = flag.String("build-remote-identity", "", "Identity from which to run remote rebuilds")
 	inferenceURL          = flag.String("inference-url", "", "URL of the inference service")
 	signingKeyVersion     = flag.String("signing-key-version", "", "Resource name of the signing CryptoKeyVersion")
@@ -303,6 +304,7 @@ func AgentCreateInit(ctx context.Context) (*apiservice.AgentCreateDeps, error) {
 	}
 	d.Project = *project
 	d.Location = *location
+	d.AILocation = *aiLocation
 	d.AgentJobName = *agentJobName
 	d.AgentAPIURL = *agentAPIURL
 	d.AgentTimeoutSeconds = *agentTimeoutSeconds

--- a/internal/api/apiservice/agent.go
+++ b/internal/api/apiservice/agent.go
@@ -31,6 +31,7 @@ type AgentCreateDeps struct {
 	RunService          *run.Service
 	Project             string
 	Location            string
+	AILocation          string // Vertex AI location for agent model calls, distinct as Gemini 3.x only serves from global
 	AgentJobName        string
 	AgentAPIURL         string
 	AgentTimeoutSeconds int
@@ -144,7 +145,7 @@ func AgentCreate(ctx context.Context, req schema.AgentCreateRequest, deps *Agent
 	if !req.ExternalAgent {
 		args := []string{
 			"--project=" + deps.Project,
-			"--location=" + deps.Location,
+			"--location=" + deps.AILocation,
 			"--session-id=" + sessionID,
 			"--agent-api-url=" + deps.AgentAPIURL,
 			"--sessions-bucket=" + deps.SessionsBucket,

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -14,8 +14,8 @@ import (
 var (
 	// Model names supported by VertexAI.
 
-	GeminiPro   = "gemini-2.5-pro"
-	GeminiFlash = "gemini-2.5-flash"
+	GeminiPro   = "gemini-3.1-pro-preview"
+	GeminiFlash = "gemini-3.7-flash"
 
 	// Roles used for demarcating speakers.
 

--- a/tools/ctl/command/localagent/localagent.go
+++ b/tools/ctl/command/localagent/localagent.go
@@ -91,7 +91,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 	aiClient, err := genai.NewClient(ctx, &genai.ClientConfig{
 		Backend:  genai.BackendVertexAI,
 		Project:  cfg.Project,
-		Location: "us-central1",
+		Location: "global",
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "making aiClient")

--- a/tools/ctl/command/tui/tui.go
+++ b/tools/ctl/command/tui/tui.go
@@ -176,7 +176,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 				aiClient, err = genai.NewClient(ctx, &genai.ClientConfig{
 					Backend:  genai.BackendVertexAI,
 					Project:  aiProject,
-					Location: "us-central1",
+					Location: "global",
 				})
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to create a genai client")


### PR DESCRIPTION
Gemini 3.x models on Vertex serve from the global endpoint, so the
genai clients that pinned us-central1 (local agent, tui) now use
"global". The api service previously forwarded its own --location (also
the Cloud Run job region) to the agent, coupling the model endpoint to
the job region. Since this association no longer holds, a separate
--ai-location flag (default "global") now sets that value instead.