### PR TITLE
Extract approximate version ordering into versionx

### DIFF
--- a/internal/versionx/versionx.go
+++ b/internal/versionx/versionx.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package versionx orders version strings across ecosystems, approximately.
+//
+// Strict semver 2.0.0 [semver] is compared per the spec. That covers npm and
+// crates.io, whose registries require semver versions. Every other form is
+// compared segment-wise: runs of digits and runs of letters compare left to
+// right, numerically where both are digits, with digit runs ordering after
+// letter runs and a version ordering after any proper prefix of itself.
+// Checked against the ordering rules and worked examples of the remaining
+// ecosystems' schemes, the segment-wise fallback agrees on:
+//
+//   - Final releases under every scheme: dotted numeric forms order
+//     identically under PEP 440 [pep440], Gem::Version [gem], Maven [maven],
+//     and Debian policy 5.6.12 [deb].
+//   - Ordering within a pre-release stage, since numeric runs compare as
+//     numbers: 1.0a2 < 1.0a12 (PEP 440), 1-foo2 < 1-foo10 (Maven).
+//   - Suffixes that order *after* the release: PEP 440 .postN, Debian +deb
+//     style additions, and Maven sp all order after the bare version.
+//   - Digit runs after letter runs: Maven specifies 1.7 > 1.K, and the same
+//     rule yields PEP 440's 1.0.post1 < 1.0.15.
+//   - Maven's pre-release qualifiers among themselves: the specified order
+//     alpha < beta < milestone < rc < snapshot is alphabetical, so it holds
+//     with no qualifier table.
+//
+// It diverges on each scheme's pre-release marker. The fallback orders every
+// suffixed form after its base, while each scheme defines a marker that
+// orders before it:
+//
+//   - PEP 440 pre-releases: the spec orders suffixes ".devN, aN, bN, rcN,
+//     <no suffix>, .postN", so 1.0rc1 < 1.0 there but 1.0rc1 > 1.0 here.
+//   - Debian "~": it "sorts before anything, even the end of a part", so
+//     1.0~rc1 < 1.0 there but after here.
+//   - Maven qualifiers: alpha through snapshot precede the bare version.
+//   - Gem::Version prereleases: a part containing letters marks the version
+//     as a prerelease that sorts below its release, so 1.0.b1 < 1.0 there.
+//   - semver "-" pre-releases, whenever a non-semver counterpart forces the
+//     fallback path (hence the intransitivity note on ApproxCompare).
+//   - Punctuation-encoded features: epoch markers (PEP 440 "N!", Debian
+//     "N:") and Debian's upstream/revision "-" boundary are discarded with
+//     all other non-alphanumerics and cannot affect the ordering.
+//
+// Spec references:
+//
+//	[semver] https://semver.org/spec/v2.0.0.html#spec-item-11
+//	[pep440] https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering
+//	[gem]    https://docs.ruby-lang.org/en/3.3/Gem/Version.html
+//	[maven]  https://maven.apache.org/pom.html#version-order-specification
+//	[deb]    https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+package versionx
+
+import (
+	"cmp"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/oss-rebuild/internal/semver"
+)
+
+// ApproxCompare orders two version strings. Strict semver versions are
+// compared per the spec. Otherwise the versions are compared segment-wise,
+// numerically where possible. The ordering is approximate for exotic version
+// schemes and fit only for uses where an approximate order beats none (e.g.
+// picking the nearest definition, or a package's probable newest version).
+// NOTE: The ordering is intransitive when candidates mix semver and
+// non-semver forms: semver prerelease ordering (1.0.0-rc1 < 1.0.0) can
+// contradict compareLoose's segment-wise ordering of the same strings
+// (1.0.0-rc1 > 1.0.0.post1 > 1.0.0), so sorts over mixed candidate sets may
+// pick a non-nearest element.
+func ApproxCompare(a, b string) int {
+	av, aerr := semver.New(a)
+	bv, berr := semver.New(b)
+	if aerr == nil && berr == nil {
+		return av.Compare(bv)
+	}
+	return compareLoose(a, b)
+}
+
+var versionSegmentRE = regexp.MustCompile(`\d+|[a-zA-Z]+`)
+
+func compareLoose(a, b string) int {
+	as := versionSegmentRE.FindAllString(a, -1)
+	bs := versionSegmentRE.FindAllString(b, -1)
+	for i := range min(len(as), len(bs)) {
+		an, aerr := strconv.Atoi(as[i])
+		bn, berr := strconv.Atoi(bs[i])
+		switch {
+		case aerr == nil && berr == nil:
+			if an != bn {
+				return cmp.Compare(an, bn)
+			}
+		case aerr == nil:
+			// Numeric segments order after alphabetic ones (e.g. 1.0.1 > 1.0.rc).
+			return 1
+		case berr == nil:
+			return -1
+		default:
+			if as[i] != bs[i] {
+				return strings.Compare(as[i], bs[i])
+			}
+		}
+	}
+	return cmp.Compare(len(as), len(bs))
+}

--- a/internal/versionx/versionx_test.go
+++ b/internal/versionx/versionx_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package versionx
+
+import "testing"
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	}
+	return 0
+}
+
+func TestApproxCompare(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "2.0.0", -1},
+		{"2.0.0", "2.0.0", 0},
+		{"2.1.0", "2.0.9", 1},
+		{"1.0.0-rc1", "1.0.0", -1},
+		{"2026.4.22", "2026.12.1", -1},
+		{"1.5", "1.10", -1},
+		{"0.10.0", "0.9.5", 1},
+		{"1.0.0.post1", "1.0.0", 1},
+		{"1.4.1", "1.17.0", -1},
+		{"2.9.0.post0", "2.9.0", 1},
+		// Spec agreements documented in the package comment.
+		{"1.0a2", "1.0a12", -1},                   // PEP 440: within-stage ordering
+		{"1.0.post456", "1.0.15", -1},             // PEP 440: digit run after letter run
+		{"1.0", "1.0+deb1", -1},                   // Debian: additions order after
+		{"1.0~beta1", "1.0~rc1", -1},              // Debian: ordering among tilde forms
+		{"1-milestone", "1-rc", -1},               // Maven: qualifier order is alphabetical
+		{"1-rc", "1-snapshot", -1},                // Maven: qualifier order is alphabetical
+		{"1-foo2", "1-foo10", -1},                 // Maven: numeric qualifier suffixes
+		{"1.K", "1.7", -1},                        // Maven: digit run after letter run
+		{"1", "1-sp", -1},                         // Maven: sp orders after release
+		{"1.0.a.2", "1.0.b1", -1},                 // Gem::Version: ordering among prereleases
+		{"1.0.0-alpha.1", "1.0.0-alpha.beta", -1}, // semver: strict path
+		// Spec divergences documented in the package comment: each scheme's
+		// pre-release marker orders before its base, Compare orders it after.
+		{"1.0rc1", "1.0", 1},     // PEP 440 orders rc before the release
+		{"1.0.dev456", "1.0", 1}, // PEP 440 orders dev before the release
+		{"1.0~rc1", "1.0", 1},    // Debian orders ~ before the release
+		{"1-snapshot", "1", 1},   // Maven orders snapshot before the release
+		{"1.0.b1", "1.0", 1},     // Gem::Version orders prereleases before the release
+	}
+	for _, tc := range tests {
+		got := ApproxCompare(tc.a, tc.b)
+		if sign(got) != tc.want {
+			t.Errorf("ApproxCompare(%q, %q) = %d, want sign %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/pkg/rebuild/maven/gen_jdk_urls.go
+++ b/pkg/rebuild/maven/gen_jdk_urls.go
@@ -35,7 +35,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/oss-rebuild/internal/semver"
+	"github.com/google/oss-rebuild/internal/versionx"
 )
 
 // Configuration constants
@@ -167,7 +167,7 @@ func addMajorVersionAliases(urlMap map[string]string) {
 		}
 		// Sort to find the latest
 		sort.Slice(versions, func(i, j int) bool {
-			return compareVersions(versions[i], versions[j])
+			return versionx.ApproxCompare(versions[i], versions[j]) < 0
 		})
 		latest := versions[len(versions)-1]
 		urlMap[major] = urlMap[latest]
@@ -393,44 +393,10 @@ func generateCode(w io.Writer, urlMap map[string]string) {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {
-		return compareVersions(keys[i], keys[j])
+		return versionx.ApproxCompare(keys[i], keys[j]) < 0
 	})
 	for _, k := range keys {
 		fmt.Fprintf(w, "\t%q: %q,\n", k, urlMap[k])
 	}
 	fmt.Fprintln(w, "}")
-}
-
-// compareVersions compares two version strings for sorting.
-// Handles both legacy (8u212) and modern (11.0.1) formats.
-// Returns true if v1 < v2.
-func compareVersions(v1, v2 string) bool {
-	// Convert to semver-compatible format for comparison
-	s1 := toSemverString(v1)
-	s2 := toSemverString(v2)
-	return semver.Cmp(s1, s2) < 0
-}
-
-// toSemverString converts a JDK version string to semver format.
-// "8u212" -> "8.0.212"
-// "11.0.1" -> "11.0.1"
-// "17" -> "17.0.0"
-func toSemverString(v string) string {
-	// Handle legacy format: 8u212 -> 8.0.212
-	if strings.Contains(v, "u") {
-		parts := strings.Split(v, "u")
-		if len(parts) == 2 {
-			return fmt.Sprintf("%s.0.%s", parts[0], parts[1])
-		}
-	}
-	// Handle major-only versions: 17 -> 17.0.0
-	if !strings.Contains(v, ".") {
-		return v + ".0.0"
-	}
-	// Handle semver with only major.minor: 11.0 -> 11.0.0
-	parts := strings.Split(v, ".")
-	if len(parts) == 2 {
-		return v + ".0"
-	}
-	return v
 }


### PR DESCRIPTION
Moves compareVersions (semver-strict with a loose segment-wise fallback)
into a dedicated internal/versionx for use in the SQLite snapshot logic.
The ordering remains approximate and intransitive across mixed
semver/non-semver sets. The package comment details which of each
ecosystem's ordering rules the fallback matches and where it diverges,
checked against the worked examples in each spec, and the test table
pins both.