### PR TITLE
Force Cloud Run image builds to amd64

### DIFF
--- a/deployments/modules/container_build_push/main.tf
+++ b/deployments/modules/container_build_push/main.tf
@@ -53,7 +53,7 @@ resource "terraform_data" "image" {
         echo Found $path
       else
         echo Building $path
-        docker build --quiet ${local.build_args_str} -f ${var.dockerfile_path} -t $path ${local.repo_docker_context} && \
+        docker build --quiet --platform linux/amd64 ${local.build_args_str} -f ${var.dockerfile_path} -t $path ${local.repo_docker_context} && \
           docker push --quiet $path
       fi
     EOT


### PR DESCRIPTION
Cloud Run only runs amd64, so the image build pins --platform
linux/amd64 rather than inheriting the host architecture.