### PR TITLE
Implement rundex for sqlite snapshot database

### DIFF
--- a/internal/rundex/sqlite.go
+++ b/internal/rundex/sqlite.go
@@ -1,0 +1,300 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package rundex
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/google/oss-rebuild/pkg/feed"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/ncruces/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+// Querier serializes access to a snapshot database connection. An
+// implementation may swap the underlying database between calls (the
+// snapshot cache does, on refresh).
+type Querier interface {
+	Query(func(*sqlite3.Conn) error) error
+}
+
+// SingleConn is a Querier over one fixed connection.
+type SingleConn struct {
+	mu sync.Mutex
+	db *sqlite3.Conn
+}
+
+func NewSingleConn(db *sqlite3.Conn) *SingleConn { return &SingleConn{db: db} }
+
+func (c *SingleConn) Query(f func(*sqlite3.Conn) error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return f(c.db)
+}
+
+// SQLite serves rundex reads from a snapshot database.
+type SQLite struct {
+	q Querier
+}
+
+var _ Reader = &SQLite{}
+var _ SessionReader = &SQLite{}
+
+// NewSQLite creates a Reader/SessionReader over a snapshot database.
+func NewSQLite(q Querier) *SQLite { return &SQLite{q: q} }
+
+// cond accumulates a WHERE clause and its bind arguments.
+type cond struct {
+	exprs []string
+	args  []string
+}
+
+func (c *cond) add(expr string, arg string) {
+	c.exprs = append(c.exprs, expr)
+	c.args = append(c.args, arg)
+}
+
+func (c *cond) in(col string, vals []string) {
+	c.exprs = append(c.exprs, col+" IN (?"+strings.Repeat(", ?", len(vals)-1)+")")
+	c.args = append(c.args, vals...)
+}
+
+func (c *cond) clause() string {
+	if len(c.exprs) == 0 {
+		return ""
+	}
+	return " WHERE " + strings.Join(c.exprs, " AND ")
+}
+
+// queryRaw runs a SELECT whose single result column is a raw source document
+// and decodes each row into T.
+func queryRaw[T any](q Querier, sql string, args []string) ([]T, error) {
+	var out []T
+	err := q.Query(func(db *sqlite3.Conn) error {
+		stmt, _, err := db.Prepare(sql)
+		if err != nil {
+			return errors.Wrap(err, "preparing query")
+		}
+		defer stmt.Close()
+		for i, a := range args {
+			if err := stmt.BindText(i+1, a); err != nil {
+				return errors.Wrap(err, "binding argument")
+			}
+		}
+		for stmt.Step() {
+			var v T
+			if err := json.Unmarshal([]byte(stmt.ColumnText(0)), &v); err != nil {
+				return errors.Wrap(err, "decoding raw document")
+			}
+			out = append(out, v)
+		}
+		return errors.Wrap(stmt.Err(), "executing query")
+	})
+	return out, err
+}
+
+func rebuildChan(attempts []schema.RebuildAttempt) <-chan Rebuild {
+	ch := make(chan Rebuild, len(attempts))
+	for _, a := range attempts {
+		ch <- Rebuild{RebuildAttempt: a}
+	}
+	close(ch)
+	return ch
+}
+
+func targetCond(c *cond, t rebuild.Target) {
+	if t.Ecosystem != "" {
+		c.add("ecosystem = ?", string(t.Ecosystem))
+	}
+	if t.Package != "" {
+		c.add("package = ?", t.Package)
+	}
+	if t.Version != "" {
+		c.add("version = ?", t.Version)
+	}
+	if t.Artifact != "" {
+		c.add("artifact = ?", t.Artifact)
+	}
+}
+
+// FetchRebuilds fetches Rebuild objects out of the snapshot database.
+func (s *SQLite) FetchRebuilds(ctx context.Context, req *FetchRebuildRequest) ([]Rebuild, error) {
+	if len(req.Executors) != 0 && len(req.Runs) != 0 {
+		return nil, errors.New("only provide one of executors and runs")
+	}
+	if req.Bench != nil && req.Bench.Count == 0 {
+		return nil, errors.New("empty bench provided")
+	}
+	var c cond
+	if req.Target != nil {
+		targetCond(&c, *req.Target)
+	}
+	if len(req.Executors) != 0 {
+		c.in("executor_version", req.Executors)
+	}
+	if len(req.Runs) != 0 {
+		c.in("run_id", req.Runs)
+	}
+	sql := "SELECT raw FROM attempts" + c.clause() + " ORDER BY created DESC"
+	// The bench/tracked filters run client-side in filterRebuilds, so a
+	// pre-filter LIMIT would drop rows they keep. The pending, prefix, and
+	// pattern filters are also client-side, but LIMIT applies over them
+	// anyway to match the Firestore reader, which limits server-side before
+	// those same filters.
+	if req.Limit > 0 && req.Bench == nil && req.Tracked == nil {
+		sql += " LIMIT " + strconv.Itoa(req.Limit)
+	}
+	attempts, err := queryRaw[schema.RebuildAttempt](s.q, sql, c.args)
+	if err != nil {
+		return nil, err
+	}
+	return filterRebuilds(rebuildChan(attempts), req), nil
+}
+
+func (s *SQLite) recent(c cond) ([]Rebuild, error) {
+	sql := "SELECT raw FROM attempts" + c.clause() + " ORDER BY created DESC LIMIT 100"
+	attempts, err := queryRaw[schema.RebuildAttempt](s.q, sql, c.args)
+	if err != nil {
+		return nil, err
+	}
+	// Match the Firestore reader: filter pending attempts and clean Message.
+	return filterRebuilds(rebuildChan(attempts), &FetchRebuildRequest{}), nil
+}
+
+// RecentRebuilds fetches the 100 most recent rebuild results.
+func (s *SQLite) RecentRebuilds(ctx context.Context) ([]Rebuild, error) {
+	return s.recent(cond{})
+}
+
+// RecentEcosystemRebuilds fetches the 100 most recent rebuild results for a specific ecosystem.
+func (s *SQLite) RecentEcosystemRebuilds(ctx context.Context, eco rebuild.Ecosystem) ([]Rebuild, error) {
+	var c cond
+	c.add("ecosystem = ?", string(eco))
+	return s.recent(c)
+}
+
+// RecentPackageRebuilds fetches the 100 most recent rebuild results for a specific package.
+func (s *SQLite) RecentPackageRebuilds(ctx context.Context, eco rebuild.Ecosystem, pkg string) ([]Rebuild, error) {
+	var c cond
+	c.add("ecosystem = ?", string(eco))
+	c.add("package = ?", pkg)
+	return s.recent(c)
+}
+
+// FetchAttempt fetches a specific Rebuild object.
+func (s *SQLite) FetchAttempt(ctx context.Context, target rebuild.Target, runID string) (Rebuild, error) {
+	var c cond
+	targetCond(&c, target)
+	c.add("run_id = ?", runID)
+	// A partial target can match several attempts in one run. Take the newest.
+	attempts, err := queryRaw[schema.RebuildAttempt](s.q, "SELECT raw FROM attempts"+c.clause()+" ORDER BY created DESC LIMIT 1", c.args)
+	if err != nil {
+		return Rebuild{}, err
+	}
+	if len(attempts) == 0 {
+		return Rebuild{}, errors.Errorf("attempt not found: %s %s", target.Package, runID)
+	}
+	return Rebuild{RebuildAttempt: attempts[0]}, nil
+}
+
+// LatestTrackedPackages fetches the most recent completed rebuild result for
+// each tracked package.
+func (s *SQLite) LatestTrackedPackages(ctx context.Context, tracked feed.TrackedPackageIndex) ([]Rebuild, error) {
+	sql := `SELECT raw FROM (
+		SELECT raw, ecosystem, package,
+			ROW_NUMBER() OVER (PARTITION BY ecosystem, package ORDER BY created DESC) rn
+		FROM attempts WHERE status != ?
+	) WHERE rn = 1`
+	attempts, err := queryRaw[schema.RebuildAttempt](s.q, sql, []string{string(schema.RebuildStatusRunning)})
+	if err != nil {
+		return nil, err
+	}
+	var res []Rebuild
+	for _, a := range attempts {
+		if pkgs, ok := tracked[rebuild.Ecosystem(a.Ecosystem)]; ok && pkgs[a.Package] {
+			res = append(res, Rebuild{RebuildAttempt: a})
+		}
+	}
+	return res, nil
+}
+
+// FetchRuns fetches Runs out of the snapshot database.
+func (s *SQLite) FetchRuns(ctx context.Context, opts FetchRunsOpts) ([]Run, error) {
+	var c cond
+	if len(opts.IDs) != 0 {
+		c.in("run_id", opts.IDs)
+	}
+	if opts.BenchmarkHash != "" {
+		c.add("benchmark_hash = ?", opts.BenchmarkHash)
+	}
+	if opts.BenchmarkName != "" {
+		c.add("benchmark_name = ?", opts.BenchmarkName)
+	}
+	runs, err := queryRaw[schema.Run](s.q, "SELECT raw FROM runs"+c.clause()+" ORDER BY run_id", c.args)
+	if err != nil {
+		return nil, err
+	}
+	var res []Run
+	for _, r := range runs {
+		res = append(res, FromRun(r))
+	}
+	return res, nil
+}
+
+func (s *SQLite) FetchSessions(ctx context.Context, req *FetchSessionsReq) ([]schema.AgentSession, error) {
+	var c cond
+	if len(req.IDs) != 0 {
+		c.in("session_id", req.IDs)
+	}
+	if req.StopReason != "" {
+		c.add("stop_reason = ?", req.StopReason)
+	}
+	if !req.Since.IsZero() {
+		c.add("created >= ?", sqlitex.TimeColumn(req.Since))
+	}
+	if !req.Until.IsZero() {
+		c.add("created <= ?", sqlitex.TimeColumn(req.Until))
+	}
+	if req.PartialTarget != nil {
+		targetCond(&c, *req.PartialTarget)
+	}
+	sql := "SELECT raw FROM agent_sessions" + c.clause()
+	if req.Limit > 0 {
+		sql += " ORDER BY created DESC LIMIT " + strconv.Itoa(req.Limit)
+	}
+	sessions, err := queryRaw[schema.AgentSession](s.q, sql, c.args)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(sessions, func(a, b schema.AgentSession) int {
+		return a.Created.Compare(b.Created)
+	})
+	return sessions, nil
+}
+
+func (s *SQLite) FetchIterations(ctx context.Context, req *FetchIterationsReq) ([]schema.AgentIteration, error) {
+	if req.SessionID == "" {
+		return nil, errors.New("empty session ID provided")
+	}
+	var c cond
+	c.add("session_id = ?", req.SessionID)
+	if len(req.IterationIDs) != 0 {
+		c.in("iteration_id", req.IterationIDs)
+	}
+	iterations, err := queryRaw[schema.AgentIteration](s.q, "SELECT raw FROM agent_iterations"+c.clause(), c.args)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(iterations, func(a, b schema.AgentIteration) int {
+		return a.Created.Compare(b.Created)
+	})
+	return iterations, nil
+}

--- a/internal/rundex/sqlite_test.go
+++ b/internal/rundex/sqlite_test.go
@@ -1,0 +1,289 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package rundex
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/snapshot"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/google/oss-rebuild/pkg/feed"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/google/oss-rebuild/tools/benchmark"
+	"github.com/ncruces/go-sqlite3"
+)
+
+// snapshotSource adapts fixtures to snapshot.Source so tests exercise the same
+// build pipeline the rollup uses.
+type snapshotSource struct {
+	attempts   []schema.RebuildAttempt
+	runs       []schema.Run
+	sessions   []schema.AgentSession
+	iterations []schema.AgentIteration
+}
+
+func (s *snapshotSource) Attempts(context.Context, time.Time) ([]schema.RebuildAttempt, error) {
+	return s.attempts, nil
+}
+func (s *snapshotSource) Runs(context.Context, time.Time) ([]schema.Run, error) { return s.runs, nil }
+func (s *snapshotSource) Sessions(context.Context, time.Time) ([]schema.AgentSession, error) {
+	return s.sessions, nil
+}
+func (s *snapshotSource) Iterations(context.Context, time.Time) ([]schema.AgentIteration, error) {
+	return s.iterations, nil
+}
+func (s *snapshotSource) Scratches(context.Context, time.Time) ([]schema.Scratch, error) {
+	return nil, nil
+}
+func (s *snapshotSource) Execs(context.Context, time.Time) ([]schema.ScratchExec, error) {
+	return nil, nil
+}
+func (s *snapshotSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
+	return nil, nil
+}
+
+func ts(min int) time.Time {
+	return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC).Add(time.Duration(min) * time.Minute)
+}
+
+func attemptFixture(pkg, version, runID string, status schema.RebuildStatus, created time.Time) schema.RebuildAttempt {
+	return schema.RebuildAttempt{
+		Ecosystem:       "pypi",
+		Package:         pkg,
+		Version:         version,
+		Artifact:        version + ".whl",
+		RunID:           runID,
+		ExecutorVersion: "exec-" + runID,
+		Status:          status,
+		Success:         status == schema.RebuildStatusSuccess,
+		Created:         created,
+		Updated:         created,
+	}
+}
+
+func newTestReader(t *testing.T, src snapshot.Source) *SQLite {
+	t.Helper()
+	ctx := context.Background()
+	dest := memfs.New()
+	if _, err := snapshot.Rollup(ctx, src, dest, snapshot.Options{Now: ts(60)}); err != nil {
+		t.Fatalf("Rollup: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "snapshot.db")
+	if err := sqlitex.Fetch(dest, snapshot.Object, path); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewSQLite(NewSingleConn(db))
+}
+
+func testSource() *snapshotSource {
+	return &snapshotSource{
+		attempts: []schema.RebuildAttempt{
+			attemptFixture("pkgA", "1.0", "r1", schema.RebuildStatusSuccess, ts(0)),
+			attemptFixture("pkgA", "1.0", "r2", schema.RebuildStatusError, ts(10)),
+			attemptFixture("pkgA", "1.1", "r3", schema.RebuildStatusRunning, ts(20)),
+			attemptFixture("pkgB", "2.0", "r4", schema.RebuildStatusSuccess, ts(5)),
+		},
+		runs: []schema.Run{
+			{ID: "r1", BenchmarkName: "bench", BenchmarkHash: "h1", Created: ts(0)},
+			{ID: "r4", BenchmarkName: "other", BenchmarkHash: "h2", Created: ts(5)},
+		},
+		sessions: []schema.AgentSession{
+			{ID: "s1", Target: rebuild.Target{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Artifact: "1.0.whl"}, Status: schema.AgentSessionStatusCompleted, Created: ts(1), Updated: ts(2)},
+			{ID: "s2", Target: rebuild.Target{Ecosystem: "pypi", Package: "pkgB", Version: "2.0", Artifact: "2.0.whl"}, Status: schema.AgentSessionStatusRunning, Created: ts(6), Updated: ts(7)},
+		},
+		iterations: []schema.AgentIteration{
+			{ID: "it2", SessionID: "s1", Number: 2, Created: ts(3), Updated: ts(3)},
+			{ID: "it1", SessionID: "s1", Number: 1, Created: ts(2), Updated: ts(2)},
+			{ID: "it3", SessionID: "s2", Number: 1, Created: ts(7), Updated: ts(7)},
+		},
+	}
+}
+
+func runIDs(rebuilds []Rebuild) []string {
+	var ids []string
+	for _, r := range rebuilds {
+		ids = append(ids, r.RunID)
+	}
+	return ids
+}
+
+func TestSQLiteRecentPackageRebuilds(t *testing.T) {
+	r := newTestReader(t, testSource())
+	got, err := r.RecentPackageRebuilds(context.Background(), "pypi", "pkgA")
+	if err != nil {
+		t.Fatalf("RecentPackageRebuilds: %v", err)
+	}
+	// Pending attempts filter out, and results order newest first.
+	if diff := cmp.Diff([]string{"r2", "r1"}, runIDs(got)); diff != "" {
+		t.Errorf("run IDs diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestSQLiteFetchRebuilds(t *testing.T) {
+	r := newTestReader(t, testSource())
+	for _, tc := range []struct {
+		name string
+		req  FetchRebuildRequest
+		want []string // run IDs, newest first
+	}{
+		{
+			name: "TargetIncludePending",
+			req: FetchRebuildRequest{
+				Target: &rebuild.Target{Ecosystem: "pypi", Package: "pkgA"},
+				Opts:   FetchRebuildOpts{IncludePending: true},
+				Limit:  10,
+			},
+			want: []string{"r3", "r2", "r1"},
+		},
+		{
+			name: "ByRun",
+			req:  FetchRebuildRequest{Runs: []string{"r4"}},
+			want: []string{"r4"},
+		},
+		{
+			name: "ByExecutor",
+			req:  FetchRebuildRequest{Executors: []string{"exec-r1"}},
+			want: []string{"r1"},
+		},
+		{
+			// The SQL LIMIT applies before the client-side pending filter,
+			// matching the Firestore reader: the newest attempt (r3) is
+			// pending, so a limit of one returns nothing.
+			name: "LimitAppliesBeforePendingFilter",
+			req:  FetchRebuildRequest{Limit: 1},
+			want: nil,
+		},
+		{
+			name: "LatestPerPackage",
+			req:  FetchRebuildRequest{LatestPerPackage: true},
+			want: []string{"r2", "r4"},
+		},
+		{
+			// A bench request skips the SQL LIMIT, so pkgA's completed
+			// attempt is found even though the newest attempt overall is
+			// pending.
+			name: "BenchSkipsSQLLimit",
+			req: FetchRebuildRequest{
+				Bench: &benchmark.PackageSet{
+					Metadata: benchmark.Metadata{Count: 1},
+					Packages: []benchmark.Package{{Ecosystem: "pypi", Name: "pkgA"}},
+				},
+				Limit: 1,
+			},
+			want: []string{"r2"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := r.FetchRebuilds(context.Background(), &tc.req)
+			if err != nil {
+				t.Fatalf("FetchRebuilds: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, runIDs(got)); diff != "" {
+				t.Errorf("run IDs diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSQLiteFetchAttempt(t *testing.T) {
+	r := newTestReader(t, testSource())
+	target := rebuild.Target{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Artifact: "1.0.whl"}
+	got, err := r.FetchAttempt(context.Background(), target, "r2")
+	if err != nil {
+		t.Fatalf("FetchAttempt: %v", err)
+	}
+	if got.RunID != "r2" || got.Status != schema.RebuildStatusError {
+		t.Errorf("got %+v", got)
+	}
+	if _, err := r.FetchAttempt(context.Background(), target, "missing"); err == nil {
+		t.Error("expected error for missing attempt")
+	}
+}
+
+func TestSQLiteLatestTrackedPackages(t *testing.T) {
+	r := newTestReader(t, testSource())
+	tracked := feed.TrackedPackageIndex{"pypi": {"pkgA": true}}
+	got, err := r.LatestTrackedPackages(context.Background(), tracked)
+	if err != nil {
+		t.Fatalf("LatestTrackedPackages: %v", err)
+	}
+	// pkgA's newest attempt (r3) is RUNNING and skipped in favor of r2, and
+	// pkgB is untracked.
+	if diff := cmp.Diff([]string{"r2"}, runIDs(got)); diff != "" {
+		t.Errorf("run IDs diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestSQLiteFetchRuns(t *testing.T) {
+	r := newTestReader(t, testSource())
+	got, err := r.FetchRuns(context.Background(), FetchRunsOpts{BenchmarkHash: "h1"})
+	if err != nil {
+		t.Fatalf("FetchRuns: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "r1" {
+		t.Errorf("got %+v, want [r1]", got)
+	}
+	byName, err := r.FetchRuns(context.Background(), FetchRunsOpts{IDs: []string{"r1", "r4"}, BenchmarkName: "other"})
+	if err != nil {
+		t.Fatalf("FetchRuns by name: %v", err)
+	}
+	if len(byName) != 1 || byName[0].ID != "r4" {
+		t.Errorf("by name got %+v, want [r4]", byName)
+	}
+}
+
+func TestSQLiteFetchSessions(t *testing.T) {
+	r := newTestReader(t, testSource())
+	got, err := r.FetchSessions(context.Background(), &FetchSessionsReq{
+		PartialTarget: &rebuild.Target{Ecosystem: "pypi", Package: "pkgA"},
+	})
+	if err != nil {
+		t.Fatalf("FetchSessions: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "s1" {
+		t.Errorf("got %+v, want [s1]", got)
+	}
+	all, err := r.FetchSessions(context.Background(), &FetchSessionsReq{Limit: 10})
+	if err != nil {
+		t.Fatalf("FetchSessions all: %v", err)
+	}
+	// Results sort ascending by creation time.
+	if len(all) != 2 || all[0].ID != "s1" || all[1].ID != "s2" {
+		t.Errorf("got %+v, want [s1 s2]", all)
+	}
+	// The range bounds are inclusive: s1 (created ts(1)) falls before the
+	// range and s2 (created ts(6)) sits exactly on Until.
+	ranged, err := r.FetchSessions(context.Background(), &FetchSessionsReq{Since: ts(2), Until: ts(6)})
+	if err != nil {
+		t.Fatalf("FetchSessions ranged: %v", err)
+	}
+	if len(ranged) != 1 || ranged[0].ID != "s2" {
+		t.Errorf("ranged got %+v, want [s2]", ranged)
+	}
+}
+
+func TestSQLiteFetchIterations(t *testing.T) {
+	r := newTestReader(t, testSource())
+	got, err := r.FetchIterations(context.Background(), &FetchIterationsReq{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("FetchIterations: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "it1" || got[1].ID != "it2" {
+		t.Errorf("got %+v, want [it1 it2] in created order", got)
+	}
+	if _, err := r.FetchIterations(context.Background(), &FetchIterationsReq{}); err == nil {
+		t.Error("expected error for empty session ID")
+	}
+}


### PR DESCRIPTION
Implement Reader and SessionReader over the snapshot. Notably, we reuse
the shared client-side pipeline (pending filter, verdict cleaning,
latest-per-package, limits) so semantics match the Firestore reader.
Access is serialized with Querier so the cache can swap the database
between calls.