### PR TITLE
Force bash for deployment local-exec provisioners

### DIFF
--- a/deployments/modules/container_binary_upload/main.tf
+++ b/deployments/modules/container_binary_upload/main.tf
@@ -17,7 +17,8 @@ resource "terraform_data" "extract" {
   }
 
   provisioner "local-exec" {
-    command = <<-EOT
+    interpreter = ["/bin/bash", "-c"] # needed for PIPESTATUS and pipefail
+    command     = <<-EOT
       path=${var.gcs_destination}
       cmd="gcloud storage objects describe $path"
       # Suppress stdout, show first line of stderr, return cmd's status.

--- a/deployments/modules/container_build_push/main.tf
+++ b/deployments/modules/container_build_push/main.tf
@@ -44,7 +44,8 @@ resource "terraform_data" "image" {
   }
 
   provisioner "local-exec" {
-    command = <<-EOT
+    interpreter = ["/bin/bash", "-c"] # needed for PIPESTATUS and pipefail
+    command     = <<-EOT
       path=${local.full_image_url}
       cmd="gcloud artifacts docker images describe $path"
       # Suppress stdout, show first line of stderr, return cmd's status.


### PR DESCRIPTION
The container build command uses process substitution and the binary
extraction uses PIPESTATUS and pipefail, none of which are portable to
every /bin/sh.