### PR TITLE
Make the agent model selectable per session

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -27,6 +27,7 @@ import (
 var (
 	project         = flag.String("project", "", "GCP Project ID for resource usage")
 	location        = flag.String("location", "global", "GCP location for resource usage")
+	model           = flag.String("model", "", "Gemini model id for the session, if overriding defaults")
 	sessionID       = flag.String("session-id", "", "Session ID for this agent run")
 	agentAPIURL     = flag.String("agent-api-url", "", "URL of the agent API service")
 	sessionsBucket  = flag.String("sessions-bucket", "", "GCS bucket for session data")
@@ -137,6 +138,7 @@ func main() {
 		LogsBucket:     *logsBucket,
 		RegistryClient: regclient,
 		Retrier:        agent.NewRetrier(),
+		Model:          *model,
 	}
 	if mode == schema.AgentExecutionModeScratch {
 		stubs := scratch.Stubs{

--- a/internal/agent/logic.go
+++ b/internal/agent/logic.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -275,7 +276,7 @@ func (a *defaultAgent) proposeInferenceWithAIAssist(ctx context.Context, initial
 		"Use the tools you have at your disposal to find the URL.",
 		"Finally, if you don't find the URL, just return an empty string.",
 	}
-	repoURL, usage, err := llm.GenerateTextContentWithUsage(ctx, a.deps.GenaiClient, llm.GeminiPro, &genai.GenerateContentConfig{
+	repoURL, usage, err := llm.GenerateTextContentWithUsage(ctx, a.deps.GenaiClient, cmp.Or(a.deps.Model, llm.GeminiPro), &genai.GenerateContentConfig{
 		Temperature: genai.Ptr(float32(0.0)),
 		Tools: []*genai.Tool{
 			{GoogleSearch: &genai.GoogleSearch{}},
@@ -657,12 +658,15 @@ func (a *defaultAgent) RecordIteration(i *schema.AgentIteration) {
 }
 
 // addSideUsage attributes the token usage of an LLM call made outside the main
-// chat to the agent's running total.
+// chat to the agent's running total. The label must match the model the side
+// call actually used (the session's model, same as the chat), or summing it
+// with the chat's usage trips TokenUsage.Add's cross-model guard and crashes
+// the session.
 func (a *defaultAgent) addSideUsage(m *genai.GenerateContentResponseUsageMetadata) {
 	if m == nil {
 		return
 	}
-	a.sideUsage = a.sideUsage.Add(tokenUsageFromMetadata(m, llm.GeminiPro))
+	a.sideUsage = a.sideUsage.Add(tokenUsageFromMetadata(m, cmp.Or(a.deps.Model, llm.GeminiPro)))
 }
 
 // Usage returns the agent's cumulative LLM token consumption: the main chat's

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log"
@@ -32,6 +33,7 @@ type AgentDeps struct {
 	GenaiClient    *genai.Client
 	RegistryClient httpx.BasicClient // Upstream registry requests (e.g. adapt-mode registry refresh) via the session's identified egress path.
 	ScratchRunner  *ScratchRunner    // When set, iteration builds run on a scratch VM with build logs read from exec output.
+	Model          string            // Gemini model id for auxiliary calls. Empty selects llm.GeminiPro.
 }
 
 type ProposeOpts struct {
@@ -63,6 +65,7 @@ type RunSessionDeps struct {
 	Retrier        ratex.Retrier     // Paces and retries model calls. Zero value calls the model once.
 	RegistryClient httpx.BasicClient // Upstream registry requests via the session's identified egress path.
 	ScratchRunner  *ScratchRunner    // When set, each iteration builds on the scratch VM. Only verified successes reach the iteration API, as GCB confirmations.
+	Model          string            // Gemini model id for the session's calls. Empty selects llm.GeminiPro.
 }
 
 func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent, deps RunSessionDeps) (*schema.AgentIteration, error) {
@@ -153,6 +156,7 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (com
 		GenaiClient:    deps.Client,
 		RegistryClient: deps.RegistryClient,
 		ScratchRunner:  deps.ScratchRunner,
+		Model:          deps.Model,
 	})
 	// Stamp the session's LLM token spend onto whatever completion we return.
 	defer func() {
@@ -161,7 +165,7 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (com
 		}
 	}()
 	var err error
-	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, llm.GeminiPro, config, &llm.ChatOpts{Tools: a.getTools(), Retrier: deps.Retrier})
+	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, cmp.Or(deps.Model, llm.GeminiPro), config, &llm.ChatOpts{Tools: a.getTools(), Retrier: deps.Retrier})
 	if err != nil {
 		return &schema.AgentCompleteRequest{
 			StopReason: schema.AgentCompleteReasonError,

--- a/internal/api/apiservice/agent.go
+++ b/internal/api/apiservice/agent.go
@@ -96,6 +96,7 @@ func AgentCreate(ctx context.Context, req schema.AgentCreateRequest, deps *Agent
 		Context:        req.Context,
 		Status:         schema.AgentSessionStatusInitializing,
 		ExecutionMode:  executionMode,
+		Model:          req.Model,
 		Created:        sessionTime,
 		Updated:        sessionTime,
 	}
@@ -159,6 +160,9 @@ func AgentCreate(ctx context.Context, req schema.AgentCreateRequest, deps *Agent
 		}
 		if deps.Host != "" {
 			args = append(args, "--host="+deps.Host)
+		}
+		if req.Model != "" {
+			args = append(args, "--model="+req.Model)
 		}
 		if executionMode == schema.AgentExecutionModeScratch {
 			args = append(args,

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -507,6 +507,7 @@ type AgentCreateRequest struct {
 	Context       *AgentContext      `form:""`
 	ExecutionMode AgentExecutionMode `form:""` // Empty means AgentExecutionModeGCB
 	ExternalAgent bool               `form:""` // Skip the hosted agent job launch: the caller runs the agent binary
+	Model         string             `form:""` // Gemini model id for the session. Empty selects the agent's default.
 }
 
 var _ api.Input = AgentCreateRequest{}
@@ -599,6 +600,7 @@ type AgentSession struct {
 	Status           string             `firestore:"status,omitempty"`
 	ExecutionName    string             `firestore:"execution_name,omitempty"`
 	ExecutionMode    AgentExecutionMode `firestore:"execution_mode,omitempty"` // Empty means GCB (sessions predating scratch support)
+	Model            string             `firestore:"model,omitempty"`          // Gemini model id driving the session
 	ScratchID        string             `firestore:"scratch_id,omitempty"`     // Scratch VM bound to the session (scratch execution mode only)
 	Usage            *TokenUsage        `firestore:"usage,omitempty"`          // total LLM tokens, reported at completion
 	Created          time.Time          `firestore:"created,omitempty"`

--- a/tools/ctl/command/runagentbenchmark/runagentbenchmark.go
+++ b/tools/ctl/command/runagentbenchmark/runagentbenchmark.go
@@ -40,6 +40,7 @@ type Config struct {
 	AgentIterations int
 	BenchmarkFile   string
 	ExecutionMode   string
+	AgentModel      string
 }
 
 // Validate ensures the configuration is valid.
@@ -149,6 +150,7 @@ func Handler(ctx context.Context, cfg Config, deps *Deps) (*act.NoOutput, error)
 				},
 				MaxIterations: cfg.AgentIterations,
 				ExecutionMode: schema.AgentExecutionMode(cfg.ExecutionMode),
+				Model:         cfg.AgentModel,
 			}
 			if len(in.Artifacts) > 0 {
 				req.Target.Artifact = in.Artifacts[i]
@@ -235,5 +237,6 @@ func flagSet(name string, cfg *Config) *flag.FlagSet {
 	set.IntVar(&cfg.MaxConcurrency, "max-concurrency", 90, "maximum number of inflight requests")
 	set.IntVar(&cfg.AgentIterations, "agent-iterations", 3, "maximum number of agent iterations before giving up")
 	set.StringVar(&cfg.ExecutionMode, "execution-mode", "", "where iteration builds execute: gcb (default) or scratch")
+	set.StringVar(&cfg.AgentModel, "agent-model", "", "Gemini model id for agent sessions (empty selects the deployment default)")
 	return set
 }


### PR DESCRIPTION
The model was compiled into the agent binary, so comparing models meant
a redeploy per candidate model. The model id now threads from a dispatch
flag into the session chat and auxiliary calls, defaulting to the
existing built-in when unset. The session document records the model
driving it, so evaluation queries can attribute outcomes and spend per
model.