### PR TITLE
Honor PublishForLocalServiceRepo in MakeRebuildPackageDeps

### DIFF
--- a/internal/api/apiservice/rebuild_deps.go
+++ b/internal/api/apiservice/rebuild_deps.go
@@ -109,7 +109,6 @@ func MakeRebuildPackageDeps(ctx context.Context, cfg *schema.RebuildDepsConfig) 
 		Ref:  cfg.BuildDefRef,
 		Dir:  cfg.BuildDefDir,
 	}
-	d.PublishForLocalServiceRepo = false // Should probably be configurable
 	d.AttestationStore, err = rebuild.NewGCSStore(context.WithValue(ctx, rebuild.RunID, ""), "gs://"+cfg.AttestationBucket)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating attestation uploader")


### PR DESCRIPTION
The config value was read correctly and then clobbered fifty lines
later by an unconditional false (its comment even conceded it should be
configurable). Deployments built from a local repo therefore had every
successful rebuild refused at attestation publish with "disallowed
file:// ServiceRepo URL", but only on the rebuild-job path: the api
service builds its deps from flags and never hit the overwrite.