### PR TITLE
Read snapshot databases in get-results, list-runs, tui

### DIFF
--- a/internal/rundex/sqlite.go
+++ b/internal/rundex/sqlite.go
@@ -53,6 +53,34 @@ var _ SessionReader = &SQLite{}
 // NewSQLite creates a Reader/SessionReader over a snapshot database.
 func NewSQLite(q Querier) *SQLite { return &SQLite{q: q} }
 
+// SQLiteFile is a SQLite reader that owns its database connection.
+type SQLiteFile struct {
+	SQLite
+	conn *sqlite3.Conn
+}
+
+// OpenSQLiteFile opens a snapshot database file for reading, refusing one
+// from any schema era but schema. The open is read-only, so a missing path
+// is an error rather than a fresh database, and waits out a concurrent
+// writer's transactions rather than failing on them.
+func OpenSQLiteFile(path string, schema int) (*SQLiteFile, error) {
+	conn, err := sqlite3.OpenFlags(path, sqlite3.OPEN_READONLY)
+	if err != nil {
+		return nil, errors.Wrapf(err, "opening database %s", path)
+	}
+	if err := conn.Exec("PRAGMA busy_timeout = 10000"); err != nil {
+		conn.Close()
+		return nil, errors.Wrap(err, "setting busy timeout")
+	}
+	if err := sqlitex.CheckVersion(conn, schema); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return &SQLiteFile{SQLite: SQLite{q: NewSingleConn(conn)}, conn: conn}, nil
+}
+
+func (f *SQLiteFile) Close() error { return f.conn.Close() }
+
 // cond accumulates a WHERE clause and its bind arguments.
 type cond struct {
 	exprs []string

--- a/internal/snapshot/local_test.go
+++ b/internal/snapshot/local_test.go
@@ -5,6 +5,7 @@ package snapshot
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -71,6 +72,23 @@ func TestLocalDB(t *testing.T) {
 	}
 	assertCount(t, ldb.Conn, "SELECT count(*) FROM attempts", "2")
 	assertCount(t, ldb.Conn, "SELECT count(*) FROM attempts WHERE success", "2")
+	// The read-only file reader sees the same rows and never creates a
+	// database at a missing path.
+	f, err := rundex.OpenSQLiteFile(path, SchemaVersion)
+	if err != nil {
+		t.Fatalf("OpenSQLiteFile: %v", err)
+	}
+	defer f.Close()
+	if rebuilds, err := f.FetchRebuilds(ctx, &rundex.FetchRebuildRequest{}); err != nil || len(rebuilds) != 2 {
+		t.Errorf("FetchRebuilds via file reader = %d rebuilds, %v, want 2", len(rebuilds), err)
+	}
+	missing := filepath.Join(t.TempDir(), "absent.db")
+	if _, err := rundex.OpenSQLiteFile(missing, SchemaVersion); err == nil {
+		t.Error("OpenSQLiteFile created a missing database")
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Errorf("missing path exists after open attempt: %v", err)
+	}
 }
 
 func TestOpenLocalRefusesOtherEra(t *testing.T) {

--- a/tools/ctl/command/getresults/getresults.go
+++ b/tools/ctl/command/getresults/getresults.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/pkg/act"
 	"github.com/google/oss-rebuild/pkg/act/cli"
 	"github.com/google/oss-rebuild/tools/benchmark"
@@ -28,6 +29,7 @@ import (
 // Config holds all configuration for the get-results command.
 type Config struct {
 	Project          string
+	DB               string
 	Run              string
 	Bench            string
 	BenchmarkName    string
@@ -44,6 +46,9 @@ type Config struct {
 
 // Validate ensures the configuration is valid.
 func (c Config) Validate() error {
+	if c.Project != "" && c.DB != "" {
+		return errors.New("only one of --project and --db may be provided")
+	}
 	if c.Run != "" && c.BenchmarkName != "" {
 		return errors.New("only one of --run and --bench-name may be provided")
 	}
@@ -129,7 +134,14 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 		return nil, err
 	}
 	var dex rundex.Reader
-	if cfg.Project == "" {
+	if cfg.DB != "" {
+		f, err := rundex.OpenSQLiteFile(cfg.DB, snapshot.SchemaVersion)
+		if err != nil {
+			return nil, errors.Wrap(err, "opening rundex database")
+		}
+		defer f.Close()
+		dex = f
+	} else if cfg.Project == "" {
 		dex = rundex.NewFilesystemClient(localfiles.Rundex())
 	} else {
 		dex, err = rundex.NewFirestore(ctx, cfg.Project)
@@ -263,7 +275,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 func Command() *cobra.Command {
 	cfg := Config{}
 	cmd := &cobra.Command{
-		Use:   "get-results --project <ID> [--run <ID> | --bench-name <name>] [--since <duration>] [--bench <benchmark.json>] [--prefix <prefix>] [--pattern <regex>] [--sample N] [--format=summary|bench|csv|jsonl] [--fields <field1,field2,...>] [--success-only]",
+		Use:   "get-results [--project <ID> | --db <PATH>] [--run <ID> | --bench-name <name>] [--since <duration>] [--bench <benchmark.json>] [--prefix <prefix>] [--pattern <regex>] [--sample N] [--format=summary|bench|csv|jsonl] [--fields <field1,field2,...>] [--success-only]",
 		Short: "Analyze rebuild results",
 		Args:  cobra.NoArgs,
 		RunE: cli.RunE(
@@ -281,6 +293,7 @@ func Command() *cobra.Command {
 func flagSet(name string, cfg *Config) *flag.FlagSet {
 	set := flag.NewFlagSet(name, flag.ContinueOnError)
 	set.StringVar(&cfg.Project, "project", "", "the project from which to fetch the Firestore data")
+	set.StringVar(&cfg.DB, "db", "", "snapshot database file to read results from")
 	set.StringVar(&cfg.Run, "run", "", "the run(s) from which to fetch results")
 	set.StringVar(&cfg.BenchmarkName, "bench-name", "", "the name of the benchmark to filter by")
 	set.DurationVar(&cfg.Since, "since", 0, "only fetch results from runs created within this duration (e.g. 24h)")

--- a/tools/ctl/command/listruns/listruns.go
+++ b/tools/ctl/command/listruns/listruns.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/pkg/act"
 	"github.com/google/oss-rebuild/pkg/act/cli"
 	"github.com/google/oss-rebuild/tools/benchmark"
@@ -24,6 +25,7 @@ import (
 // Config holds all configuration for the list-runs command.
 type Config struct {
 	Project       string
+	DB            string
 	BenchmarkPath string
 	BenchmarkName string
 	Since         time.Duration
@@ -31,8 +33,8 @@ type Config struct {
 
 // Validate ensures the configuration is valid.
 func (c Config) Validate() error {
-	if c.Project == "" {
-		return errors.New("project is required")
+	if (c.Project == "") == (c.DB == "") {
+		return errors.New("exactly one of --project and --db is required")
 	}
 	return nil
 }
@@ -63,9 +65,20 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 		log.Printf("Loaded benchmark of %d artifacts...\n", set.Count)
 		opts.BenchmarkHash = hex.EncodeToString(set.Hash(sha256.New()))
 	}
-	client, err := rundex.NewFirestore(ctx, cfg.Project)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating firestore client")
+	var client rundex.Reader
+	if cfg.DB != "" {
+		f, err := rundex.OpenSQLiteFile(cfg.DB, snapshot.SchemaVersion)
+		if err != nil {
+			return nil, errors.Wrap(err, "opening rundex database")
+		}
+		defer f.Close()
+		client = f
+	} else {
+		var err error
+		client, err = rundex.NewFirestore(ctx, cfg.Project)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating firestore client")
+		}
 	}
 	runs, err := client.FetchRuns(ctx, opts)
 	if err != nil {
@@ -94,7 +107,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 func Command() *cobra.Command {
 	cfg := Config{}
 	cmd := &cobra.Command{
-		Use:   "list-runs --project <ID> [--bench <benchmark.json>] [--bench-name <name>] [--since <duration>]",
+		Use:   "list-runs [--project <ID> | --db <PATH>] [--bench <benchmark.json>] [--bench-name <name>] [--since <duration>]",
 		Short: "List runs",
 		Args:  cobra.NoArgs,
 		RunE: cli.RunE(
@@ -112,6 +125,7 @@ func Command() *cobra.Command {
 func flagSet(name string, cfg *Config) *flag.FlagSet {
 	set := flag.NewFlagSet(name, flag.ContinueOnError)
 	set.StringVar(&cfg.Project, "project", "", "the project from which to fetch the Firestore data")
+	set.StringVar(&cfg.DB, "db", "", "snapshot database file to read runs from")
 	set.StringVar(&cfg.BenchmarkPath, "bench", "", "a path to a benchmark file for filtering")
 	set.StringVar(&cfg.BenchmarkName, "bench-name", "", "the name of the benchmark to filter by")
 	set.DurationVar(&cfg.Since, "since", 0, "only list runs created within this duration (e.g. 24h)")

--- a/tools/ctl/command/tui/tui.go
+++ b/tools/ctl/command/tui/tui.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/google/oss-rebuild/internal/httpx"
 	"github.com/google/oss-rebuild/internal/rundex"
+	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/pkg/act"
 	"github.com/google/oss-rebuild/pkg/act/cli"
 	"github.com/google/oss-rebuild/pkg/rebuild/meta"
@@ -36,6 +37,7 @@ const vertexAIService = "aiplatform.googleapis.com"
 // Config holds all configuration for the tui command.
 type Config struct {
 	Project          string
+	DB               string
 	DebugStorage     string
 	LogsBucket       string
 	MetadataBucket   string
@@ -84,7 +86,15 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 	var dex rundex.Reader
 	var watcher rundex.Watcher
 	{
-		if cfg.RundexGCSPath != "" {
+		if cfg.DB != "" {
+			f, err := rundex.OpenSQLiteFile(cfg.DB, snapshot.SchemaVersion)
+			if err != nil {
+				return nil, errors.Wrap(err, "opening rundex database")
+			}
+			defer f.Close()
+			dex = f
+			// Like GCS and Firestore, no watcher is available.
+		} else if cfg.RundexGCSPath != "" {
 			u, err := url.Parse(cfg.RundexGCSPath)
 			if err != nil {
 				return nil, errors.Wrap(err, "parsing --rundex-gcs-path")
@@ -199,7 +209,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 func Command() *cobra.Command {
 	cfg := Config{}
 	cmd := &cobra.Command{
-		Use:   "tui [--project <ID>] [--debug-storage <bucket>] [--benchmark-dir <dir>] [--clean] [--llm-project] [--rundex-gcs-path <path>] [--merged-asset-store <path>] [-bootstrap-bucket <BUCKET> -bootstrap-version <VERSION>]",
+		Use:   "tui [--project <ID> | --db <PATH>] [--debug-storage <bucket>] [--benchmark-dir <dir>] [--clean] [--llm-project] [--rundex-gcs-path <path>] [--merged-asset-store <path>] [-bootstrap-bucket <BUCKET> -bootstrap-version <VERSION>]",
 		Short: "A terminal UI for the OSS-Rebuild debugging tools",
 		Args:  cobra.NoArgs,
 		RunE: cli.RunE(
@@ -217,6 +227,7 @@ func Command() *cobra.Command {
 func flagSet(name string, cfg *Config) *flag.FlagSet {
 	set := flag.NewFlagSet(name, flag.ContinueOnError)
 	set.StringVar(&cfg.Project, "project", "", "the project from which to fetch the Firestore data")
+	set.StringVar(&cfg.DB, "db", "", "snapshot database file to browse instead of Firestore or the local rundex")
 	set.StringVar(&cfg.DebugStorage, "debug-storage", "", "the gcs bucket to find debug logs and artifacts")
 	set.StringVar(&cfg.LogsBucket, "logs-bucket", "", "the gcs bucket where gcb logs are stored")
 	set.StringVar(&cfg.MetadataBucket, "metadata-bucket", "", "the gcs bucket where rebuild output is stored")


### PR DESCRIPTION
--db <PATH> serves both commands from a snapshot database file, whether
written by run-bench -db, written by ctl snapshot rollup, or fetched from the
analytics bucket. The file opens read-only through rundex.SQLiteFile.