### PR TITLE
Upgrade to Go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.25", "1.26"]
+        go-version: ["1.26", "1.27"]
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/build/package/Dockerfile.agent
+++ b/build/package/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.agent-api
+++ b/build/package/Dockerfile.agent-api
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 ARG BUILD_REPO
 ARG BUILD_VERSION

--- a/build/package/Dockerfile.api
+++ b/build/package/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 ARG BUILD_REPO
 ARG BUILD_VERSION

--- a/build/package/Dockerfile.crates-registry
+++ b/build/package/Dockerfile.crates-registry
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.exampleanalyzer
+++ b/build/package/Dockerfile.exampleanalyzer
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 ARG BUILD_REPO
 ARG BUILD_VERSION

--- a/build/package/Dockerfile.examplesubscriber
+++ b/build/package/Dockerfile.examplesubscriber
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.gateway
+++ b/build/package/Dockerfile.gateway
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.git_cache
+++ b/build/package/Dockerfile.git_cache
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.gsutil_writeonly
+++ b/build/package/Dockerfile.gsutil_writeonly
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.inference
+++ b/build/package/Dockerfile.inference
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 ARG BUILD_REPO
 ARG BUILD_VERSION

--- a/build/package/Dockerfile.networkanalyzer
+++ b/build/package/Dockerfile.networkanalyzer
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 ARG BUILD_REPO
 ARG BUILD_VERSION

--- a/build/package/Dockerfile.networksubscriber
+++ b/build/package/Dockerfile.networksubscriber
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.proxy
+++ b/build/package/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.rebuild-job
+++ b/build/package/Dockerfile.rebuild-job
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 ARG BUILD_REPO
 ARG BUILD_VERSION

--- a/build/package/Dockerfile.scratch-worker
+++ b/build/package/Dockerfile.scratch-worker
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.systemanalyzer
+++ b/build/package/Dockerfile.systemanalyzer
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 ARG BUILD_REPO
 ARG BUILD_VERSION

--- a/build/package/Dockerfile.systemsubscriber
+++ b/build/package/Dockerfile.systemsubscriber
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.tetragon_sysgraph
+++ b/build/package/Dockerfile.tetragon_sysgraph
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/build/package/Dockerfile.timewarp
+++ b/build/package/Dockerfile.timewarp
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS binary
+FROM golang:1.26-alpine AS binary
 ARG DEBUG=false
 WORKDIR /src
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/oss-rebuild
 
-go 1.25.8
+go 1.26.5
 
 require (
 	cloud.google.com/go/bigquery v1.67.0


### PR DESCRIPTION
Toolchain and image base move from 1.25 to 1.26 now that 1.27 is out.