### PR TITLE
Extract prebuild binaries via docker cp

### DIFF
--- a/deployments/modules/container_binary_upload/main.tf
+++ b/deployments/modules/container_binary_upload/main.tf
@@ -27,26 +27,13 @@ resource "terraform_data" "extract" {
       else
         echo "Extracting and uploading binary"
         set -o pipefail
-        image_archive_files=$(docker save ${var.source_image_url} | tar -t)
-        if echo "$image_archive_files" | grep -q "index.json"; then  # OCI archive format
-          manifest_path=$(docker save ${var.source_image_url} | tar -xO index.json | jq -r '.manifests[0].digest' | sed -E 's#(.+):(.+)#blobs/\1/\2#g')
-          layer_paths=$(docker save ${var.source_image_url} | tar -xO "$manifest_path" | jq -r '.layers[].digest' | sed -E 's#(.+):(.+)#blobs/\1/\2#g')
-        elif echo "$image_archive_files" | grep -q "manifest.json"; then  # Docker archive format
-          layer_paths=$(docker save ${var.source_image_url} | tar -xO manifest.json | jq -r '.[0].Layers[]')
-        else
-          echo "Unknown archive format"
-          exit 1
-        fi
-        for layer in $layer_paths; do
-          if docker save ${var.source_image_url} | tar -xO "$layer" | tar -t | grep -q "${var.binary_name}"; then
-            docker save ${var.source_image_url} | tar -xO "$layer" | tar -xO ${var.binary_name} | \
-              gcloud storage cp - $path && \
-              gcloud storage objects update $path --custom-metadata=goog-reserved-posix-mode=750
-            exit 0
-          fi
-        done
-        echo "Binary not found in image"
-        exit 1
+        cid=$(docker create ${var.source_image_url}) || exit 1
+        docker cp "$cid:/${var.binary_name}" - | tar -xO | \
+          gcloud storage cp - $path && \
+          gcloud storage objects update $path --custom-metadata=goog-reserved-posix-mode=750
+        status=$?
+        docker rm "$cid" >/dev/null
+        exit $status
       fi
     EOT
   }


### PR DESCRIPTION
The extraction walked `docker save` archives with tar and jq, assuming
index.json points directly at an image manifest. Under the containerd
image store (docker with the containerd snapshotter, now the default)
the index nests a manifest list, so the layer query iterates null and
every prebuild binary upload fails. Copying out of a created, never
started container reads the assembled filesystem instead, which is
independent of archive layout and drops the format sniffing entirely.