### PR TITLE
Support local snapshot database in benchmark runs

### DIFF
--- a/internal/docdb/docdb_test.go
+++ b/internal/docdb/docdb_test.go
@@ -153,6 +153,18 @@ func TestQueryTable(t *testing.T) {
 	}
 }
 
+func TestEnsureDocTables(t *testing.T) {
+	db := newDB(t)
+	defs := []TableDef{probeTable, {Name: "message_counts", Query: "SELECT message, count(*) AS n FROM gen_probe GROUP BY message"}}
+	must1(EnsureDocTables(db, defs))
+	must1(ApplyDocs(db, probeTable, []json.RawMessage{probe("k1", "hello", dt(0))}))
+	// A second pass leaves the existing table (and its rows) alone, and the
+	// derived table is never created by it.
+	must1(EnsureDocTables(db, defs))
+	assertCount(t, db, "SELECT count(*) FROM gen_probe", "1")
+	assertCount(t, db, "SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='message_counts'", "0")
+}
+
 func TestValidateTable(t *testing.T) {
 	docCols := []Col{{"key", "TEXT", Doc("$.Key")}}
 	for name, td := range map[string]TableDef{

--- a/internal/docdb/store.go
+++ b/internal/docdb/store.go
@@ -211,6 +211,48 @@ func StoreDocs(db *sqlite3.Conn, td TableDef, docs []json.RawMessage) error {
 	return nil
 }
 
+// EnsureDocTables creates the doc tables among defs (and their indexes)
+// that db does not already have, making an empty or partial database
+// writable in place. Derived tables are skipped: they materialize from
+// queries, not writes.
+// NOTE: Existing tables are not reconciled with defs. Columns added to the
+// registry appear only on the next full rebuild, since SQLite cannot ALTER
+// in a STORED generated column.
+func EnsureDocTables(db *sqlite3.Conn, defs []TableDef) error {
+	stmt, _, err := db.Prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+	if err != nil {
+		return errors.Wrap(err, "preparing table lookup")
+	}
+	defer stmt.Close()
+	for _, td := range defs {
+		if len(td.Cols) == 0 {
+			continue
+		}
+		if err := validateTable(td); err != nil {
+			return err
+		}
+		if err := stmt.BindText(1, td.Name); err != nil {
+			return errors.Wrap(err, "binding table name")
+		}
+		exists := stmt.Step()
+		if err := stmt.Reset(); err != nil {
+			return errors.Wrapf(err, "checking table %s", td.Name)
+		}
+		if exists {
+			continue
+		}
+		if err := db.Exec(createTableSQL(td)); err != nil {
+			return errors.Wrapf(err, "creating table %s", td.Name)
+		}
+		for _, idx := range td.Indexes {
+			if err := db.Exec(createIndexSQL(td.Name, idx)); err != nil {
+				return errors.Wrapf(err, "creating index on %s", td.Name)
+			}
+		}
+	}
+	return nil
+}
+
 // ApplyDocs upserts documents into td's existing doc table.
 func ApplyDocs(db *sqlite3.Conn, td TableDef, docs []json.RawMessage) (err error) {
 	stmt, _, err := db.Prepare(docUpsertSQL(td))

--- a/internal/rundex/sqlite.go
+++ b/internal/rundex/sqlite.go
@@ -10,7 +10,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/google/oss-rebuild/internal/docdb"
 	"github.com/google/oss-rebuild/internal/sqlitex"
 	"github.com/google/oss-rebuild/pkg/feed"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
@@ -278,6 +280,60 @@ func (s *SQLite) FetchSessions(ctx context.Context, req *FetchSessionsReq) ([]sc
 		return a.Created.Compare(b.Created)
 	})
 	return sessions, nil
+}
+
+// SQLiteWriter writes rebuilds and runs into a snapshot database's doc
+// tables through the same guarded upserts the rollup uses, so local writes,
+// re-runs, and replayed upstream deltas all compose safely.
+type SQLiteWriter struct {
+	q        Querier
+	attempts docdb.TableDef
+	runs     docdb.TableDef
+}
+
+var _ Writer = &SQLiteWriter{}
+
+// NewSQLiteWriter creates a Writer over a snapshot database. defs is the
+// owning schema's table registry (e.g. snapshot.Tables()).
+func NewSQLiteWriter(q Querier, defs []docdb.TableDef) (*SQLiteWriter, error) {
+	w := &SQLiteWriter{q: q}
+	for _, td := range defs {
+		switch td.Name {
+		case "attempts":
+			w.attempts = td
+		case "runs":
+			w.runs = td
+		}
+	}
+	if w.attempts.Name == "" || w.runs.Name == "" {
+		return nil, errors.New("registry does not define attempts and runs tables")
+	}
+	return w, nil
+}
+
+func (w *SQLiteWriter) writeDoc(td docdb.TableDef, v any) error {
+	doc, err := json.Marshal(v)
+	if err != nil {
+		return errors.Wrap(err, "encoding document")
+	}
+	return w.q.Query(func(db *sqlite3.Conn) error {
+		return docdb.ApplyDocs(db, td, []json.RawMessage{doc})
+	})
+}
+
+// WriteRebuild records a rebuild attempt, stamping Updated (as the API
+// service does on its writes) so the upsert guard orders it against other
+// writes of the same attempt.
+func (w *SQLiteWriter) WriteRebuild(ctx context.Context, r Rebuild) error {
+	if r.Updated.IsZero() {
+		r.Updated = time.Now().UTC()
+	}
+	return w.writeDoc(w.attempts, r.RebuildAttempt)
+}
+
+// WriteRun records a run.
+func (w *SQLiteWriter) WriteRun(ctx context.Context, r Run) error {
+	return w.writeDoc(w.runs, r.Run)
 }
 
 func (s *SQLite) FetchIterations(ctx context.Context, req *FetchIterationsReq) ([]schema.AgentIteration, error) {

--- a/internal/snapshot/local.go
+++ b/internal/snapshot/local.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"time"
+
+	"github.com/google/oss-rebuild/internal/docdb"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/ncruces/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+// LocalDB is a read-write snapshot database on the local filesystem: the
+// same layout the rollup publishes, but owned and written in place by a
+// local tool (e.g. a benchmark run) with no Firestore involved. Concurrent
+// processes coordinate through SQLite's own file locking.
+type LocalDB struct {
+	Conn *sqlite3.Conn
+}
+
+// OpenLocal opens or creates a snapshot database at path. Missing doc
+// tables are created, so a fresh path yields an empty writable database. A
+// database from a different schema era is refused: rebuilding it from its
+// raw documents is the only migration.
+func OpenLocal(path string) (*LocalDB, error) {
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening database")
+	}
+	fail := func(err error) (*LocalDB, error) {
+		db.Close()
+		return nil, err
+	}
+	if err := db.Exec("PRAGMA busy_timeout = 10000"); err != nil {
+		return fail(errors.Wrap(err, "setting busy timeout"))
+	}
+	if err := docdb.EnsureDocTables(db, Tables()); err != nil {
+		return fail(err)
+	}
+	version, err := sqlitex.Version(db)
+	if err != nil {
+		return fail(err)
+	}
+	if version == 0 {
+		// No era yet: a fresh database, stamped with this one.
+		if err := sqlitex.SetVersion(db, SchemaVersion); err != nil {
+			return fail(err)
+		}
+		if err := WriteMeta(db, Meta{BuiltAt: time.Now().UTC(), SourceProject: "local"}); err != nil {
+			return fail(errors.Wrap(err, "stamping meta"))
+		}
+	} else if err := sqlitex.CheckVersion(db, SchemaVersion); err != nil {
+		return fail(err)
+	}
+	return &LocalDB{Conn: db}, nil
+}
+
+// Refresh rematerializes the derived tables from the doc rows written so
+// far and re-stamps the meta build time.
+func (l *LocalDB) Refresh() (map[string]int, error) {
+	counts, err := refreshDerived(l.Conn)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := ReadMeta(l.Conn)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading meta")
+	}
+	meta.BuiltAt = time.Now().UTC()
+	return counts, WriteMeta(l.Conn, meta)
+}
+
+func (l *LocalDB) Close() error { return l.Conn.Close() }

--- a/internal/snapshot/local_test.go
+++ b/internal/snapshot/local_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+func TestLocalDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "rebuild.db")
+	ldb, err := OpenLocal(path)
+	if err != nil {
+		t.Fatalf("OpenLocal: %v", err)
+	}
+	q := rundex.NewSingleConn(ldb.Conn)
+	w, err := rundex.NewSQLiteWriter(q, Tables())
+	if err != nil {
+		t.Fatalf("NewSQLiteWriter: %v", err)
+	}
+	if err := w.WriteRun(ctx, rundex.FromRun(schema.Run{ID: "run1", BenchmarkName: "bench.json", Created: at(0)})); err != nil {
+		t.Fatalf("WriteRun: %v", err)
+	}
+	for _, a := range []schema.RebuildAttempt{
+		attempt("pypi", "absl-py", "1.0.0", "run1", true, schema.RebuildStatusSuccess, at(0)),
+		attempt("pypi", "requests", "2.0.0", "run1", false, schema.RebuildStatusFailure, at(time.Minute)),
+	} {
+		if err := w.WriteRebuild(ctx, rundex.Rebuild{RebuildAttempt: a}); err != nil {
+			t.Fatalf("WriteRebuild(%s): %v", a.Package, err)
+		}
+	}
+	if _, err := ldb.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	r := rundex.NewSQLite(q)
+	if runs, err := r.FetchRuns(ctx, rundex.FetchRunsOpts{}); err != nil || len(runs) != 1 {
+		t.Errorf("FetchRuns = %v, %v, want 1 run", runs, err)
+	}
+	rebuilds, err := r.FetchRebuilds(ctx, &rundex.FetchRebuildRequest{})
+	if err != nil || len(rebuilds) != 2 {
+		t.Fatalf("FetchRebuilds = %d rebuilds, %v, want 2", len(rebuilds), err)
+	}
+	if err := ldb.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Reopening finds the same era. A rewrite of an attempt supersedes it.
+	ldb, err = OpenLocal(path)
+	if err != nil {
+		t.Fatalf("OpenLocal(existing): %v", err)
+	}
+	defer ldb.Close()
+	q = rundex.NewSingleConn(ldb.Conn)
+	w, err = rundex.NewSQLiteWriter(q, Tables())
+	if err != nil {
+		t.Fatalf("NewSQLiteWriter: %v", err)
+	}
+	retry := attempt("pypi", "requests", "2.0.0", "run1", true, schema.RebuildStatusSuccess, at(2*time.Minute))
+	if err := w.WriteRebuild(ctx, rundex.Rebuild{RebuildAttempt: retry}); err != nil {
+		t.Fatalf("WriteRebuild(retry): %v", err)
+	}
+	if _, err := ldb.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	assertCount(t, ldb.Conn, "SELECT count(*) FROM attempts", "2")
+	assertCount(t, ldb.Conn, "SELECT count(*) FROM attempts WHERE success", "2")
+}
+
+func TestOpenLocalRefusesOtherEra(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rebuild.db")
+	ldb, err := OpenLocal(path)
+	if err != nil {
+		t.Fatalf("OpenLocal: %v", err)
+	}
+	if err := sqlitex.SetVersion(ldb.Conn, SchemaVersion+1); err != nil {
+		t.Fatalf("bumping stored version: %v", err)
+	}
+	if err := ldb.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := OpenLocal(path); err == nil {
+		t.Error("OpenLocal accepted a database from another schema era")
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"time"
@@ -165,11 +166,6 @@ func fillSnapshotDB(db *sqlite3.Conn, docTables map[string][]json.RawMessage, me
 	docTableCount := 0
 	for _, td := range Tables() {
 		if td.Query != "" {
-			n, err := docdb.StoreQuery(db, td)
-			if err != nil {
-				return nil, errors.Wrapf(err, "materializing %s", td.Name)
-			}
-			counts[td.Name] = n
 			continue
 		}
 		docTableCount++
@@ -185,8 +181,35 @@ func fillSnapshotDB(db *sqlite3.Conn, docTables map[string][]json.RawMessage, me
 	if docTableCount != len(docTables) {
 		return nil, errors.Errorf("built documents for %d tables, registry declares %d doc tables", len(docTables), docTableCount)
 	}
+	derived, err := refreshDerived(db)
+	if err != nil {
+		return nil, err
+	}
+	maps.Copy(counts, derived)
 	if err := sqlitex.SetVersion(db, SchemaVersion); err != nil {
 		return nil, err
 	}
 	return counts, WriteMeta(db, meta)
+}
+
+// refreshDerived drops and rematerializes every derived table from the doc
+// rows currently in db, in registry order so a derived table may build on
+// an earlier one. Idempotent, so it serves both the one-shot snapshot build
+// and in-place refresh of a locally written database.
+func refreshDerived(db *sqlite3.Conn) (map[string]int, error) {
+	counts := make(map[string]int)
+	for _, td := range Tables() {
+		if td.Query == "" {
+			continue
+		}
+		if err := db.Exec("DROP TABLE IF EXISTS " + td.Name); err != nil {
+			return nil, errors.Wrapf(err, "dropping %s", td.Name)
+		}
+		n, err := docdb.StoreQuery(db, td)
+		if err != nil {
+			return nil, errors.Wrapf(err, "materializing %s", td.Name)
+		}
+		counts[td.Name] = n
+	}
+	return counts, nil
 }

--- a/tools/ctl/command/runbenchmark/runbenchmark.go
+++ b/tools/ctl/command/runbenchmark/runbenchmark.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/oss-rebuild/internal/gcsx"
 	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/internal/taskqueue"
 	"github.com/google/oss-rebuild/pkg/act"
 	"github.com/google/oss-rebuild/pkg/act/api"
@@ -65,6 +66,7 @@ type Config struct {
 	OverwriteMode     string
 	MaxConcurrency    int
 	RunID             string
+	DB                string
 }
 
 // Validate ensures the configuration is valid.
@@ -83,6 +85,9 @@ func (c Config) Validate() error {
 	}
 	if !c.Local && c.GitCacheURL != "" {
 		return errors.New("git-cache-url is only supported in local mode")
+	}
+	if !c.Local && c.DB != "" {
+		return errors.New("db is only supported in local mode")
 	}
 	if c.OverwriteMode != "" && c.OverwriteMode != string(schema.OverwriteServiceUpdate) && c.OverwriteMode != string(schema.OverwriteForce) {
 		return errors.Errorf("invalid overwrite-mode: %s. Expected one of 'SERVICE_UPDATE' or 'FORCE'", c.OverwriteMode)
@@ -196,7 +201,24 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 			return cratesregistryservice.FindRegistryCommit(ctx, req, &cratesregistryservice.FindRegistryCommitDeps{IndexManager: mgr})
 		}
 		executor = benchrun.NewLocalExecutionService(localCfg)
-		dex = rundex.NewFilesystemClient(localfiles.Rundex())
+		if cfg.DB != "" {
+			ldb, err := snapshot.OpenLocal(cfg.DB)
+			if err != nil {
+				return nil, errors.Wrap(err, "opening rundex database")
+			}
+			defer func() {
+				if _, err := ldb.Refresh(); err != nil {
+					log.Println(errors.Wrap(err, "refreshing rundex database"))
+				}
+				ldb.Close()
+			}()
+			dex, err = rundex.NewSQLiteWriter(rundex.NewSingleConn(ldb.Conn), snapshot.Tables())
+			if err != nil {
+				return nil, errors.Wrap(err, "creating rundex writer")
+			}
+		} else {
+			dex = rundex.NewFilesystemClient(localfiles.Rundex())
+		}
 		if err := dex.WriteRun(ctx, rundex.FromRun(schema.Run{
 			ID:            runID,
 			BenchmarkName: filepath.Base(cfg.BenchmarkPath),
@@ -340,7 +362,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 func Command() *cobra.Command {
 	cfg := Config{}
 	cmd := &cobra.Command{
-		Use:   "run-bench attest -api <URI>  [-local -bootstrap-bucket <BUCKET> -bootstrap-version <VERSION>] [-format=summary|csv] <benchmark.json>",
+		Use:   "run-bench attest -api <URI>  [-local -bootstrap-bucket <BUCKET> -bootstrap-version <VERSION> -db <PATH>] [-format=summary|csv] <benchmark.json>",
 		Short: "Run benchmark",
 		Args:  cobra.ExactArgs(2),
 		RunE: cli.RunE(
@@ -374,5 +396,6 @@ func flagSet(name string, cfg *Config) *flag.FlagSet {
 	set.StringVar(&cfg.OverwriteMode, "overwrite-mode", "", "reason to overwrite existing attestation (SERVICE_UPDATE or FORCE)")
 	set.StringVar(&cfg.GitCacheURL, "git-cache-url", "", "if provided, the git-cache service to use to fetch repos (local mode only)")
 	set.StringVar(&cfg.RunID, "run-id", "", "explicit run ID to use")
+	set.StringVar(&cfg.DB, "db", "", "snapshot database file to record results into, created if missing (local mode only)")
 	return set
 }


### PR DESCRIPTION
run-bench -local -db <PATH> writes its run and verdicts into a snapshot
database on disk instead of the per-attempt file tree, creating the file
on first use, and rederives the trend tables when the run finishes. The
result is the same artifact the rollup publishes, so every snapshot
consumer (the dashboard sqlite rundex, ctl snapshot) reads it unchanged,
and because writes go through the guarded upserts, re-runs and replayed
upstream delta segments compose with local results safely. A database
from another schema era is refused: rebuilding from raw documents is the
only migration. Cross-process writers coordinate through SQLite file
locking.