### PR TITLE
Record updated on rebuild attempts

### DIFF
--- a/internal/api/agentapiservice/scratch_exec.go
+++ b/internal/api/agentapiservice/scratch_exec.go
@@ -144,6 +144,7 @@ func ScratchExecCreate(ctx context.Context, req schema.ScratchExecRequest, deps 
 		State:          schema.ScratchExecPending,
 		OutURI:         outURIFor(deps.OutputBucket, scratch.ObliviousID, opID),
 		CreatedAt:      time.Now().UTC(),
+		Updated:        time.Now().UTC(),
 	}
 	if err := deps.Execs.Insert(ctx, exec); err != nil {
 		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "execs insert"))
@@ -453,6 +454,7 @@ func finalFromStatus(exec schema.ScratchExec, status *scratchworkerservice.ExecS
 	final := exec
 	final.ExitCode = status.ExitCode
 	final.StartedAt = status.StartedAt
+	final.Updated = now
 	if !status.FinishedAt.IsZero() {
 		final.FinishedAt = status.FinishedAt
 	} else {
@@ -493,6 +495,7 @@ func finalize(ctx context.Context, execs db.ScratchExecs, exec schema.ScratchExe
 	exec.State = schema.ScratchExecLost
 	exec.Error = st
 	exec.FinishedAt = time.Now().UTC()
+	exec.Updated = exec.FinishedAt
 	if err := execs.Update(ctx, exec); err != nil {
 		return exec, errors.Wrap(err, "finalize update")
 	}

--- a/internal/api/agentapiservice/scratch_exec_sync_test.go
+++ b/internal/api/agentapiservice/scratch_exec_sync_test.go
@@ -199,6 +199,7 @@ func TestSyncer_FinalFromStatus(t *testing.T) {
 				CreatedAt:  created,
 				StartedAt:  workerStart,
 				FinishedAt: workerFinish,
+				Updated:    brokerNow,
 			},
 		},
 		{
@@ -212,6 +213,7 @@ func TestSyncer_FinalFromStatus(t *testing.T) {
 				State:      schema.ScratchExecCompleted,
 				CreatedAt:  created,
 				FinishedAt: brokerNow,
+				Updated:    brokerNow,
 			},
 		},
 		{
@@ -231,6 +233,7 @@ func TestSyncer_FinalFromStatus(t *testing.T) {
 				CreatedAt:  created,
 				StartedAt:  workerStart,
 				FinishedAt: workerFinish,
+				Updated:    brokerNow,
 				Error: &schema.Status{
 					Code:    int(codes.DeadlineExceeded),
 					Message: "command exceeded TimeoutSeconds",
@@ -252,6 +255,7 @@ func TestSyncer_FinalFromStatus(t *testing.T) {
 				CreatedAt:  created,
 				StartedAt:  workerStart,
 				FinishedAt: workerFinish,
+				Updated:    brokerNow,
 				Error: &schema.Status{
 					Code:    int(codes.Internal),
 					Message: "spawn failed",

--- a/internal/api/agentapiservice/scratch_reap.go
+++ b/internal/api/agentapiservice/scratch_reap.go
@@ -142,6 +142,7 @@ func ScratchReap(ctx context.Context, _ ScratchReapRequest, deps *ScratchReapDep
 		exec.State = next
 		exec.Error = errStatus
 		exec.FinishedAt = now
+		exec.Updated = now
 		if err := deps.Execs.Update(ctx, exec); err != nil {
 			log.Printf("reap finalize op %s: %v", exec.ID, err)
 			continue

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -408,6 +408,7 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 		RunID:           req.ID,
 		Started:         started,
 		Created:         time.Now().UTC(),
+		Updated:         time.Now().UTC(),
 	}
 	if err := deps.Attempts.Upsert(ctx, attempt); err != nil {
 		return nil, errors.Wrap(err, "initial write to db")
@@ -416,6 +417,7 @@ func RebuildPackage(ctx context.Context, req schema.RebuildPackageRequest, deps 
 	finish := func(status schema.RebuildStatus) {
 		attempt.Status = status
 		attempt.Finished = time.Now().UTC()
+		attempt.Updated = time.Now().UTC()
 		// We use a background context for the terminal write to ensure it completes
 		// even if the request context is cancelled.
 		if err := deps.Attempts.Update(context.Background(), attempt); err != nil {

--- a/internal/api/apiservice/rebuild_lro.go
+++ b/internal/api/apiservice/rebuild_lro.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/oss-rebuild/internal/db"
 	"github.com/google/oss-rebuild/pkg/longrunning"
@@ -126,6 +127,7 @@ func CreateRebuildOp(
 			Artifact:  req.Artifact,
 			RunID:     req.ID,
 			Status:    schema.RebuildStatusRunning,
+			Updated:   time.Now().UTC(),
 		}
 
 		if err := deps.Attempts.Insert(ctx, attempt); err != nil {
@@ -136,6 +138,7 @@ func CreateRebuildOp(
 			// Best-effort mark the attempt as failed.
 			attempt.Status = schema.RebuildStatusError
 			attempt.Message = "failed to launch rebuild job: " + err.Error()
+			attempt.Updated = time.Now().UTC()
 			_ = deps.Attempts.Update(ctx, attempt)
 			return nil, err
 		}

--- a/internal/api/inferenceservice/infer.go
+++ b/internal/api/inferenceservice/infer.go
@@ -6,6 +6,7 @@ package inferenceservice
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/db"
@@ -83,6 +84,7 @@ func recordRepoMetrics(ctx context.Context, store db.RepoMetrics, rcfg rebuild.R
 		Commits:    commits,
 		Head:       ref.Hash().String(),
 		MeasuredAt: rcfg.FetchedAt,
+		Updated:    time.Now().UTC(),
 	}
 	return errors.Wrap(store.Upsert(ctx, m), "upserting")
 }

--- a/internal/api/inferenceservice/infer_test.go
+++ b/internal/api/inferenceservice/infer_test.go
@@ -73,6 +73,9 @@ func TestRecordRepoMetrics(t *testing.T) {
 	if !got.MeasuredAt.Equal(fetched) {
 		t.Errorf("MeasuredAt = %v; want the config's FetchedAt %v", got.MeasuredAt, fetched)
 	}
+	if got.Updated.IsZero() {
+		t.Error("Updated is zero; want a timestamp")
+	}
 }
 
 func TestRecordRepoMetricsBadURI(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -29,6 +29,8 @@ var (
 	ErrAlreadyExists = errors.New("already exists")
 )
 
+// TODO: Fold Updated stamping into the resource layer for every mutable resource.
+
 // Type aliases for the resources currently defined.
 type (
 	Runs     = Resource[schema.Run, string]

--- a/internal/db/repometrics_test.go
+++ b/internal/db/repometrics_test.go
@@ -21,11 +21,11 @@ func TestMemoryRepoMetrics_RoundTrip(t *testing.T) {
 		t.Fatalf("canonicalize: %v", err)
 	}
 	want := schema.RepoMetrics{
-		URI:        canonical,
-		Bytes:      4096,
-		Commits:    12,
-		Head:       "deadbeef",
-		MeasuredAt: time.Unix(1700000000, 0).UTC(),
+		URI:     canonical,
+		Bytes:   4096,
+		Commits: 12,
+		Head:    "deadbeef",
+		Updated: time.Unix(1700000000, 0).UTC(),
 	}
 	if err := s.Upsert(ctx, want); err != nil {
 		t.Fatalf("Upsert: %v", err)

--- a/pkg/rebuild/schema/costs.go
+++ b/pkg/rebuild/schema/costs.go
@@ -81,4 +81,5 @@ type RepoMetrics struct {
 	Commits    int64     `json:"commits,omitempty" firestore:"commits,omitempty"`        // commit objects in the clone
 	Head       string    `json:"head,omitempty" firestore:"head,omitempty"`              // head commit hash at measurement
 	MeasuredAt time.Time `json:"measured_at,omitzero" firestore:"measured_at,omitempty"` // if calculable, when the repo was fetched from the remote (diverges from current time for e.g. git-cache)
+	Updated    time.Time `json:"updated,omitzero" firestore:"updated,omitempty"`         // when this record was last written
 }

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -381,6 +381,7 @@ type RebuildAttempt struct {
 	Started         time.Time             `firestore:"started,omitempty"`    // The time rebuild started
 	Finished        time.Time             `firestore:"finished,omitempty"`   // The time rebuild finished
 	Created         time.Time             `firestore:"created,omitempty"`    // The time this record was created
+	Updated         time.Time             `firestore:"updated,omitempty"`    // The time this record was last written
 }
 
 func (a RebuildAttempt) Target() rebuild.Target {

--- a/pkg/rebuild/schema/scratch.go
+++ b/pkg/rebuild/schema/scratch.go
@@ -155,14 +155,17 @@ type ScratchExec struct {
 	// broker at create (request value, or the configured default when the
 	// request omits it). The reaper derives each op's hard deadline from it.
 	// Zero means unbounded: the reaper warns and leaves the scratch up.
-	TimeoutSeconds int              `json:"timeout_seconds,omitempty" firestore:"timeout_seconds,omitempty"`
-	OutURI         string           `json:"out_uri,omitempty" firestore:"out_uri,omitempty"`
-	CreatedAt      time.Time        `json:"created_at,omitzero" firestore:"created_at,omitempty"`
-	StartedAt      time.Time        `json:"started_at,omitzero" firestore:"started_at,omitempty"`
-	FinishedAt     time.Time        `json:"finished_at,omitzero" firestore:"finished_at,omitempty"`
-	State          ScratchExecState `json:"state" firestore:"state"`
-	ExitCode       int              `json:"exit_code,omitempty" firestore:"exit_code,omitempty"`
-	Error          *Status          `json:"error,omitempty" firestore:"error,omitempty"`
+	TimeoutSeconds int       `json:"timeout_seconds,omitempty" firestore:"timeout_seconds,omitempty"`
+	OutURI         string    `json:"out_uri,omitempty" firestore:"out_uri,omitempty"`
+	CreatedAt      time.Time `json:"created_at,omitzero" firestore:"created_at,omitempty"`
+	StartedAt      time.Time `json:"started_at,omitzero" firestore:"started_at,omitempty"`
+	FinishedAt     time.Time `json:"finished_at,omitzero" firestore:"finished_at,omitempty"`
+	// Updated is the last broker write observed on the *server*, not the worker.
+	// This is in contrast with the *At times above.
+	Updated  time.Time        `json:"updated,omitzero" firestore:"updated,omitempty"`
+	State    ScratchExecState `json:"state" firestore:"state"`
+	ExitCode int              `json:"exit_code,omitempty" firestore:"exit_code,omitempty"`
+	Error    *Status          `json:"error,omitempty" firestore:"error,omitempty"`
 }
 
 // ScratchExecResult is the API payload inside derived from ScratchExec.


### PR DESCRIPTION
Attempts are mutable (status transitions, timings, costs), so incremental
snapshot replay needs a clock recording the last write, not the first.
Every attempt write site stamps Updated alongside its other mutations,
and the collection group gains the single-field index exemptions its
updated range scans require.