### PR TITLE
agent: route inference clones through the git-cache

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -12,6 +12,7 @@ import (
 
 	gcs "cloud.google.com/go/storage"
 	"github.com/google/oss-rebuild/internal/agent"
+	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/internal/httpegress"
 	"github.com/google/oss-rebuild/pkg/act/api"
 	"github.com/google/oss-rebuild/pkg/build/scratch"
@@ -21,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/idtoken"
+	gapihttp "google.golang.org/api/transport/http"
 	"google.golang.org/genai"
 )
 
@@ -30,6 +32,7 @@ var (
 	model           = flag.String("model", "", "Gemini model id for the session, if overriding defaults")
 	sessionID       = flag.String("session-id", "", "Session ID for this agent run")
 	agentAPIURL     = flag.String("agent-api-url", "", "URL of the agent API service")
+	gitCacheURL     = flag.String("git-cache-url", "", "if provided, the git-cache service to use to fetch repos")
 	sessionsBucket  = flag.String("sessions-bucket", "", "GCS bucket for session data")
 	metadataBucket  = flag.String("metadata-bucket", "", "GCS bucket for build metadata")
 	logsBucket      = flag.String("logs-bucket", "", "GCS bucket for build logs")
@@ -127,6 +130,22 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to create egress client: ", err)
 	}
+	var gitCache *gitcache.Client
+	if *gitCacheURL != "" {
+		idc, err := idtoken.NewClient(ctx, *gitCacheURL)
+		if err != nil {
+			log.Fatal("Failed to create git cache id client: ", err)
+		}
+		apic, _, err := gapihttp.NewClient(ctx)
+		if err != nil {
+			log.Fatal("Failed to create git cache API client: ", err)
+		}
+		u, err := url.Parse(*gitCacheURL)
+		if err != nil {
+			log.Fatal("Failed to parse git cache URL: ", err)
+		}
+		gitCache = &gitcache.Client{IDClient: idc, APIClient: apic, URL: u}
+	}
 	target := rebuild.Target{Ecosystem: rebuild.Ecosystem(*targetEcosystem), Package: *targetPackage, Version: *targetVersion, Artifact: *targetArtifact}
 	deps := agent.RunSessionDeps{
 		Client:         aiClient,
@@ -139,6 +158,7 @@ func main() {
 		RegistryClient: regclient,
 		Retrier:        agent.NewRetrier(),
 		Model:          *model,
+		GitCache:       gitCache,
 	}
 	if mode == schema.AgentExecutionModeScratch {
 		stubs := scratch.Stubs{

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -59,6 +59,7 @@ var (
 	gcbPrivatePoolRegion  = flag.String("gcb-private-pool-region", "", "GCP location to use for GCB private pool builds, if configured. Note: This should generally be the same as the region where the private pool is located.")
 	agentJobName          = flag.String("agent-job-name", "", "Name of the pre-created Cloud Run Job for AI agent")
 	agentAPIURL           = flag.String("agent-api-url", "", "URL of the agent API service")
+	gitCacheURL           = flag.String("git-cache-url", "", "URL of the git-cache service, forwarded to agent jobs so inference routes clones through it")
 	agentSessionsBucket   = flag.String("agent-sessions-bucket", "", "GCS bucket for agent session data")
 	agentMetadataBucket   = flag.String("agent-metadata-bucket", "", "GCS bucket for agent build metadata")
 	agentLogsBucket       = flag.String("agent-logs-bucket", "", "GCS bucket for agent build logs")
@@ -307,6 +308,7 @@ func AgentCreateInit(ctx context.Context) (*apiservice.AgentCreateDeps, error) {
 	d.AILocation = *aiLocation
 	d.AgentJobName = *agentJobName
 	d.AgentAPIURL = *agentAPIURL
+	d.GitCacheURL = *gitCacheURL
 	d.AgentTimeoutSeconds = *agentTimeoutSeconds
 	d.SessionsBucket = *agentSessionsBucket
 	d.MetadataBucket = *agentMetadataBucket

--- a/deployments/iam.tf
+++ b/deployments/iam.tf
@@ -91,6 +91,7 @@ resource "google_storage_bucket_iam_member" "cachers-read-git-cache" {
   for_each = toset([
     google_service_account.crates-registry.member,
     google_service_account.inference.member,
+    google_service_account.agent-job.member,
   ])
   member = each.key
 }
@@ -253,6 +254,7 @@ resource "google_cloud_run_v2_service_iam_member" "cachers-call-git-cache" {
   for_each = toset([
     google_service_account.crates-registry.member,
     google_service_account.inference.member,
+    google_service_account.agent-job.member,
   ])
   member = each.key
 }

--- a/deployments/services.tf
+++ b/deployments/services.tf
@@ -241,6 +241,7 @@ resource "google_cloud_run_v2_service" "orchestrator" {
         "--block-local-repo-publish=${var.public}",
         "--agent-job-name=${google_cloud_run_v2_job.agent.id}",
         "--agent-api-url=${google_cloud_run_v2_service.agent-api.uri}",
+        "--git-cache-url=${google_cloud_run_v2_service.git-cache.uri}",
         "--agent-timeout-seconds=3600", // 1 hour
         "--agent-sessions-bucket=${google_storage_bucket.agent-sessions.name}",
         "--agent-metadata-bucket=${google_storage_bucket.agent-metadata.name}",

--- a/internal/agent/logic.go
+++ b/internal/agent/logic.go
@@ -308,7 +308,7 @@ func (a *defaultAgent) proposeInferenceWithAIAssist(ctx context.Context, initial
 		req,
 		&inferenceservice.InferDeps{
 			HTTPClient: http.DefaultClient,
-			GitCache:   nil,
+			GitCache:   a.deps.GitCache,
 			RepoOptF: func() *gitx.RepositoryOptions {
 				return &gitx.RepositoryOptions{
 					Worktree: wt,
@@ -333,7 +333,7 @@ func (a *defaultAgent) proposeNormalInference(ctx context.Context) (*schema.Stra
 		},
 		&inferenceservice.InferDeps{
 			HTTPClient: http.DefaultClient,
-			GitCache:   nil,
+			GitCache:   a.deps.GitCache,
 			RepoOptF: func() *gitx.RepositoryOptions {
 				return &gitx.RepositoryOptions{
 					Worktree: wt,

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	gcs "cloud.google.com/go/storage"
+	"github.com/google/oss-rebuild/internal/gitcache"
 	"github.com/google/oss-rebuild/internal/httpx"
 	"github.com/google/oss-rebuild/internal/ratex"
 	"github.com/google/oss-rebuild/pkg/act/api"
@@ -34,6 +35,7 @@ type AgentDeps struct {
 	RegistryClient httpx.BasicClient // Upstream registry requests (e.g. adapt-mode registry refresh) via the session's identified egress path.
 	ScratchRunner  *ScratchRunner    // When set, iteration builds run on a scratch VM with build logs read from exec output.
 	Model          string            // Gemini model id for auxiliary calls. Empty selects llm.GeminiPro.
+	GitCache       *gitcache.Client  // When set, inference repo clones go through the git-cache.
 }
 
 type ProposeOpts struct {
@@ -66,6 +68,7 @@ type RunSessionDeps struct {
 	RegistryClient httpx.BasicClient // Upstream registry requests via the session's identified egress path.
 	ScratchRunner  *ScratchRunner    // When set, each iteration builds on the scratch VM. Only verified successes reach the iteration API, as GCB confirmations.
 	Model          string            // Gemini model id for the session's calls. Empty selects llm.GeminiPro.
+	GitCache       *gitcache.Client  // When set, iteration inference repo clones go through the git-cache.
 }
 
 func doIteration(ctx context.Context, sessionID string, iterNum int, agent Agent, deps RunSessionDeps) (*schema.AgentIteration, error) {
@@ -157,6 +160,7 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (com
 		RegistryClient: deps.RegistryClient,
 		ScratchRunner:  deps.ScratchRunner,
 		Model:          deps.Model,
+		GitCache:       deps.GitCache,
 	})
 	// Stamp the session's LLM token spend onto whatever completion we return.
 	defer func() {

--- a/internal/api/apiservice/agent.go
+++ b/internal/api/apiservice/agent.go
@@ -34,6 +34,7 @@ type AgentCreateDeps struct {
 	AILocation          string // Vertex AI location for agent model calls, distinct as Gemini 3.x only serves from global
 	AgentJobName        string
 	AgentAPIURL         string
+	GitCacheURL         string
 	AgentTimeoutSeconds int
 	SessionsBucket      string
 	MetadataBucket      string
@@ -160,6 +161,9 @@ func AgentCreate(ctx context.Context, req schema.AgentCreateRequest, deps *Agent
 		}
 		if deps.Host != "" {
 			args = append(args, "--host="+deps.Host)
+		}
+		if deps.GitCacheURL != "" {
+			args = append(args, "--git-cache-url="+deps.GitCacheURL)
 		}
 		if req.Model != "" {
 			args = append(args, "--model="+req.Model)


### PR DESCRIPTION
Wire --git-cache-url through the agent job launch (apiservice/agent.go +
cmd/api) and add the necessary permissions so agent inference clones hit
the cache instead of cloning fresh every session.