### PR TITLE
Add incremental snapshot deltas

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -69,7 +69,7 @@ var (
 	agentLogsBucket       = flag.String("agent-logs-bucket", "", "GCS bucket for agent build logs")
 	agentTimeoutSeconds   = flag.Int("agent-timeout-seconds", 3600, "Seconds to allow agent to run")
 	rebuildJobName        = flag.String("rebuild-job-name", "", "Name of the pre-created Cloud Run Job for rebuilds")
-	analyticsURI          = flag.String("analytics-uri", "", "URI for snapshots (supported schemes: gs, file). Empty disables /snapshot/rollup")
+	analyticsURI          = flag.String("analytics-uri", "", "URI for snapshots (supported schemes: gs, file). Empty disables the /snapshot endpoints")
 	port                  = flag.Int("port", 8080, "port on which to serve")
 )
 
@@ -385,6 +385,21 @@ func analyticsDest(ctx context.Context) (billy.Filesystem, error) {
 	return billyx.NewResolver().DirFS(ctx, *analyticsURI)
 }
 
+func SnapshotDeltaInit(ctx context.Context) (*snapshotservice.DeltaDeps, error) {
+	if *analyticsURI == "" {
+		return &snapshotservice.DeltaDeps{}, nil
+	}
+	src, err := snapshot.NewFirestoreSource(ctx, *project)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating snapshot source")
+	}
+	dest, err := analyticsDest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &snapshotservice.DeltaDeps{Source: src, Dest: dest}, nil
+}
+
 func main() {
 	httpcfg.RegisterFlags(flag.CommandLine)
 	flag.Parse()
@@ -396,6 +411,7 @@ func main() {
 	http.HandleFunc("/runs", api.Handler(CreateRunInit, apiservice.CreateRun))
 	http.HandleFunc("/agent", api.Handler(AgentCreateInit, apiservice.AgentCreate))
 	http.HandleFunc("/snapshot/rollup", api.Handler(SnapshotRollupInit, snapshotservice.Rollup))
+	http.HandleFunc("/snapshot/delta", api.Handler(SnapshotDeltaInit, snapshotservice.Delta))
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil); err != nil {
 		log.Fatalln(err)
 	}

--- a/deployments/platform.tf
+++ b/deployments/platform.tf
@@ -310,6 +310,46 @@ resource "google_firestore_index" "attempts-ecosystem-package" {
   }
   depends_on = [google_firestore_database.default]
 }
+
+resource "google_firestore_field" "attempts-updated" {
+  collection = "attempts"
+  field      = "updated"
+  index_config {
+    indexes {
+      order       = "ASCENDING"
+      query_scope = "COLLECTION_GROUP"
+    }
+    indexes {
+      order       = "ASCENDING"
+      query_scope = "COLLECTION"
+    }
+    indexes {
+      order       = "DESCENDING"
+      query_scope = "COLLECTION"
+    }
+  }
+  depends_on = [google_firestore_database.default]
+}
+
+resource "google_firestore_field" "agent-iterations-updated" {
+  collection = "agent_iterations"
+  field      = "updated"
+  index_config {
+    indexes {
+      order       = "ASCENDING"
+      query_scope = "COLLECTION_GROUP"
+    }
+    indexes {
+      order       = "ASCENDING"
+      query_scope = "COLLECTION"
+    }
+    indexes {
+      order       = "DESCENDING"
+      query_scope = "COLLECTION"
+    }
+  }
+  depends_on = [google_firestore_database.default]
+}
 ## PubSub
 
 resource "google_pubsub_topic" "attestation-topic" {

--- a/internal/api/snapshotservice/delta.go
+++ b/internal/api/snapshotservice/delta.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshotservice
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/google/oss-rebuild/internal/snapshot"
+	"github.com/google/oss-rebuild/pkg/act/api"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+)
+
+// DeltaRequest is the (empty) input to /snapshot/delta.
+type DeltaRequest struct{}
+
+// Validate implements act.Input.
+func (DeltaRequest) Validate() error { return nil }
+
+// DeltaResponse reports the delta segment that was written. Segment is
+// empty when nothing had changed since the previous delta.
+type DeltaResponse struct {
+	Since     time.Time      `json:"since"`
+	Segment   string         `json:"segment,omitempty"`
+	RowCounts map[string]int `json:"row_counts"`
+}
+
+// DeltaDeps wires the delta handler.
+type DeltaDeps struct {
+	Source snapshot.Source  // records written since the resume point
+	Dest   billy.Filesystem // segment destination, also listed for the resume point. when nil, endpoint reports error
+	Opts   snapshot.DeltaOptions
+}
+
+// Delta writes one delta segment to the configured analytics
+// destination. It is stateless: the resume point is recovered from the
+// newest segment at the destination, so it is safe to invoke repeatedly and
+// a skipped run is caught up by the next one.
+func Delta(ctx context.Context, _ DeltaRequest, deps *DeltaDeps) (*DeltaResponse, error) {
+	if deps.Dest == nil {
+		return nil, api.AsStatus(codes.FailedPrecondition, errors.New("the delta export is disabled: no destination configured"))
+	}
+	res, err := snapshot.Delta(ctx, deps.Source, deps.Dest, deps.Opts)
+	if err != nil {
+		return nil, api.AsStatus(codes.Internal, errors.Wrap(err, "running delta"))
+	}
+	return &DeltaResponse{Since: res.Since, Segment: res.Segment, RowCounts: res.RowCounts}, nil
+}

--- a/internal/api/snapshotservice/delta_test.go
+++ b/internal/api/snapshotservice/delta_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshotservice
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/internal/snapshot"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestDeltaUnconfigured(t *testing.T) {
+	_, err := Delta(context.Background(), DeltaRequest{}, &DeltaDeps{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("code = %s; want FailedPrecondition. err=%v", status.Code(err), err)
+	}
+}
+
+func TestDeltaWritesSegment(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeSource{attempts: []schema.RebuildAttempt{
+		{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Artifact: "1.0.whl", RunID: "r1", Status: schema.RebuildStatusRunning, Updated: time.Now().UTC()},
+	}}
+	deps := &DeltaDeps{Source: src, Dest: memfs.New()}
+	resp, err := Delta(ctx, DeltaRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Delta: %v", err)
+	}
+	if resp.Segment == "" || resp.RowCounts[snapshot.TableAttempts] != 1 {
+		t.Errorf("response = %+v, want a segment with 1 attempt", resp)
+	}
+}

--- a/internal/api/snapshotservice/rollup_test.go
+++ b/internal/api/snapshotservice/rollup_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/google/oss-rebuild/internal/snapshot"
@@ -20,17 +21,21 @@ type fakeSource struct {
 	attempts []schema.RebuildAttempt
 }
 
-func (f *fakeSource) Attempts(context.Context) ([]schema.RebuildAttempt, error) {
+func (f *fakeSource) Attempts(context.Context, time.Time) ([]schema.RebuildAttempt, error) {
 	return f.attempts, nil
 }
-func (f *fakeSource) Runs(context.Context) ([]schema.Run, error)              { return nil, nil }
-func (f *fakeSource) Sessions(context.Context) ([]schema.AgentSession, error) { return nil, nil }
-func (f *fakeSource) Iterations(context.Context) ([]schema.AgentIteration, error) {
+func (f *fakeSource) Runs(context.Context, time.Time) ([]schema.Run, error) { return nil, nil }
+func (f *fakeSource) Sessions(context.Context, time.Time) ([]schema.AgentSession, error) {
 	return nil, nil
 }
-func (f *fakeSource) Scratches(context.Context) ([]schema.Scratch, error)       { return nil, nil }
-func (f *fakeSource) Execs(context.Context) ([]schema.ScratchExec, error)       { return nil, nil }
-func (f *fakeSource) RepoMetrics(context.Context) ([]schema.RepoMetrics, error) { return nil, nil }
+func (f *fakeSource) Iterations(context.Context, time.Time) ([]schema.AgentIteration, error) {
+	return nil, nil
+}
+func (f *fakeSource) Scratches(context.Context, time.Time) ([]schema.Scratch, error) { return nil, nil }
+func (f *fakeSource) Execs(context.Context, time.Time) ([]schema.ScratchExec, error) { return nil, nil }
+func (f *fakeSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
+	return nil, nil
+}
 
 func TestRollupUnconfigured(t *testing.T) {
 	_, err := Rollup(context.Background(), RollupRequest{}, &RollupDeps{})

--- a/internal/snapshot/delta.go
+++ b/internal/snapshot/delta.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/google/oss-rebuild/internal/docdb"
+	"github.com/pkg/errors"
+)
+
+// DeltaOptions configures a delta run.
+type DeltaOptions struct {
+	// Now overrides the segment timestamp. Zero means time.Now().UTC().
+	Now time.Time
+	// Slack widens the resume window to capture clock skew with servers and
+	// writes with stamps that may be slow to appear in the database.
+	// The guarded upserts make the resulting overlap harmless. Zero means 2m.
+	Slack time.Duration
+	// Bootstrap is how far back the first delta (no prior segments)
+	// reaches. Anything older is covered by the snapshot rollup. Zero
+	// means 24h.
+	Bootstrap time.Duration
+}
+
+// DeltaResult reports what a delta run wrote.
+type DeltaResult struct {
+	// Since is the watermark the source was queried from.
+	Since time.Time
+	// Segment is the written object name, empty when nothing had changed.
+	Segment   string
+	RowCounts map[string]int
+}
+
+// Delta writes one segment of everything written since the previous
+// segment. It is stateless: the resume watermark is recovered from the
+// newest segment name at the destination, so a crashed or skipped run is
+// caught up by the next one.
+func Delta(ctx context.Context, src Source, dest billy.Filesystem, opts DeltaOptions) (*DeltaResult, error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+	slack := opts.Slack
+	if slack == 0 {
+		slack = 2 * time.Minute
+	}
+	bootstrap := opts.Bootstrap
+	if bootstrap == 0 {
+		bootstrap = 24 * time.Hour
+	}
+	segs, err := docdb.ListSegments(dest, DeltaPrefix, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "listing segments")
+	}
+	since := now.Add(-bootstrap)
+	if len(segs) > 0 {
+		t, err := docdb.SegmentTime(segs[len(segs)-1])
+		if err != nil {
+			return nil, err
+		}
+		since = t.Add(-slack)
+	}
+	attempts, err := src.Attempts(ctx, since)
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning attempts")
+	}
+	runs, err := src.Runs(ctx, since)
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning runs")
+	}
+	sessions, err := src.Sessions(ctx, since)
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning agent sessions")
+	}
+	iterations, err := src.Iterations(ctx, since)
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning agent iterations")
+	}
+	scratches, err := src.Scratches(ctx, since)
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning scratch VMs")
+	}
+	execs, err := src.Execs(ctx, since)
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning scratch execs")
+	}
+	repoMetrics, err := src.RepoMetrics(ctx, since)
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning repo metrics")
+	}
+	tables := map[string][]json.RawMessage{
+		TableAttempts:        docsOf(attempts),
+		TableRuns:            docsOf(runs),
+		TableAgentSessions:   docsOf(sessions),
+		TableAgentIterations: docsOf(iterations),
+		TableScratchVMs:      docsOf(scratches),
+		TableScratchExecs:    docsOf(execs),
+		TableRepoMetrics:     docsOf(repoMetrics),
+	}
+	res := &DeltaResult{Since: since, RowCounts: make(map[string]int, len(tables))}
+	for name, docs := range tables {
+		res.RowCounts[name] = len(docs)
+	}
+	res.Segment, err = docdb.WriteSegment(dest, DeltaPrefix, now, Tables(), tables)
+	if err != nil {
+		return nil, errors.Wrap(err, "writing segment")
+	}
+	return res, nil
+}

--- a/internal/snapshot/delta_test.go
+++ b/internal/snapshot/delta_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/internal/docdb"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+func TestDeltaBootstrapAndResume(t *testing.T) {
+	ctx := context.Background()
+	dest := memfs.New()
+	now := time.Date(2026, 8, 20, 14, 5, 0, 0, time.UTC)
+	src := &fakeSource{
+		attempts: []schema.RebuildAttempt{
+			{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Artifact: "a.whl", RunID: "r1", Status: schema.RebuildStatusRunning, Updated: now},
+		},
+		scratches: []schema.Scratch{
+			{ID: "sc1", State: schema.ScratchReady, Created: now.Add(-time.Hour), Updated: now},
+		},
+	}
+	// With no prior segments the bootstrap lookback applies.
+	res, err := Delta(ctx, src, dest, DeltaOptions{Now: now})
+	if err != nil {
+		t.Fatalf("Delta: %v", err)
+	}
+	if want := now.Add(-24 * time.Hour); !res.Since.Equal(want) {
+		t.Errorf("bootstrap since = %v, want %v", res.Since, want)
+	}
+	if res.Segment == "" || res.RowCounts[TableAttempts] != 1 || res.RowCounts[TableScratchVMs] != 1 {
+		t.Errorf("first delta = %+v, want a segment with 1 attempt and 1 scratch", res)
+	}
+	// A later run resumes from the newest segment minus the slack window.
+	res2, err := Delta(ctx, src, dest, DeltaOptions{Now: now.Add(5 * time.Minute)})
+	if err != nil {
+		t.Fatalf("second Delta: %v", err)
+	}
+	if want := now.Add(-2 * time.Minute); !res2.Since.Equal(want) {
+		t.Errorf("resume since = %v, want %v", res2.Since, want)
+	}
+	if res2.Segment == "" {
+		t.Error("second delta wrote no segment despite changed rows")
+	}
+	// A quiet tick writes nothing, and the resume point holds position.
+	quiet := &fakeSource{}
+	res3, err := Delta(ctx, quiet, dest, DeltaOptions{Now: now.Add(10 * time.Minute)})
+	if err != nil {
+		t.Fatalf("third Delta: %v", err)
+	}
+	if res3.Segment != "" {
+		t.Errorf("quiet delta wrote %q", res3.Segment)
+	}
+	if want := now.Add(5*time.Minute - 2*time.Minute); !res3.Since.Equal(want) {
+		t.Errorf("quiet since = %v, want %v", res3.Since, want)
+	}
+	segs, err := docdb.ListSegments(dest, DeltaPrefix, "")
+	if err != nil {
+		t.Fatalf("ListSegments: %v", err)
+	}
+	if len(segs) != 2 {
+		t.Errorf("segments = %v, want 2", segs)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -19,12 +19,15 @@ import (
 )
 
 // Object is the destination object name of the snapshot database, stored
-// gzip-compressed as its name says. It carries the schema version, so each
-// version bump requires an artifact cutover. Within an era, the name is
-// stable with each rollup replaces the object wholesale with the object
-// store's versioning (e.g. GCS generations) responsible for providing
-// historical entries.
-var Object = fmt.Sprintf("rebuild-v%d.db.gz", SchemaVersion)
+// gzip-compressed as its name says, and DeltaPrefix the prefix of its
+// incremental segments. Both carry the schema version, so each version bump
+// requires an artifact cutover. Within an era, the object name is stable
+// with each rollup replacing it wholesale and the object store's versioning
+// (e.g. GCS generations) responsible for providing historical entries.
+var (
+	Object      = fmt.Sprintf("rebuild-v%d.db.gz", SchemaVersion)
+	DeltaPrefix = fmt.Sprintf("deltas-v%d", SchemaVersion)
+)
 
 // Options configures a snapshot run.
 type Options struct {
@@ -65,31 +68,31 @@ func Rollup(ctx context.Context, src Source, dest billy.Filesystem, opts Options
 		now = time.Now()
 	}
 	now = now.UTC()
-	attempts, err := src.Attempts(ctx)
+	attempts, err := src.Attempts(ctx, FullScan)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning attempts")
 	}
-	runs, err := src.Runs(ctx)
+	runs, err := src.Runs(ctx, FullScan)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning runs")
 	}
-	sessions, err := src.Sessions(ctx)
+	sessions, err := src.Sessions(ctx, FullScan)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning agent sessions")
 	}
-	iterations, err := src.Iterations(ctx)
+	iterations, err := src.Iterations(ctx, FullScan)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning agent iterations")
 	}
-	scratches, err := src.Scratches(ctx)
+	scratches, err := src.Scratches(ctx, FullScan)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning scratch VMs")
 	}
-	execs, err := src.Execs(ctx)
+	execs, err := src.Execs(ctx, FullScan)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning scratch execs")
 	}
-	repoMetrics, err := src.RepoMetrics(ctx)
+	repoMetrics, err := src.RepoMetrics(ctx, FullScan)
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning repo metrics")
 	}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 // fakeSource serves fixed fixtures, isolating the snapshot writer/derivation
-// pipeline from Firestore.
+// pipeline from Firestore. It records the watermark of each attempts scan.
 type fakeSource struct {
+	since       []time.Time
 	attempts    []schema.RebuildAttempt
 	runs        []schema.Run
 	sessions    []schema.AgentSession
@@ -30,17 +31,24 @@ type fakeSource struct {
 	repoMetrics []schema.RepoMetrics
 }
 
-func (f *fakeSource) Attempts(context.Context) ([]schema.RebuildAttempt, error) {
+func (f *fakeSource) Attempts(_ context.Context, since time.Time) ([]schema.RebuildAttempt, error) {
+	f.since = append(f.since, since)
 	return f.attempts, nil
 }
-func (f *fakeSource) Runs(context.Context) ([]schema.Run, error)              { return f.runs, nil }
-func (f *fakeSource) Sessions(context.Context) ([]schema.AgentSession, error) { return f.sessions, nil }
-func (f *fakeSource) Iterations(context.Context) ([]schema.AgentIteration, error) {
+func (f *fakeSource) Runs(context.Context, time.Time) ([]schema.Run, error) { return f.runs, nil }
+func (f *fakeSource) Sessions(context.Context, time.Time) ([]schema.AgentSession, error) {
+	return f.sessions, nil
+}
+func (f *fakeSource) Iterations(context.Context, time.Time) ([]schema.AgentIteration, error) {
 	return f.iterations, nil
 }
-func (f *fakeSource) Scratches(context.Context) ([]schema.Scratch, error) { return f.scratches, nil }
-func (f *fakeSource) Execs(context.Context) ([]schema.ScratchExec, error) { return f.execs, nil }
-func (f *fakeSource) RepoMetrics(context.Context) ([]schema.RepoMetrics, error) {
+func (f *fakeSource) Scratches(context.Context, time.Time) ([]schema.Scratch, error) {
+	return f.scratches, nil
+}
+func (f *fakeSource) Execs(context.Context, time.Time) ([]schema.ScratchExec, error) {
+	return f.execs, nil
+}
+func (f *fakeSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
 	return f.repoMetrics, nil
 }
 
@@ -98,6 +106,10 @@ func TestSnapshotFileRoundTrip(t *testing.T) {
 	res, err := Rollup(ctx, src, dest, Options{Project: "proj-x", ToolVersion: "v-test", Now: now})
 	if err != nil {
 		t.Fatalf("Rollup: %v", err)
+	}
+	// The rollup reads everything: one attempts scan, from the zero watermark.
+	if len(src.since) != 1 || !src.since[0].IsZero() {
+		t.Errorf("rollup attempts scans = %v, want one FullScan", src.since)
 	}
 	// Result row counts.
 	if got := res.RowCounts[TableAttempts]; got != 2 {

--- a/internal/snapshot/source.go
+++ b/internal/snapshot/source.go
@@ -5,6 +5,7 @@ package snapshot
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/google/oss-rebuild/internal/iterx"
@@ -13,18 +14,22 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-// Source is the read side of the rollup: it yields the raw records the
-// snapshot is built from. Scanning is isolated behind this interface so the
+// Source is the read side of the snapshot pipelines: each scan yields the
+// records written at or after the given watermark, and FullScan yields
+// every record. Scanning is isolated behind this interface so the
 // derivations can be tested with in-memory fixtures.
 type Source interface {
-	Attempts(context.Context) ([]schema.RebuildAttempt, error)
-	Runs(context.Context) ([]schema.Run, error)
-	Sessions(context.Context) ([]schema.AgentSession, error)
-	Iterations(context.Context) ([]schema.AgentIteration, error)
-	Scratches(context.Context) ([]schema.Scratch, error)
-	Execs(context.Context) ([]schema.ScratchExec, error)
-	RepoMetrics(context.Context) ([]schema.RepoMetrics, error)
+	Attempts(context.Context, time.Time) ([]schema.RebuildAttempt, error)
+	Runs(context.Context, time.Time) ([]schema.Run, error)
+	Sessions(context.Context, time.Time) ([]schema.AgentSession, error)
+	Iterations(context.Context, time.Time) ([]schema.AgentIteration, error)
+	Scratches(context.Context, time.Time) ([]schema.Scratch, error)
+	Execs(context.Context, time.Time) ([]schema.ScratchExec, error)
+	RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error)
 }
+
+// FullScan is the zero watermark: a scan given it reads every record.
+var FullScan time.Time
 
 // FirestoreSource scans a project's Firestore, reusing the same collection and
 // collection-group access patterns as internal/rundex.
@@ -69,32 +74,64 @@ func scanQuery[T any](ctx context.Context, q firestore.Query) ([]T, error) {
 	return out, nil
 }
 
-func (s *FirestoreSource) Attempts(ctx context.Context) ([]schema.RebuildAttempt, error) {
-	return scanQuery[schema.RebuildAttempt](ctx, s.client.CollectionGroup("attempts").Query)
+// sinceQuery bounds q to documents whose clock field is at or after since.
+// A zero since deliberately leaves the query unfiltered.
+func sinceQuery(q firestore.Query, clock string, since time.Time) firestore.Query {
+	if since.IsZero() {
+		return q
+	}
+	return q.Where(clock, ">=", since)
 }
 
-func (s *FirestoreSource) Runs(ctx context.Context) ([]schema.Run, error) {
-	return scanQuery[schema.Run](ctx, s.client.Collection("runs").Query)
+func (s *FirestoreSource) Attempts(ctx context.Context, since time.Time) ([]schema.RebuildAttempt, error) {
+	return scanQuery[schema.RebuildAttempt](ctx, sinceQuery(s.client.CollectionGroup("attempts").Query, "updated", since))
 }
 
-func (s *FirestoreSource) Sessions(ctx context.Context) ([]schema.AgentSession, error) {
-	return scanQuery[schema.AgentSession](ctx, s.client.Collection("agent_sessions").Query)
+// Runs bound on created: runs are write-once, so creation time is the only
+// clock they carry.
+func (s *FirestoreSource) Runs(ctx context.Context, since time.Time) ([]schema.Run, error) {
+	return scanRuns(ctx, sinceQuery(s.client.Collection("runs").Query, "created", since))
 }
 
-func (s *FirestoreSource) Iterations(ctx context.Context) ([]schema.AgentIteration, error) {
+// scanRuns reads run documents, recovering the ID from the document ref for
+// historical entries that only carry it there.
+func scanRuns(ctx context.Context, q firestore.Query) ([]schema.Run, error) {
+	var out []schema.Run
+	iter := q.Documents(ctx)
+	for doc, err := range iterx.ToSeq2(iter, iterator.Done) {
+		if err != nil {
+			return nil, errors.Wrap(err, "iterating runs")
+		}
+		var r schema.Run
+		if err := doc.DataTo(&r); err != nil {
+			return nil, errors.Wrap(err, "decoding run")
+		}
+		if r.ID == "" {
+			r.ID = doc.Ref.ID
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func (s *FirestoreSource) Sessions(ctx context.Context, since time.Time) ([]schema.AgentSession, error) {
+	return scanQuery[schema.AgentSession](ctx, sinceQuery(s.client.Collection("agent_sessions").Query, "updated", since))
+}
+
+func (s *FirestoreSource) Iterations(ctx context.Context, since time.Time) ([]schema.AgentIteration, error) {
 	// Iterations live in agent_sessions/{id}/agent_iterations. A collection
 	// group query gathers them all in one scan (each carries session_id).
-	return scanQuery[schema.AgentIteration](ctx, s.client.CollectionGroup("agent_iterations").Query)
+	return scanQuery[schema.AgentIteration](ctx, sinceQuery(s.client.CollectionGroup("agent_iterations").Query, "updated", since))
 }
 
-func (s *FirestoreSource) Scratches(ctx context.Context) ([]schema.Scratch, error) {
-	return scanQuery[schema.Scratch](ctx, s.client.Collection("scratch").Query)
+func (s *FirestoreSource) Scratches(ctx context.Context, since time.Time) ([]schema.Scratch, error) {
+	return scanQuery[schema.Scratch](ctx, sinceQuery(s.client.Collection("scratch").Query, "updated", since))
 }
 
-func (s *FirestoreSource) Execs(ctx context.Context) ([]schema.ScratchExec, error) {
-	return scanQuery[schema.ScratchExec](ctx, s.client.Collection("scratch-execs").Query)
+func (s *FirestoreSource) Execs(ctx context.Context, since time.Time) ([]schema.ScratchExec, error) {
+	return scanQuery[schema.ScratchExec](ctx, sinceQuery(s.client.Collection("scratch-execs").Query, "updated", since))
 }
 
-func (s *FirestoreSource) RepoMetrics(ctx context.Context) ([]schema.RepoMetrics, error) {
-	return scanQuery[schema.RepoMetrics](ctx, s.client.Collection("repo_metrics").Query)
+func (s *FirestoreSource) RepoMetrics(ctx context.Context, since time.Time) ([]schema.RepoMetrics, error) {
+	return scanQuery[schema.RepoMetrics](ctx, sinceQuery(s.client.Collection("repo_metrics").Query, "updated", since))
 }


### PR DESCRIPTION
Delta writes one docdb segment of every document written since the
newest segment already exported, recovering its resume point from the
segment name so the delta writer itself is stateless. This allows a
crashed or skipped run to be repaired by the following run. All
collection groups gain the requisite single-field indices for their
updated range scans.

Segments live under a schema-versioned prefix (deltas-v<N>/), so a
reader only ever replays segments matching its base's era.