### PR TITLE
Add dependency graph priority signal

### DIFF
--- a/internal/signals/doc.go
+++ b/internal/signals/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package signals defines the priority signals that rank packages for
+// onboarding: per-package measures of importance, each normalized within its
+// ecosystem into (0,1] so heavy tails and incomparable registry scales stay
+// out of the arithmetic, and combined into one priority score at read time.
+//
+// "Prevalence" is the signal derived from the dependency graphs of each
+// ecosystem. We define it as "how many other packages depend on this one,
+// directly or transitively," measured both per package and per version.
+//
+// This package holds the record types, the scoring, and the exports' storage.
+// The jobs that produce and consume the exports live in
+// tools/ctl/command/onboard.
+package signals

--- a/internal/signals/prevalence.go
+++ b/internal/signals/prevalence.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// EcosystemSystem maps a local Ecosystem to its deps.dev `System`.
+// This allows querying against the enum in bigquery-public-data.deps_dev_v1.
+var EcosystemSystem = map[rebuild.Ecosystem]string{
+	rebuild.NPM:      "NPM",
+	rebuild.PyPI:     "PYPI",
+	rebuild.CratesIO: "CARGO",
+	rebuild.RubyGems: "RUBYGEMS",
+	rebuild.Maven:    "MAVEN",
+}
+
+// PrevalenceRecord contains the number of distinct packages that depend on a
+// package, directly or transitively, resolved against the latest deps.dev
+// dependency-graph snapshot, and that count scored against its ecosystem.
+// Version is omitted for package-level rows and set for version-level ones.
+//
+// Version granularity is pertinent because the most-depended-upon version is
+// rarely the newest and old versions may retain use (and, thus, value) well
+// past their publication. Ranking a package's versions by its
+// package-level prevalence would leave recency as the only differentiator,
+// which may not correlate strongly with blast radius.
+type PrevalenceRecord struct {
+	Ecosystem  string `json:"ecosystem"`
+	Package    string `json:"package"`
+	Version    string `json:"version,omitempty"`
+	Dependents int64  `json:"dependents"`
+	// Prevalence is Dependents on a log scale relative to the ecosystem's most
+	// depended-on package, in (0,1]. Counts are tail heavy enough that a rank
+	// quantile over the ecosystem would crowd every exported row above 0.99.
+	Prevalence float64 `json:"prevalence"`
+}

--- a/internal/signals/score.go
+++ b/internal/signals/score.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import "math"
+
+// LogScale maps a dependent count onto (0,1] by its order of magnitude
+// relative to max, the ecosystem's most depended-on package:
+// ln(1+count)/ln(1+max). Dependent counts are tail heavy, so a rank quantile
+// over a whole ecosystem crowds every exported row above 0.99 where a log
+// scale spreads them by blast radius. A count at or above max scores 1 and
+// max <= 0 yields 0.
+func LogScale(count, max int64) float64 {
+	if max <= 0 || count <= 0 {
+		return 0
+	}
+	return min(1, math.Log1p(float64(count))/math.Log1p(float64(max)))
+}

--- a/internal/signals/score_test.go
+++ b/internal/signals/score_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLogScale(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		count, max int64
+		want       float64
+	}{
+		{"Top", 9000, 9000, 1.0},
+		{"Single", 1, 9000, math.Log1p(1) / math.Log1p(9000)},
+		{"AboveMax", 10000, 9000, 1.0},
+		{"ZeroCount", 0, 9000, 0},
+		{"EmptyPopulation", 5, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, LogScale(tc.count, tc.max)); diff != "" {
+				t.Errorf("LogScale(%d, %d) mismatch (-want +got):\n%s", tc.count, tc.max, diff)
+			}
+		})
+	}
+}

--- a/tools/ctl/command/onboard/README.md
+++ b/tools/ctl/command/onboard/README.md
@@ -1,0 +1,36 @@
+# Onboarding
+
+Bringing a package into oss-rebuild coverage means two things: deciding it is
+worth the capacity, and then spending capacity until it reproduces.
+`ctl onboard priority` answers the first.
+
+## Priority
+
+There are far more packages than rebuild capacity, so something has to say
+which ones matter. Priority is a per-package score combining independent
+signals of importance, each computed by its own offline job and each
+normalized per ecosystem into (0,1] so heavy tails and incomparable registry
+scales stay out of the arithmetic.
+
+| Signal     | What it measures                                            | Source                    |
+| ---------- | ----------------------------------------------------------- | ------------------------- |
+| prevalence | distinct packages depending on this one, transitively too   | deps.dev dependency graph |
+
+Prevalence is computed at two granularities. The package number measures total
+use and is a coarse estimation of overall value. The per-version number allows
+us to better assess priority within a package's publications. Both are the
+dependent count on a log scale relative to the ecosystem's most depended-on
+package, so a version never outscores its package and the gap between them is
+the share of the package's use that version carries: lodash sits near the top
+of npm, lodash@4.17.21 just under it, and lodash@3.10.1 well below. The
+package number says lodash is worth tracking at all. The version numbers say
+which of its releases to rebuild first.
+
+Each job writes its ranked signal as a JSONL export, to a local path or a
+gs:// object:
+
+```sh
+# Read-only against public BigQuery data.
+ctl onboard priority prevalence --project my-project --out prevalence.jsonl
+ctl onboard priority prevalence --project my-project --out gs://my-analytics/priority/prevalence.jsonl
+```

--- a/tools/ctl/command/onboard/onboard.go
+++ b/tools/ctl/command/onboard/onboard.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package onboard implements the commands that bring packages into oss-rebuild coverage.
+package onboard
+
+import (
+	"context"
+
+	"github.com/google/oss-rebuild/pkg/act/cli"
+	"github.com/spf13/cobra"
+)
+
+// Deps is shared by all onboard subcommands.
+type Deps struct{ IO cli.IO }
+
+func (d *Deps) SetIO(cio cli.IO) { d.IO = cio }
+
+// InitDeps initializes shared dependencies.
+func InitDeps(context.Context) (*Deps, error) { return &Deps{}, nil }
+
+// Command returns the parent `onboard` command.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "onboard",
+		Short: "Bring packages into rebuild coverage",
+	}
+	cmd.AddCommand(priorityCommand())
+	return cmd
+}

--- a/tools/ctl/command/onboard/prevalence.go
+++ b/tools/ctl/command/onboard/prevalence.go
@@ -1,0 +1,356 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import (
+	"cmp"
+	"context"
+	"flag"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/google/oss-rebuild/internal/billyx"
+	"github.com/google/oss-rebuild/internal/jsonl"
+	"github.com/google/oss-rebuild/internal/signals"
+	"github.com/google/oss-rebuild/pkg/act"
+	"github.com/google/oss-rebuild/pkg/act/cli"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+type prevalenceConfig struct {
+	Project     string
+	Ecosystems  string
+	Top         int // bounds the package rows kept per ecosystem
+	TopVersions int // bounds the version rows kept per ecosystem
+	Out         string
+}
+
+func (c prevalenceConfig) Validate() error {
+	if c.Project == "" {
+		return errors.New("project is required")
+	}
+	if c.Out == "" {
+		return errors.New("out is required")
+	}
+	ecos := c.ecosystems()
+	if len(ecos) == 0 {
+		return errors.New("at least one ecosystem is required")
+	}
+	for _, name := range ecos {
+		if _, ok := signals.EcosystemSystem[rebuild.Ecosystem(name)]; !ok {
+			return errors.Errorf("ecosystem %q has no deps.dev dependency-graph coverage", name)
+		}
+	}
+	return nil
+}
+
+func (c prevalenceConfig) ecosystems() []string {
+	var out []string
+	for name := range strings.SplitSeq(c.Ecosystems, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func prevalenceHandler(ctx context.Context, cfg prevalenceConfig, deps *Deps) (*act.NoOutput, error) {
+	client, err := bigquery.NewClient(ctx, cfg.Project, option.WithQuotaProject(cfg.Project))
+	if err != nil {
+		return nil, errors.Wrap(err, "creating bigquery client")
+	}
+	defer client.Close()
+	ds, err := workDataset(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	snap, err := latestSnapshot(ctx, client, ds)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(deps.IO.Err, "deps.dev snapshot %s\n", snap.Format(time.RFC3339))
+	var recs []signals.PrevalenceRecord
+	for _, name := range cfg.ecosystems() {
+		pkgs, err := packagePrevalence(ctx, client, ds, name, snap, cfg.Top)
+		if err != nil {
+			return nil, errors.Wrapf(err, "querying %s package prevalence", name)
+		}
+		vers, err := versionPrevalence(ctx, client, ds, name, snap, cfg.TopVersions)
+		if err != nil {
+			return nil, errors.Wrapf(err, "querying %s version prevalence", name)
+		}
+		fmt.Fprintf(deps.IO.Err, "[%s] %d package(s), %d version(s)\n", name, len(pkgs), len(vers))
+		recs = append(recs, pkgs...)
+		recs = append(recs, vers...)
+	}
+	scored := scoreByEcosystem(recs)
+	outFS, out, err := billyx.NewResolver().FS(ctx, cfg.Out)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolving %s", cfg.Out)
+	}
+	w, err := outFS.Create(out)
+	if err != nil {
+		return nil, errors.Wrapf(err, "opening %s", cfg.Out)
+	}
+	if err := jsonl.Encode(w, scored); err != nil {
+		w.Close()
+		return nil, errors.Wrap(err, "writing export")
+	}
+	if err := w.Close(); err != nil {
+		return nil, errors.Wrapf(err, "finalizing %s", cfg.Out)
+	}
+	fmt.Fprintf(deps.IO.Out, "wrote %d prevalence record(s) to %s\n", len(scored), cfg.Out)
+	return &act.NoOutput{}, nil
+}
+
+// scoreByEcosystem attaches per-ecosystem scores: each row's dependent count on
+// a log scale relative to the ecosystem's most depended-on package. Scoring is
+// per-ecosystem because raw counts are not comparable across registries:
+// npm's graph is denser than RubyGems' by an order of magnitude, so a shared
+// scale would bury every gem below the npm long tail. Package and version rows
+// share the denominator, so a version never outscores its package and the gap
+// between them is the share of the package's use that version carries.
+// Package rows precede version rows, ecosystems are sorted, and ties break by
+// name, so the export is stable to rerun.
+func scoreByEcosystem(recs []signals.PrevalenceRecord) []signals.PrevalenceRecord {
+	pkgsByEco := map[string][]signals.PrevalenceRecord{}
+	versByEco := map[string][]signals.PrevalenceRecord{}
+	for _, r := range recs {
+		if r.Ecosystem == "" || r.Package == "" {
+			continue
+		}
+		if r.Version == "" {
+			pkgsByEco[r.Ecosystem] = append(pkgsByEco[r.Ecosystem], r)
+		} else {
+			versByEco[r.Ecosystem] = append(versByEco[r.Ecosystem], r)
+		}
+	}
+	maxByEco := map[string]int64{}
+	for _, byEco := range []map[string][]signals.PrevalenceRecord{pkgsByEco, versByEco} {
+		for eco, rs := range byEco {
+			for _, r := range rs {
+				maxByEco[eco] = max(maxByEco[eco], r.Dependents)
+			}
+		}
+	}
+	var out []signals.PrevalenceRecord
+	for _, byEco := range []map[string][]signals.PrevalenceRecord{pkgsByEco, versByEco} {
+		for _, eco := range slices.Sorted(maps.Keys(byEco)) {
+			scored := byDependents(byEco[eco])
+			for i := range scored {
+				scored[i].Prevalence = signals.LogScale(scored[i].Dependents, maxByEco[eco])
+			}
+			out = append(out, scored...)
+		}
+	}
+	return out
+}
+
+// byDependents orders by descending dependent count with a name tiebreak. The
+// queries apply the same total order to their LIMIT, so membership at the
+// cutoff is deterministic and the export is byte-stable across reruns of the
+// same snapshot.
+func byDependents(recs []signals.PrevalenceRecord) []signals.PrevalenceRecord {
+	slices.SortFunc(recs, func(a, b signals.PrevalenceRecord) int {
+		return cmp.Or(
+			cmp.Compare(b.Dependents, a.Dependents),
+			cmp.Compare(a.Package, b.Package),
+			cmp.Compare(a.Version, b.Version),
+		)
+	})
+	return recs
+}
+
+// latestSnapshot reads the most recent deps.dev snapshot time. Pinning queries
+// to it as a TIMESTAMP parameter lets BigQuery prune to a single partition.
+func latestSnapshot(ctx context.Context, client *bigquery.Client, ds *bigquery.Dataset) (time.Time, error) {
+	it, err := runQuery(ctx, client.Query("SELECT MAX(Time) AS Time FROM `bigquery-public-data.deps_dev_v1.Snapshots`"), ds.Table("latest_snapshot"))
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "reading deps.dev snapshots")
+	}
+	var row struct{ Time time.Time }
+	if err := it.Next(&row); err != nil {
+		return time.Time{}, errors.Wrap(err, "reading latest snapshot")
+	}
+	if row.Time.IsZero() {
+		return time.Time{}, errors.New("no deps.dev snapshot found")
+	}
+	return row.Time, nil
+}
+
+// depsDevSystem resolves an ecosystem to the deps.dev `System` enum naming it.
+func depsDevSystem(ecosystem string) (string, error) {
+	system, ok := signals.EcosystemSystem[rebuild.Ecosystem(ecosystem)]
+	if !ok {
+		return "", errors.Errorf("ecosystem %q has no deps.dev dependency-graph coverage", ecosystem)
+	}
+	return system, nil
+}
+
+// packagePrevalence counts, for each package, the distinct packages whose
+// resolved dependency graph contains it at the given snapshot: its transitive
+// dependents. Every edge row names the root package version whose graph it
+// belongs to, so this is a distinct count over that root, not a graph walk. A
+// root's graph can contain another version of the root itself; those rows are
+// excluded, as are bundled copies: deps.dev names a dependency vendored inside
+// another package's tarball by its nesting path joined with ">", e.g.
+// "react-scripts>0.5.1>babel-preset-react-app>regjsgen". Consumers receive
+// those copies through the parent artifact, not the registry, so they are not
+// rebuild targets and would otherwise inflate the population several-fold.
+func packagePrevalence(ctx context.Context, client *bigquery.Client, ds *bigquery.Dataset, ecosystem string, snap time.Time, top int) ([]signals.PrevalenceRecord, error) {
+	system, err := depsDevSystem(ecosystem)
+	if err != nil {
+		return nil, err
+	}
+	q := client.Query("SELECT T.`To`.Name AS Package, COUNT(DISTINCT T.Name) AS Dependents\n" +
+		"FROM `bigquery-public-data.deps_dev_v1.DependencyGraphEdges` T\n" +
+		"WHERE T.System = @system AND T.SnapshotAt = @snap\n" +
+		"  AND T.Name != T.`To`.Name\n" +
+		"  AND T.`To`.Name NOT LIKE '%>%'\n" +
+		"GROUP BY Package\n" +
+		"ORDER BY Dependents DESC, Package\n" +
+		"LIMIT @top")
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "system", Value: system},
+		{Name: "snap", Value: snap},
+		{Name: "top", Value: top},
+	}
+	it, err := runQuery(ctx, q, ds.Table("pkg_prevalence_"+ecosystem))
+	if err != nil {
+		return nil, err
+	}
+	var out []signals.PrevalenceRecord
+	for {
+		var row struct {
+			Package    string
+			Dependents int64
+		}
+		switch err := it.Next(&row); err {
+		case nil:
+			out = append(out, signals.PrevalenceRecord{Ecosystem: ecosystem, Package: row.Package, Dependents: row.Dependents})
+		case iterator.Done:
+			return out, nil
+		default:
+			return nil, errors.Wrap(err, "iterating results")
+		}
+	}
+}
+
+// versionPrevalence counts, for each exact version, the distinct packages
+// whose resolved dependency graph contains that version. Same table, snapshot
+// and exclusions as packagePrevalence, grouped one column finer.
+func versionPrevalence(ctx context.Context, client *bigquery.Client, ds *bigquery.Dataset, ecosystem string, snap time.Time, top int) ([]signals.PrevalenceRecord, error) {
+	system, err := depsDevSystem(ecosystem)
+	if err != nil {
+		return nil, err
+	}
+	q := client.Query("SELECT T.`To`.Name AS Package, T.`To`.Version AS Version, COUNT(DISTINCT T.Name) AS Dependents\n" +
+		"FROM `bigquery-public-data.deps_dev_v1.DependencyGraphEdges` T\n" +
+		"WHERE T.System = @system AND T.SnapshotAt = @snap\n" +
+		"  AND T.Name != T.`To`.Name\n" +
+		"  AND T.`To`.Name NOT LIKE '%>%'\n" +
+		"  AND T.`To`.Version != ''\n" +
+		"GROUP BY Package, Version\n" +
+		"ORDER BY Dependents DESC, Package, Version\n" +
+		"LIMIT @top")
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "system", Value: system},
+		{Name: "snap", Value: snap},
+		{Name: "top", Value: top},
+	}
+	it, err := runQuery(ctx, q, ds.Table("ver_prevalence_"+ecosystem))
+	if err != nil {
+		return nil, err
+	}
+	var out []signals.PrevalenceRecord
+	for {
+		var row struct {
+			Package    string
+			Version    string
+			Dependents int64
+		}
+		switch err := it.Next(&row); err {
+		case nil:
+			out = append(out, signals.PrevalenceRecord{Ecosystem: ecosystem, Package: row.Package, Version: row.Version, Dependents: row.Dependents})
+		case iterator.Done:
+			return out, nil
+		default:
+			return nil, errors.Wrap(err, "iterating results")
+		}
+	}
+}
+
+// workDataset returns the dataset that holds query results, creating it if
+// missing. Without an explicit destination BigQuery materializes results
+// into a hidden per-user dataset whose ACL names the querying user, which
+// domain-restricted organizations reject at creation; a dataset granted
+// only the project's special groups never names a user, so it is allowed.
+func workDataset(ctx context.Context, client *bigquery.Client) (*bigquery.Dataset, error) {
+	ds := client.Dataset("onboard_prevalence")
+	if _, err := ds.Metadata(ctx); err == nil {
+		return ds, nil
+	}
+	err := ds.Create(ctx, &bigquery.DatasetMetadata{
+		Description:            "Query results for ctl onboard priority prevalence.",
+		DefaultTableExpiration: 24 * time.Hour,
+		Access: []*bigquery.AccessEntry{
+			{Role: bigquery.OwnerRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectOwners"},
+			{Role: bigquery.WriterRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectWriters"},
+			{Role: bigquery.ReaderRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectReaders"},
+		},
+	})
+	return ds, errors.Wrap(err, "creating work dataset")
+}
+
+func runQuery(ctx context.Context, q *bigquery.Query, dst *bigquery.Table) (*bigquery.RowIterator, error) {
+	q.Dst = dst
+	q.WriteDisposition = bigquery.WriteTruncate
+	job, err := q.Run(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "running query")
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "waiting for query")
+	}
+	if err := status.Err(); err != nil {
+		return nil, errors.Wrap(err, "query failed")
+	}
+	it, err := job.Read(ctx)
+	return it, errors.Wrap(err, "reading results")
+}
+
+func prevalenceCommand() *cobra.Command {
+	cfg := prevalenceConfig{}
+	cmd := &cobra.Command{
+		Use:   "prevalence --project <project> --out <uri> [--ecosystems <eco,...>] [--top <n>] [--top-versions <n>]",
+		Short: "Rank packages by distinct transitive dependents (deps.dev graph)",
+		Long: `Rank packages by distinct transitive dependents (deps.dev graph).
+
+Counts how many distinct packages depend, directly or transitively, on each
+package, and separately on each exact version, at the latest deps.dev
+snapshot, then scores both on a log scale relative to the ecosystem's most
+depended-on package and writes the result as a JSONL export.
+
+Reads public data and writes externally so no BigQuery write access required.`,
+		Args: cobra.NoArgs,
+		RunE: cli.RunE(&cfg, cli.SkipArgs[prevalenceConfig], InitDeps, prevalenceHandler),
+	}
+	set := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
+	set.StringVar(&cfg.Project, "project", "", "GCP project that runs and is billed for the BigQuery jobs")
+	set.StringVar(&cfg.Ecosystems, "ecosystems", "npm,pypi,cratesio,rubygems,maven", "comma-separated ecosystems to rank")
+	set.IntVar(&cfg.Top, "top", 5000, "max packages to keep per ecosystem, by dependent count")
+	set.IntVar(&cfg.TopVersions, "top-versions", 20000, "max versions to keep per ecosystem, by dependent count")
+	set.StringVar(&cfg.Out, "out", "", "write the ranked JSONL export to this path or gs:// URI")
+	cmd.Flags().AddGoFlagSet(set)
+	return cmd
+}

--- a/tools/ctl/command/onboard/prevalence_test.go
+++ b/tools/ctl/command/onboard/prevalence_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/jsonl"
+	"github.com/google/oss-rebuild/internal/signals"
+)
+
+func TestRankByEcosystem(t *testing.T) {
+	// Package and version rows share each ecosystem's denominator, its most
+	// depended-on package, so a version never outscores its package.
+	got := scoreByEcosystem([]signals.PrevalenceRecord{
+		{Ecosystem: "npm", Package: "rarely-used", Dependents: 1},
+		{Ecosystem: "rubygems", Package: "rack", Dependents: 50},
+		{Ecosystem: "npm", Package: "lodash", Dependents: 9000},
+		{Ecosystem: "npm", Package: "lodash", Version: "4.17.21", Dependents: 8000},
+		{Ecosystem: "npm", Package: "lodash", Version: "3.10.1", Dependents: 400},
+		{Ecosystem: "npm", Package: "rarely-used", Version: "1.0.0", Dependents: 1},
+		{Ecosystem: "", Package: "dropped-no-ecosystem", Dependents: 5},
+		{Ecosystem: "npm", Package: "", Dependents: 5},
+	})
+
+	npm := func(dependents int64) float64 { return math.Log1p(float64(dependents)) / math.Log1p(9000) }
+	want := []signals.PrevalenceRecord{
+		{Ecosystem: "npm", Package: "lodash", Dependents: 9000, Prevalence: 1.0},
+		{Ecosystem: "npm", Package: "rarely-used", Dependents: 1, Prevalence: npm(1)},
+		{Ecosystem: "rubygems", Package: "rack", Dependents: 50, Prevalence: 1.0},
+		{Ecosystem: "npm", Package: "lodash", Version: "4.17.21", Dependents: 8000, Prevalence: npm(8000)},
+		{Ecosystem: "npm", Package: "lodash", Version: "3.10.1", Dependents: 400, Prevalence: npm(400)},
+		{Ecosystem: "npm", Package: "rarely-used", Version: "1.0.0", Dependents: 1, Prevalence: npm(1)},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ranked records mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWriteJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prevalence.jsonl")
+	rows := []signals.PrevalenceRecord{
+		{Ecosystem: "npm", Package: "lodash", Dependents: 9000, Prevalence: 1.0},
+		{Ecosystem: "npm", Package: "lodash", Version: "4.17.21", Dependents: 8000, Prevalence: 1.0},
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := jsonl.Encode(f, rows); err != nil {
+		t.Fatalf("jsonl.Encode: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading export: %v", err)
+	}
+	var got []signals.PrevalenceRecord
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	for dec.More() {
+		var r signals.PrevalenceRecord
+		if err := dec.Decode(&r); err != nil {
+			t.Fatalf("decoding line: %v", err)
+		}
+		got = append(got, r)
+	}
+	if diff := cmp.Diff(rows, got); diff != "" {
+		t.Errorf("round-tripped records mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/tools/ctl/command/onboard/priority.go
+++ b/tools/ctl/command/onboard/priority.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import "github.com/spf13/cobra"
+
+// priorityCommand groups the jobs that rank onboarding candidates.
+func priorityCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "priority",
+		Short: "Compute and export the signals that rank onboarding candidates",
+	}
+	cmd.AddCommand(prevalenceCommand())
+	return cmd
+}

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/oss-rebuild/tools/ctl/command/listruns"
 	"github.com/google/oss-rebuild/tools/ctl/command/localagent"
 	"github.com/google/oss-rebuild/tools/ctl/command/migrate"
+	"github.com/google/oss-rebuild/tools/ctl/command/onboard"
 	"github.com/google/oss-rebuild/tools/ctl/command/runagent"
 	"github.com/google/oss-rebuild/tools/ctl/command/runagentbenchmark"
 	"github.com/google/oss-rebuild/tools/ctl/command/runbenchmark"
@@ -48,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(localagent.Command())
 	rootCmd.AddCommand(runagentbenchmark.Command())
 	rootCmd.AddCommand(scratch.Command())
+	rootCmd.AddCommand(onboard.Command())
 	// Reading data
 	rootCmd.AddCommand(tui.Command())
 	rootCmd.AddCommand(getresults.Command())


### PR DESCRIPTION
For onboarding, we want to define an order correlated with the security
relevance of a package to its ecosystem. The number of recursive
dependent packages is a good proxy for this and can be calculated from
deps.dev's dependency graph tables. We define this count as a package's
"criticality" to its ecosystem. Notably, while download counts and
repository statistics could serve a similar role, the dependency graph
is the only data uniformly available across all ecosystems we support.

It is relevant to calculate at two granularities: 1) A package in
aggregate and 2) a package at a particular version. The aggregate may be
used to judge a package's worth to all ecosystem participants and so
whether we might consider it worthwhile to track on an ongoing basis.
The per-version value is a useful prioritization within a given
package's history.

Scores are stored as per-ecosystem quantiles rather than raw counts, since
dependent counts are tail heavy (i.e. many with few dependents) and
values are not comparable across registries (e.g. npm has many more
total packages and thus higher dependents per package).

The ranked result is written as a JSONL export to a local path or a GCS
object rather than loaded into Firestore. The export is recomputed
wholesale on each run, so a bulk artifact matches the write pattern:
refreshing it is one atomic object rewrite, and consumers combine the
exported quantiles at read time.