### PR TITLE
Wire the snapshot pipeline into the deployment

### DIFF
--- a/deployments/iam.tf
+++ b/deployments/iam.tf
@@ -65,6 +65,10 @@ resource "google_service_account" "scratch-worker" {
   account_id  = "scratch-worker"
   description = "Bootstrap identity for scratch worker VMs, used by the startup script to fetch the worker binary from the bootstrap-tools bucket on private deployments."
 }
+resource "google_service_account" "cron" {
+  account_id  = "cron-invoker" # NOTE: ID must be >=6 chars
+  description = "Identity for Cloud Scheduler jobs triggering maintenance endpoints. Holds run.invoker only."
+}
 data "google_storage_project_service_account" "attestation-pubsub-publisher" {
 }
 
@@ -169,6 +173,12 @@ resource "google_storage_bucket_iam_member" "orchestrator-manages-attestations" 
   role   = "roles/storage.objectAdmin"
   member = google_service_account.orchestrator.member
 }
+# NOTE: objectAdmin since replacing the published snapshot requires delete.
+resource "google_storage_bucket_iam_member" "orchestrator-manages-analytics" {
+  bucket = google_storage_bucket.analytics.name
+  role   = "roles/storage.objectAdmin"
+  member = google_service_account.orchestrator.member
+}
 resource "google_project_iam_member" "orchestrator-uses-datastore" {
   project = var.project
   role    = "roles/datastore.user"
@@ -211,6 +221,13 @@ resource "google_project_iam_member" "orchestrators-run-gcb-builds" {
     var.enable_system_analyzer ? [google_service_account.system-analyzer[0].member] : []
   ))
   member = each.key
+}
+resource "google_cloud_run_v2_service_iam_member" "cron-calls-orchestrator" {
+  location = google_cloud_run_v2_service.orchestrator.location
+  project  = google_cloud_run_v2_service.orchestrator.project
+  name     = google_cloud_run_v2_service.orchestrator.name
+  role     = "roles/run.invoker"
+  member   = google_service_account.cron.member
 }
 resource "google_cloud_run_v2_service_iam_member" "orchestrator-calls-inference" {
   location = google_cloud_run_v2_service.inference.location
@@ -452,6 +469,14 @@ resource "google_cloud_run_v2_service_iam_member" "orchestrator-calls-agent-api"
   name     = google_cloud_run_v2_service.agent-api.name
   role     = "roles/run.invoker"
   member   = google_service_account.orchestrator.member
+}
+resource "google_cloud_run_v2_service_iam_member" "cron-calls-agent-api" {
+  count    = var.enable_scratch ? 1 : 0
+  location = google_cloud_run_v2_service.agent-api.location
+  project  = google_cloud_run_v2_service.agent-api.project
+  name     = google_cloud_run_v2_service.agent-api.name
+  role     = "roles/run.invoker"
+  member   = google_service_account.cron.member
 }
 resource "google_storage_bucket_iam_member" "builder-agent-writes-metadata" {
   bucket = google_storage_bucket.agent-metadata.name

--- a/deployments/platform.tf
+++ b/deployments/platform.tf
@@ -161,6 +161,17 @@ resource "google_storage_bucket" "analytics" {
       type = "Delete"
     }
   }
+  # Delta segments are superseded once a newer daily rollup incorporates them.
+  lifecycle_rule {
+    condition {
+      age            = 14
+      matches_prefix = ["deltas-"] # matches deltas-v<N>/ format
+    }
+    action {
+      type = "Delete"
+    }
+  }
+  # NOTE: Previous schema versions of rebuild-v<N>.db must be cleaned up manually.
 }
 
 ## Firestore
@@ -529,8 +540,47 @@ resource "google_compute_firewall" "scratch-worker-ingress" {
 }
 
 resource "google_project_service" "cloudscheduler" {
-  count   = var.enable_scratch ? 1 : 0
   service = "cloudscheduler.googleapis.com"
+}
+
+# Writes one delta segment of recent Firestore writes to the analytics
+# destination. The snapshot cache picks segments up on its poll loop.
+resource "google_cloud_scheduler_job" "snapshot-delta" {
+  name     = "${var.host}-snapshot-delta"
+  schedule = "*/5 * * * *" # every 5 minutes
+  region   = "us-central1"
+  http_target {
+    uri         = "${google_cloud_run_v2_service.orchestrator.uri}/snapshot/delta"
+    http_method = "POST"
+    headers = {
+      "Content-Type" = "application/x-www-form-urlencoded"
+    }
+    oidc_token {
+      service_account_email = google_service_account.cron.email
+      audience              = google_cloud_run_v2_service.orchestrator.uri
+    }
+  }
+  depends_on = [google_project_service.cloudscheduler]
+}
+
+# Rebuilds the snapshot database from a full Firestore scan, correcting any
+# drift the delta stream cannot see (out-of-band edits, migrations).
+resource "google_cloud_scheduler_job" "snapshot-rollup" {
+  name     = "${var.host}-snapshot-rollup"
+  schedule = "0 9 * * *" # daily at 09:00 UTC
+  region   = "us-central1"
+  http_target {
+    uri         = "${google_cloud_run_v2_service.orchestrator.uri}/snapshot/rollup"
+    http_method = "POST"
+    headers = {
+      "Content-Type" = "application/x-www-form-urlencoded"
+    }
+    oidc_token {
+      service_account_email = google_service_account.cron.email
+      audience              = google_cloud_run_v2_service.orchestrator.uri
+    }
+  }
+  depends_on = [google_project_service.cloudscheduler]
 }
 
 resource "google_cloud_scheduler_job" "scratch-reap" {
@@ -545,7 +595,7 @@ resource "google_cloud_scheduler_job" "scratch-reap" {
       "Content-Type" = "application/x-www-form-urlencoded"
     }
     oidc_token {
-      service_account_email = google_service_account.orchestrator.email
+      service_account_email = google_service_account.cron.email
       audience              = google_cloud_run_v2_service.agent-api.uri
     }
   }

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -247,6 +247,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--agent-metadata-bucket=${google_storage_bucket.agent-metadata.name}",
         "--agent-logs-bucket=${google_storage_bucket.agent-logs.name}",
         "--rebuild-job-name=${google_cloud_run_v2_job.rebuild-job.name}",
+        "--analytics-uri=gs://${google_storage_bucket.analytics.name}",
         ], var.enable_private_build_pool ? [
         "--gcb-private-pool-name=${google_cloudbuild_worker_pool.private-pool[0].id}",
         "--gcb-private-pool-region=us-central1",

--- a/internal/api/snapshotservice/rollup.go
+++ b/internal/api/snapshotservice/rollup.go
@@ -1,10 +1,10 @@
 // Copyright 2025 Google LLC
 // SPDX-License-Identifier: Apache-2.0
 
-// Package snapshotservice exposes the internal/snapshot rollup engine.
-// Each invocation performs one idempotent snapshot that replaces the published
-// object wholesale, so the endpoint is safe to invoke manually, repeatedly,
-// and from a scheduler.
+// Package snapshotservice exposes the internal/snapshot pipelines.
+// /snapshot/rollup rebuilds the published database while recurring updates are
+// handled by /snapshot/delta. These are idempotent and, thus, safe to invoke
+// via a naive scheduler.
 package snapshotservice
 
 import (


### PR DESCRIPTION
Pass --analytics-uri to the api service and schedule the 5m delta and
daily rollup against it. The scheduler API enablement is now
unconditional. Delta segments age out of the analytics bucket after 14d,
past what any reader replays.

This also creates a dedicated role for cron triggers which makes the
auth flow cleaner.