### PR TITLE
Conclude tool loops gracefully and raise the turn budget

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -30,7 +30,7 @@ type AgentDeps struct {
 	MetadataBucket string
 	LogsBucket     string
 	GCSClient      *gcs.Client
-	MaxTurns       int
+	MaxTurns       int // Bounds each model exchange's tool uses (ChatOpts.MaxToolIterations)
 	GenaiClient    *genai.Client
 	RegistryClient httpx.BasicClient // Upstream registry requests (e.g. adapt-mode registry refresh) via the session's identified egress path.
 	ScratchRunner  *ScratchRunner    // When set, iteration builds run on a scratch VM with build logs read from exec output.
@@ -155,7 +155,7 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (com
 		MetadataBucket: deps.MetadataBucket,
 		LogsBucket:     deps.LogsBucket,
 		GCSClient:      deps.GCSClient,
-		MaxTurns:       10,
+		MaxTurns:       250, // ~20m @5s/fn
 		GenaiClient:    deps.Client,
 		RegistryClient: deps.RegistryClient,
 		ScratchRunner:  deps.ScratchRunner,
@@ -169,7 +169,7 @@ func doSession(ctx context.Context, req RunSessionReq, deps RunSessionDeps) (com
 		}
 	}()
 	var err error
-	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, cmp.Or(deps.Model, llm.GeminiPro), config, &llm.ChatOpts{Tools: a.getTools(), Retrier: deps.Retrier})
+	a.deps.Chat, err = llm.NewChat(ctx, deps.Client, cmp.Or(deps.Model, llm.GeminiPro), config, &llm.ChatOpts{Tools: a.getTools(), MaxToolIterations: a.deps.MaxTurns, Retrier: deps.Retrier})
 	if err != nil {
 		return &schema.AgentCompleteRequest{
 			StopReason: schema.AgentCompleteReasonError,

--- a/pkg/llm/chat.go
+++ b/pkg/llm/chat.go
@@ -16,6 +16,9 @@ import (
 
 const defaultMaxToolIterations = 10
 
+// finalTurnNudge is appended to the final budegeted tool response delivered.
+const finalTurnNudge = "Tool budget exhausted: this is the final turn. Do not call more tools. Respond now with your conclusion from the information already gathered."
+
 // ChatOpts provides configuration options for creating a new Chat instance.
 type ChatOpts struct {
 	// Tools defines the set of function definitions (declaration + implementation)
@@ -123,7 +126,7 @@ func (cm *Chat) SendMessageStream(ctx context.Context, parts ...*genai.Part) ite
 			return
 		}
 		currentParts := slices.Clone(parts)
-		for range cm.maxIter {
+		for i := range cm.maxIter {
 			if !yield(&genai.Content{Parts: currentParts, Role: UserRole}, nil) {
 				return
 			}
@@ -170,6 +173,10 @@ func (cm *Chat) SendMessageStream(ctx context.Context, parts ...*genai.Part) ite
 					funcResponse := implFunc(call.Args)
 					responsePart := genai.Part{FunctionResponse: &funcResponse}
 					currentParts = append(currentParts, &responsePart)
+				}
+				if i == cm.maxIter-2 {
+					// The next iteration is the last the budget allows so force a response.
+					currentParts = append(currentParts, genai.NewPartFromText(finalTurnNudge))
 				}
 				continue
 			} else if candidate.FinishReason == genai.FinishReasonStop {


### PR DESCRIPTION
Hitting the tool-loop bound errored the whole turn which lost the
iteration and proposed nothing. The second-to-last turn now tells the
model the budget is gone so it concludes from what it has gathered, and
only a model that still insists on calling tools hits the exceeded
error.

Additionally, though, we should essentially never hit this constraint
since the agent's whole purpose is to explore and test configurations
interactively, meaning it should really only ever return with a proposal
once it's confirmed functional. As such, we raise it to 250 which,
functionally, shouldn't be reached.