### PR TITLE
Serve the dashboard from a cached snapshot database

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -17,8 +17,10 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/google/oss-rebuild/internal/api/dashboard"
+	"github.com/google/oss-rebuild/internal/billyx"
 	"github.com/google/oss-rebuild/internal/httpegress"
 	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/pkg/act/api"
 	"github.com/google/oss-rebuild/pkg/feed"
 	"github.com/google/oss-rebuild/pkg/rebuild/meta"
@@ -33,6 +35,7 @@ var (
 	port            = flag.Int("port", 8080, "port on which to serve")
 	successRegex    = flag.String("success-regex", "", "Regex to determine if a rebuild is successful based on its message")
 	logsBucket      = flag.String("logs-bucket", "", "GCS bucket containing build logs")
+	rundexURI       = flag.String("rundex", "", "Snapshot database URI to serve rundex reads from (supported schemes: gs, file). If empty, reads Firestore directly")
 )
 
 var egressCfg httpegress.Config
@@ -42,37 +45,57 @@ var (
 	tracked    feed.TrackedPackageIndex
 	benchName  string
 	registry   rebuild.RegistryMux // built once at startup
+	snapReader *rundex.SQLite      // process-level snapshot reader when -rundex is set
 )
 
 func DashboardInit(ctx context.Context) (*dashboard.Deps, error) {
-	rundexClient, err := rundex.NewFirestore(ctx, *project)
-	if err != nil {
-		return nil, err
-	}
-	var storageClient *storage.Client
-	if *logsBucket != "" {
-		storageClient, err = storage.NewClient(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &dashboard.Deps{
-		Rundex:        rundexClient,
-		Sessions:      rundexClient,
-		GCSClient:     storageClient,
+	deps := &dashboard.Deps{
 		LogsBucket:    *logsBucket,
 		Tracked:       tracked,
 		BenchmarkName: benchName,
 		SuccessRegex:  successPat,
 		Registry:      registry,
-	}, nil
+	}
+	if snapReader != nil {
+		deps.Rundex = snapReader
+		deps.Sessions = snapReader
+	} else {
+		rundexClient, err := rundex.NewFirestore(ctx, *project)
+		if err != nil {
+			return nil, err
+		}
+		deps.Rundex = rundexClient
+		deps.Sessions = rundexClient
+	}
+	if *logsBucket != "" {
+		storageClient, err := storage.NewClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		deps.GCSClient = storageClient
+	}
+	return deps, nil
 }
 
 func main() {
 	egressCfg.RegisterFlags(flag.CommandLine)
 	flag.Parse()
-	if *project == "" {
-		log.Fatal("Must provide -project")
+	if *project == "" && *rundexURI == "" {
+		log.Fatal("Must provide -project (or -rundex to serve from a snapshot)")
+	}
+	if *rundexURI != "" {
+		ctx := context.Background()
+		dest, err := billyx.NewResolver().DirFS(ctx, *rundexURI)
+		if err != nil {
+			log.Fatalf("Failed to resolve snapshot %s: %v", *rundexURI, err)
+		}
+		cache, err := snapshot.OpenCache(ctx, dest, 30*time.Second)
+		if err != nil {
+			log.Fatalf("Failed to open snapshot %s: %v", *rundexURI, err)
+		}
+		defer cache.Close()
+		snapReader = rundex.NewSQLite(cache)
+		log.Printf("Serving rundex reads from %s (fresh through %s)", *rundexURI, cache.Freshness().Format(time.RFC3339))
 	}
 	if *logsBucket == "" {
 		log.Printf("Warning: -logs-bucket not provided, log viewing will be unavailable")

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -29,6 +29,21 @@ var (
 	DeltaPrefix = fmt.Sprintf("deltas-v%d", SchemaVersion)
 )
 
+// OpenCache serves a cached local copy of the snapshot database published
+// under dest, refreshed in the background every interval until closed. It
+// binds the docdb cache to this schema era: the versioned object and delta
+// names, the table registry, the highest version this binary understands,
+// and the meta row that carries the base watermark.
+func OpenCache(ctx context.Context, dest billy.Filesystem, interval time.Duration) (*docdb.Cache, error) {
+	watermark := func(db *sqlite3.Conn) (time.Time, error) {
+		m, err := ReadMeta(db)
+		return m.Watermark, err
+	}
+	return docdb.OpenCache(ctx, docdb.Upstream{
+		FS: dest, Object: Object, Deltas: DeltaPrefix, Defs: Tables(), Schema: SchemaVersion, Watermark: watermark,
+	}, interval)
+}
+
 // Options configures a snapshot run.
 type Options struct {
 	Project     string    // recorded in the database meta as the source project


### PR DESCRIPTION
A -rundex flag points the dashboard at a snapshot destination. The docdb
cache keeps a local copy of rebuild db, kept up to date from deltas,
which is used to serve all of the dashboard queries. The Firestore path
remains the default.