### PR TITLE
Grant the orchestrator write access to agent metadata

### DIFF
--- a/deployments/iam.tf
+++ b/deployments/iam.tf
@@ -389,6 +389,11 @@ resource "google_storage_bucket_iam_member" "agent-reads-metadata" {
   ])
   member = each.key
 }
+resource "google_storage_bucket_iam_member" "orchestrator-writes-agent-metadata" {
+  bucket = google_storage_bucket.agent-metadata.name
+  role   = "roles/storage.objectCreator"
+  member = google_service_account.orchestrator.member
+}
 resource "google_storage_bucket_iam_member" "builder-agent-views-buckets" {
   bucket = google_storage_bucket.agent-logs.name
   role   = google_project_iam_custom_role.bucket-viewer-role.name


### PR DESCRIPTION
The agent-api service runs as the orchestrator, and its iteration
handler hands the GCB executor an asset store on the agent metadata
bucket to which uploads (e.g. Dockerfile and BuildInfo) are attempted.
An upload failure is folded into the build error, so the GCB iteration
path cannot succeed without this grant.