### PR TITLE
fix(benchmark): stamp User-Agent on registry HTTP clients

### DIFF
--- a/tools/benchmark/artifact_backfill/main.go
+++ b/tools/benchmark/artifact_backfill/main.go
@@ -68,7 +68,7 @@ func backfillArtifacts(dataPath string) error {
 		return fmt.Errorf("loading benchmark data: %w", err)
 	}
 	// Set up registry mux with cached HTTP client
-	mux := meta.NewRegistryMux(httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{}))
+	mux := meta.NewRegistryMux(httpx.NewCachedClient(&httpx.WithUserAgent{BasicClient: http.DefaultClient, UserAgent: rebuild.UserAgent("localbuild")}, &cache.CoalescingMemoryCache{}))
 	// Create rate limiters per ecosystem (matching benchmark defaults)
 	limiters := map[rebuild.Ecosystem]*ratex.BackoffLimiter{
 		rebuild.Debian:   ratex.NewBackoffLimiter(1000*time.Millisecond, time.Minute),

--- a/tools/benchmark/generate/main.go
+++ b/tools/benchmark/generate/main.go
@@ -22,8 +22,10 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/google/oss-rebuild/internal/httpx"
 	"github.com/google/oss-rebuild/internal/semver"
 	"github.com/google/oss-rebuild/internal/urlx"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/registry/cratesio"
 	"github.com/google/oss-rebuild/pkg/registry/debian"
 	"github.com/google/oss-rebuild/pkg/registry/debian/control"
@@ -68,7 +70,7 @@ const (
 var cratesioTop2000 = RebuildBenchmark{
 	Filename: "cratesio_top_2000.json",
 	Generator: func(ctx context.Context) (ps benchmark.PackageSet) {
-		client := http.DefaultClient
+		client := &httpx.WithUserAgent{BasicClient: http.DefaultClient, UserAgent: rebuild.UserAgent("localbuild")}
 		now := time.Now()
 		ageThreshold := now.Add(-1 * maxAge)
 		crates := make(chan cratesio.Metadata, 100)
@@ -103,7 +105,7 @@ var cratesioTop2000 = RebuildBenchmark{
 			if len(ps.Packages) >= maxPackages {
 				break
 			}
-			pmeta, err := cratesio.HTTPRegistry{Client: http.DefaultClient}.Crate(ctx, m.Name)
+			pmeta, err := cratesio.HTTPRegistry{Client: client}.Crate(ctx, m.Name)
 			if err != nil {
 				log.Fatalf("error fetching package metadata for %s: %v", m.Name, err)
 			}
@@ -1338,7 +1340,7 @@ LIMIT 5000
 			close(pkgs)
 		}()
 		// Select packages with versions that satisfy our criteria.
-		reg := rubygems.HTTPRegistry{Client: http.DefaultClient}
+		reg := rubygems.HTTPRegistry{Client: &httpx.WithUserAgent{BasicClient: http.DefaultClient, UserAgent: rebuild.UserAgent("localbuild")}}
 		for p := range pkgs {
 			if len(ps.Packages) >= 1000 {
 				break

--- a/tools/benchmark/run/local.go
+++ b/tools/benchmark/run/local.go
@@ -60,7 +60,7 @@ func (s *localExecutionService) RebuildPackage(ctx context.Context, req schema.R
 	if req.UseSyscallMonitor {
 		return nil, errors.New("syscall monitor not supported")
 	}
-	mux := meta.NewRegistryMux(httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{}))
+	mux := meta.NewRegistryMux(httpx.NewCachedClient(&httpx.WithUserAgent{BasicClient: http.DefaultClient, UserAgent: rebuild.UserAgent("localbuild")}, &cache.CoalescingMemoryCache{}))
 	t := rebuild.Target{Ecosystem: req.Ecosystem, Package: req.Package, Version: req.Version, Artifact: req.Artifact}
 	if req.Artifact == "" {
 		a, err := meta.GuessArtifact(ctx, t, mux)
@@ -95,7 +95,7 @@ func RebuildWithStrategy(ctx context.Context, executor ExecutionService, t rebui
 	if !ok {
 		return nil, errors.New("RebuildWithStrategy is only supported for local execution")
 	}
-	mux := meta.NewRegistryMux(httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{}))
+	mux := meta.NewRegistryMux(httpx.NewCachedClient(&httpx.WithUserAgent{BasicClient: http.DefaultClient, UserAgent: rebuild.UserAgent("localbuild")}, &cache.CoalescingMemoryCache{}))
 	if t.Artifact == "" {
 		a, err := meta.GuessArtifact(ctx, t, mux)
 		if err != nil {
@@ -141,7 +141,7 @@ func (s *localExecutionService) Infer(ctx context.Context, req schema.InferenceR
 	if req.StrategyHint != nil {
 		return nil, errors.New("strategy hint not supported")
 	}
-	mux := meta.NewRegistryMux(httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{}))
+	mux := meta.NewRegistryMux(httpx.NewCachedClient(&httpx.WithUserAgent{BasicClient: http.DefaultClient, UserAgent: rebuild.UserAgent("localbuild")}, &cache.CoalescingMemoryCache{}))
 	t := rebuild.Target{Ecosystem: req.Ecosystem, Package: req.Package, Version: req.Version, Artifact: req.Artifact}
 	if req.Artifact == "" {
 		a, err := meta.GuessArtifact(ctx, t, mux)

--- a/tools/benchmark/run/run.go
+++ b/tools/benchmark/run/run.go
@@ -55,7 +55,7 @@ func NewRemoteExecutionService(client *http.Client, baseURL *url.URL) ExecutionS
 
 func (s *remoteExecutionService) RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest) (*schema.Verdict, error) {
 	if req.Artifact == "" {
-		mux := meta.NewRegistryMux(httpx.NewCachedClient(http.DefaultClient, &cache.CoalescingMemoryCache{}))
+		mux := meta.NewRegistryMux(httpx.NewCachedClient(&httpx.WithUserAgent{BasicClient: http.DefaultClient, UserAgent: rebuild.UserAgent("localbuild")}, &cache.CoalescingMemoryCache{}))
 		t := rebuild.Target{Ecosystem: req.Ecosystem, Package: req.Package, Version: req.Version, Artifact: req.Artifact}
 		a, err := meta.GuessArtifact(ctx, t, mux)
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes google/oss-rebuild#1327 (remaining unfixed paths).

crates.io rejects requests whose User-Agent is the Go default (`Go-http-client/1.1`), so the benchmark tooling failed with `403 Forbidden` when fetching crate metadata over a bare `http.DefaultClient`. `tools/ctl/command/export` and `tools/ctl/command/tui` already wrap their registry clients in `httpx.WithUserAgent` with `rebuild.UserAgent("localbuild")`; this change applies the same pattern to the benchmark tools.

## Changes

- `tools/benchmark/run/local.go`: wrap the `meta.NewRegistryMux` client in `httpx.WithUserAgent` (3 sites).
- `tools/benchmark/run/run.go`: same (1 site).
- `tools/benchmark/artifact_backfill/main.go`: same (1 site).
- `tools/benchmark/generate/main.go`: stamp the User-Agent on the crates.io listing client, the `cratesio.HTTPRegistry` client, and the `rubygems.HTTPRegistry` client.

## Verification

- `httpx.WithUserAgent` implements `httpx.BasicClient`, which is what `meta.NewRegistryMux` and each registry `HTTPRegistry.Client` accept.
- `rebuild.UserAgent("localbuild")` returns `oss-rebuild+localbuild/<version>` (or `0.0.0` unstamped), matching the existing ctl tooling.

Note: `rebuild.DoContext` and `internal/verifier/summary.go` already stamp a fallback User-Agent, so they are untouched.