### PR TITLE
Pass the rebuild job short name to the api service

### DIFF
--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -245,7 +245,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--agent-sessions-bucket=${google_storage_bucket.agent-sessions.name}",
         "--agent-metadata-bucket=${google_storage_bucket.agent-metadata.name}",
         "--agent-logs-bucket=${google_storage_bucket.agent-logs.name}",
-        "--rebuild-job-name=${google_cloud_run_v2_job.rebuild-job.id}",
+        "--rebuild-job-name=${google_cloud_run_v2_job.rebuild-job.name}",
         ], var.enable_private_build_pool ? [
         "--gcb-private-pool-name=${google_cloudbuild_worker_pool.private-pool[0].id}",
         "--gcb-private-pool-region=us-central1",


### PR DESCRIPTION
launchRebuildJob composes the full Cloud Run job resource path from
project, location, and a short job name, but the deployment passed the
job .id (already the full path), so every ExtendedExecution rebuild
launch hit an invalid URL and 404ed.