### PR TITLE
Record the repo fetch time in repo metrics

### DIFF
--- a/internal/agent/logic.go
+++ b/internal/agent/logic.go
@@ -77,10 +77,11 @@ func (a *defaultAgent) InitializeFromIteration(ctx context.Context, initialItera
 	if err != nil {
 		return errors.Wrap(err, "parsing previous iteration")
 	}
-	a.repo, err = rebuild.LoadRepo(ctx, a.t.Package, memory.NewStorage(), memfs.New(), git.CloneOptions{URL: loc.Repo, RecurseSubmodules: git.DefaultSubmoduleRecursionDepth})
+	repo, err := rebuild.LoadRepo(ctx, a.t.Package, memory.NewStorage(), memfs.New(), git.CloneOptions{URL: loc.Repo, RecurseSubmodules: git.DefaultSubmoduleRecursionDepth})
 	if err != nil {
 		return errors.Wrap(err, "loading repo")
 	}
+	a.repo = repo.Repository
 	w, err := a.repo.Worktree()
 	if err != nil {
 		return errors.Wrap(err, "getting worktree")

--- a/internal/api/inferenceservice/infer.go
+++ b/internal/api/inferenceservice/infer.go
@@ -6,7 +6,6 @@ package inferenceservice
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
 	"github.com/google/oss-rebuild/internal/db"
@@ -83,7 +82,7 @@ func recordRepoMetrics(ctx context.Context, store db.RepoMetrics, rcfg rebuild.R
 		Bytes:      bytes,
 		Commits:    commits,
 		Head:       ref.Hash().String(),
-		MeasuredAt: time.Now().UTC(),
+		MeasuredAt: rcfg.FetchedAt,
 	}
 	return errors.Wrap(store.Upsert(ctx, m), "upserting")
 }

--- a/internal/api/inferenceservice/infer_test.go
+++ b/internal/api/inferenceservice/infer_test.go
@@ -6,6 +6,7 @@ package inferenceservice
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/google/oss-rebuild/internal/db"
@@ -48,7 +49,8 @@ func TestRecordRepoMetrics(t *testing.T) {
 	}
 	store := db.NewMemoryRepoMetrics()
 	// The non-canonical ssh alias exercises canonicalization on write.
-	rcfg := rebuild.RepoConfig{Repository: repo.Repository, URI: "git@github.com:Org/Repo.git"}
+	fetched := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	rcfg := rebuild.RepoConfig{Repo: gitx.Repo{Repository: repo.Repository, FetchedAt: fetched}, URI: "git@github.com:Org/Repo.git"}
 	if err := recordRepoMetrics(context.Background(), store, rcfg); err != nil {
 		t.Fatalf("recordRepoMetrics: %v", err)
 	}
@@ -68,15 +70,15 @@ func TestRecordRepoMetrics(t *testing.T) {
 	if got.Bytes <= 0 {
 		t.Errorf("Bytes = %d; want > 0", got.Bytes)
 	}
-	if got.MeasuredAt.IsZero() {
-		t.Error("MeasuredAt is zero; want a timestamp")
+	if !got.MeasuredAt.Equal(fetched) {
+		t.Errorf("MeasuredAt = %v; want the config's FetchedAt %v", got.MeasuredAt, fetched)
 	}
 }
 
 func TestRecordRepoMetricsBadURI(t *testing.T) {
 	repo := newTestRepo(t)
 	store := db.NewMemoryRepoMetrics()
-	if err := recordRepoMetrics(context.Background(), store, rebuild.RepoConfig{Repository: repo.Repository, URI: ""}); err == nil {
+	if err := recordRepoMetrics(context.Background(), store, rebuild.RepoConfig{Repo: gitx.Repo{Repository: repo.Repository}, URI: ""}); err == nil {
 		t.Error("recordRepoMetrics(empty URI) = nil error; want error")
 	}
 }

--- a/internal/gitcache/client.go
+++ b/internal/gitcache/client.go
@@ -87,7 +87,7 @@ func (c Client) GetLinkWithRef(repo string, contains time.Time, ref string) (uri
 }
 
 // Clone provides an interface to clone a git repo using the GitCache.
-func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*git.Repository, error) {
+func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*gitx.Repo, error) {
 	if opt.Auth != nil || opt.RemoteName != "" || opt.Depth != 0 || opt.RecurseSubmodules != 0 || opt.Tags != git.InvalidTagMode || opt.InsecureSkipTLS || len(opt.CABundle) > 0 {
 		// No support for non-trivial opts aside from NoCheckout, ReferenceName, and SingleBranch.
 		return nil, errors.New("Unsupported opt")
@@ -121,6 +121,8 @@ func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Wrap(errors.New(resp.Status), "fetching cached repo")
 	}
+	// NOTE: The repo's FetchedAt reflects the served cache entry's fetch time.
+	fetchedAt, _ := http.ParseTime(resp.Header.Get("Last-Modified"))
 	gr, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "gzip read error")
@@ -150,7 +152,7 @@ func (c Client) Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem
 			return nil, errors.Wrap(err, "checkout error")
 		}
 	}
-	return repo, nil
+	return &gitx.Repo{Repository: repo, FetchedAt: fetchedAt}, nil
 }
 
 var _ gitx.CloneFunc = Client{}.Clone

--- a/internal/gitcache/client_test.go
+++ b/internal/gitcache/client_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
@@ -21,12 +22,17 @@ import (
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
 )
 
 // bigContent exceeds go-git's 16KiB small-object threshold, so packfile reads
 // will access it lazily via the backed storer.
 var bigContent = strings.Repeat("x", 64*1024)
+
+// entryFetchTime is the Last-Modified the fixture cache serves its tarball
+// with, standing in for the entry's upstream fetch time.
+var entryFetchTime = time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 
 var testRepoYAML = `
 commits:
@@ -46,7 +52,7 @@ func setupCloneTestServer(t *testing.T, yamlSpec string) Client {
 	t.Helper()
 	// Stand in for the network clone: build the repo from YAML directly into
 	// the storer populateCache provides.
-	cloneFunc := func(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*git.Repository, error) {
+	cloneFunc := func(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*gitx.Repo, error) {
 		repo, err := gitxtest.CreateRepoFromYAML(yamlSpec, &gitxtest.RepositoryOptions{
 			Storer:   s,
 			Worktree: memfs.New(),
@@ -63,7 +69,7 @@ func setupCloneTestServer(t *testing.T, yamlSpec string) Client {
 		if sf, ok := s.(*filesystem.Storage); ok {
 			sf.Filesystem().Remove("index")
 		}
-		return repo.Repository, nil
+		return &gitx.Repo{Repository: repo.Repository}, nil
 	}
 	cacheDir := t.TempDir()
 	srv := &Server{backend: &localBackend{baseDir: cacheDir}, cloneFunc: cloneFunc}
@@ -86,6 +92,7 @@ func setupCloneTestServer(t *testing.T, yamlSpec string) Client {
 	})
 	mux.HandleFunc("/tarball", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/gzip")
+		w.Header().Set("Last-Modified", entryFetchTime.Format(http.TimeFormat))
 		w.Write(tarballBytes)
 	})
 	u, err := url.Parse(ts.URL)
@@ -139,6 +146,9 @@ func TestClientClone(t *testing.T) {
 			})
 			if err != nil {
 				t.Fatalf("Clone() error = %v", err)
+			}
+			if !repo.FetchedAt.Equal(entryFetchTime) {
+				t.Errorf("FetchedAt = %v, want %v", repo.FetchedAt, entryFetchTime)
 			}
 			// Verify HEAD is resolvable.
 			head, err := repo.Head()

--- a/internal/gitcache/server_test.go
+++ b/internal/gitcache/server_test.go
@@ -301,7 +301,7 @@ func setupLocalRepo(t *testing.T, yamlSpec string) string {
 // localCloneFunc returns a CloneFunc that rewrites the URL to localURL
 // before delegating to gitx.Clone.
 func localCloneFunc(localURL string) gitx.CloneFunc {
-	return func(ctx context.Context, s storage.Storer, fs billy.Filesystem, opts *git.CloneOptions) (*git.Repository, error) {
+	return func(ctx context.Context, s storage.Storer, fs billy.Filesystem, opts *git.CloneOptions) (*gitx.Repo, error) {
 		opts.URL = localURL
 		return gitx.Clone(ctx, s, fs, opts)
 	}

--- a/internal/gitx/clone.go
+++ b/internal/gitx/clone.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
@@ -28,12 +29,18 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Repo is a cloned repository and its clone-time provenance.
+type Repo struct {
+	*git.Repository
+	FetchedAt time.Time // when the contents were fetched from the remote. Zero when unrecorded (reused local repo)
+}
+
 // CloneFunc defines an interface for cloning a git repo.
-type CloneFunc func(context.Context, storage.Storer, billy.Filesystem, *git.CloneOptions) (*git.Repository, error)
+type CloneFunc func(context.Context, storage.Storer, billy.Filesystem, *git.CloneOptions) (*Repo, error)
 
 // Clone performs a clone operation, using native git if available,
 // otherwise falling back to go-git.
-func Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*git.Repository, error) {
+func Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*Repo, error) {
 	if NativeGitAvailable() && opt.Auth == nil {
 		// NOTE: Native git remains several times faster than go-git even for
 		// non-OS-backed storers, where NativeClone stages the clone on disk
@@ -46,7 +53,11 @@ func Clone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.
 	} else {
 		log.Println("No git binary found. Cloning using go-git")
 	}
-	return git.CloneContext(ctx, s, fs, opt)
+	repo, err := git.CloneContext(ctx, s, fs, opt)
+	if err != nil {
+		return nil, err
+	}
+	return &Repo{Repository: repo, FetchedAt: time.Now().UTC()}, nil
 }
 
 var _ CloneFunc = Clone
@@ -91,7 +102,7 @@ func classifyCloneError(output []byte, execErr error) error {
 }
 
 // Reuse reuses the existing git repo in Storer and Filesystem.
-func Reuse(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*git.Repository, error) {
+func Reuse(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*Repo, error) {
 	if opt.Auth != nil || opt.RemoteName != "" || opt.ReferenceName != "" || opt.SingleBranch || opt.Depth != 0 || opt.Tags != git.InvalidTagMode || opt.InsecureSkipTLS || len(opt.CABundle) > 0 {
 		// No support for non-trivial opts aside from NoCheckout.
 		return nil, errors.New("Unsupported opt")
@@ -150,7 +161,7 @@ func Reuse(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.
 	} else if err != nil {
 		return nil, errors.Wrapf(err, "Failed to checkout")
 	}
-	return repo, nil
+	return &Repo{Repository: repo}, nil
 }
 
 var _ CloneFunc = Reuse
@@ -187,7 +198,7 @@ func isOSFilesystem(bfs billy.Filesystem) bool {
 // NativeClone clones a git repository using the native `git` command.
 // If the target storage is not OS-backed, the results are first staged on disk.
 // Supports both filesystem.Storage and memory.Storage.
-func NativeClone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*git.Repository, error) {
+func NativeClone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt *git.CloneOptions) (*Repo, error) {
 	if opt.Auth != nil {
 		return nil, errors.New("unsupported clone option for native git: Auth")
 	}
@@ -303,7 +314,7 @@ func NativeClone(ctx context.Context, s storage.Storer, fs billy.Filesystem, opt
 			return nil, errors.Wrap(err, "checking out worktree")
 		}
 	}
-	return repo, nil
+	return &Repo{Repository: repo, FetchedAt: time.Now().UTC()}, nil
 }
 
 var _ CloneFunc = NativeClone

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -74,9 +74,10 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 
 func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, ropt *gitx.RepositoryOptions) (r rebuild.RepoConfig, err error) {
 	r.URI = repoURI
-	r.Repository, err = rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
+	repo, err := rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
 	switch err {
 	case nil:
+		r.Repo = *repo
 	case transport.ErrAuthenticationRequired:
 		return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)
 	default:

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/oss-rebuild/internal/api/cratesregistryservice"
+	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
 	"github.com/google/oss-rebuild/internal/httpx/httpxtest"
 	"github.com/google/oss-rebuild/pkg/act/api"
@@ -859,10 +860,10 @@ version = 3
 			repo := must(gitxtest.CreateRepoFromYAML(tc.repo, nil))
 			target := rebuild.Target{Ecosystem: rebuild.CratesIO, Package: "serde", Version: "1.0.150", Artifact: "serde-1.0.150.crate"}
 			rcfg := rebuild.RepoConfig{
-				Repository: repo.Repository,
-				URI:        "https://github.com/serde-rs/serde",
-				Dir:        "",
-				RefMap:     map[string]string{"1.0.150": repo.Commits["version-bump"].String()},
+				Repo:   gitx.Repo{Repository: repo.Repository},
+				URI:    "https://github.com/serde-rs/serde",
+				Dir:    "",
+				RefMap: map[string]string{"1.0.150": repo.Commits["version-bump"].String()},
 			}
 			files := tc.files
 			if tc.filesFn != nil {
@@ -953,7 +954,7 @@ func TestInferRefAndDirUsesVCSPathForFallback(t *testing.T) {
 				rebuild.Target{Package: "serde", Version: "1.0.150"},
 				&cratesio.CrateVersion{Version: cratesio.Version{Version: "1.0.150"}},
 				crate.Bytes(),
-				&rebuild.RepoConfig{Repository: repo.Repository, Dir: "current", RefMap: refMap},
+				&rebuild.RepoConfig{Repo: gitx.Repo{Repository: repo.Repository}, Dir: "current", RefMap: refMap},
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -55,9 +55,10 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 
 func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, ropt *gitx.RepositoryOptions) (r rebuild.RepoConfig, err error) {
 	r.URI = repoURI
-	r.Repository, err = rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
+	repo, err := rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
 	switch err {
 	case nil:
+		r.Repo = *repo
 		return r, nil
 	case transport.ErrAuthenticationRequired:
 		return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)

--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -46,9 +46,10 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 
 func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, ropt *gitx.RepositoryOptions) (r rebuild.RepoConfig, err error) {
 	r.URI = repoURI
-	r.Repository, err = rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
+	repo, err := rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
 	switch err {
 	case nil:
+		r.Repo = *repo
 	case transport.ErrAuthenticationRequired:
 		return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)
 	default:

--- a/pkg/rebuild/npm/infer_test.go
+++ b/pkg/rebuild/npm/infer_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
 	"github.com/google/oss-rebuild/internal/httpx/httpxtest"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -434,10 +435,10 @@ func TestInferStrategy_NPM(t *testing.T) {
 			}
 			target.Artifact = ArtifactName(target)
 			rcfg := rebuild.RepoConfig{
-				Repository: repo.Repository,
-				URI:        "https://github.com/test-org/test-package",
-				Dir:        "",
-				RefMap:     map[string]string{"1.0.0": repo.Commits["version-bump"].String()},
+				Repo:   gitx.Repo{Repository: repo.Repository},
+				URI:    "https://github.com/test-org/test-package",
+				Dir:    "",
+				RefMap: map[string]string{"1.0.0": repo.Commits["version-bump"].String()},
 			}
 			client := httpxtest.MockClient{
 				Calls: []httpxtest.Call{

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -114,9 +114,10 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 
 func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, ropt *gitx.RepositoryOptions) (r rebuild.RepoConfig, err error) {
 	r.URI = repoURI
-	r.Repository, err = rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
+	repo, err := rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
 	switch err {
 	case nil:
+		r.Repo = *repo
 		return r, nil
 	case transport.ErrAuthenticationRequired:
 		return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)

--- a/pkg/rebuild/rebuild/git.go
+++ b/pkg/rebuild/rebuild/git.go
@@ -99,8 +99,7 @@ func allTags(repo *git.Repository) (tags []string, err error) {
 //
 // If rebuild.RepoCacheClientID is present, a Git cache service will be used
 // instead of the remote defined in CloneOptions.URL.
-func LoadRepo(ctx context.Context, pkg string, s storage.Storer, fs billy.Filesystem, opt git.CloneOptions) (*git.Repository, error) {
-	var r *git.Repository
+func LoadRepo(ctx context.Context, pkg string, s storage.Storer, fs billy.Filesystem, opt git.CloneOptions) (*gitx.Repo, error) {
 	r, err := gitx.Reuse(ctx, s, fs, &opt)
 	switch err {
 	case nil:

--- a/pkg/rebuild/rebuild/rebuild.go
+++ b/pkg/rebuild/rebuild/rebuild.go
@@ -7,16 +7,15 @@ import (
 	"context"
 	"io"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/google/oss-rebuild/internal/gitx"
 )
 
 // RepoConfig describes the repo currently being used.
 type RepoConfig struct {
-	*git.Repository
-	URI    string
-	Dir    string
-	RefMap map[string]string
+	gitx.Repo // NOTE: by value so Repository access on a zero RepoConfig is nil and not panic
+	URI       string
+	Dir       string
+	RefMap    map[string]string
 }
 
 // Rebuilder defines the operations used to rebuild an ecosystem's packages.

--- a/pkg/rebuild/rubygems/infer.go
+++ b/pkg/rebuild/rubygems/infer.go
@@ -61,9 +61,10 @@ func (Rebuilder) InferRepo(ctx context.Context, t rebuild.Target, mux rebuild.Re
 
 func (Rebuilder) CloneRepo(ctx context.Context, t rebuild.Target, repoURI string, ropt *gitx.RepositoryOptions) (r rebuild.RepoConfig, err error) {
 	r.URI = repoURI
-	r.Repository, err = rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
+	repo, err := rebuild.LoadRepo(ctx, t.Package, ropt.Storer, ropt.Worktree, git.CloneOptions{URL: r.URI, RecurseSubmodules: git.NoRecurseSubmodules, NoCheckout: true})
 	switch err {
 	case nil:
+		r.Repo = *repo
 		return r, nil
 	case transport.ErrAuthenticationRequired:
 		return r, errors.Errorf("repo invalid or private [repo=%s]", r.URI)

--- a/pkg/rebuild/rubygems/infer_test.go
+++ b/pkg/rebuild/rubygems/infer_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/gitx"
 	"github.com/google/oss-rebuild/internal/gitx/gitxtest"
 	"github.com/google/oss-rebuild/internal/httpx/httpxtest"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -188,8 +189,8 @@ func TestInferStrategy(t *testing.T) {
 			}
 			target.Artifact = ArtifactName(target)
 			rcfg := rebuild.RepoConfig{
-				Repository: repo.Repository,
-				URI:        "https://github.com/test-org/test-gem",
+				Repo: gitx.Repo{Repository: repo.Repository},
+				URI:  "https://github.com/test-org/test-gem",
 			}
 			// Mock the registry: Artifact call (for gem spec) and Version call.
 			client := httpxtest.MockClient{

--- a/pkg/rebuild/schema/costs.go
+++ b/pkg/rebuild/schema/costs.go
@@ -76,9 +76,9 @@ type AttemptCosts struct {
 // clone by the inference service. Keyed by repo rather than target since
 // many packages share a repository.
 type RepoMetrics struct {
-	URI        string    `json:"uri,omitempty" firestore:"uri,omitempty"`         // canonical repo URI
-	Bytes      int64     `json:"bytes,omitempty" firestore:"bytes,omitempty"`     // packed object store bytes at clone
-	Commits    int64     `json:"commits,omitempty" firestore:"commits,omitempty"` // commit objects in the clone
-	Head       string    `json:"head,omitempty" firestore:"head,omitempty"`       // head commit hash at measurement
-	MeasuredAt time.Time `json:"measured_at,omitzero" firestore:"measured_at,omitempty"`
+	URI        string    `json:"uri,omitempty" firestore:"uri,omitempty"`                // canonical repo URI
+	Bytes      int64     `json:"bytes,omitempty" firestore:"bytes,omitempty"`            // packed object store bytes at clone
+	Commits    int64     `json:"commits,omitempty" firestore:"commits,omitempty"`        // commit objects in the clone
+	Head       string    `json:"head,omitempty" firestore:"head,omitempty"`              // head commit hash at measurement
+	MeasuredAt time.Time `json:"measured_at,omitzero" firestore:"measured_at,omitempty"` // if calculable, when the repo was fetched from the remote (diverges from current time for e.g. git-cache)
 }


### PR DESCRIPTION
RepoMetrics.MeasuredAt previously stamped the record write time, which
overstates freshness. Inference clones through the git cache with no
freshness bound, so the measured contents can long predate the
measurement.

CloneFunc is made to return gitx.Repo, a git.Repository plus its
clone-time provenance, so every cloner reports the fetch time
uniformly.