### PR TITLE
api: expose /infer for inference-only benchmark runs

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -201,6 +201,20 @@ func RebuildPackageInit(ctx context.Context) (*apiservice.RebuildPackageDeps, er
 	return &d, nil
 }
 
+func InferInit(ctx context.Context) (*apiservice.InferDeps, error) {
+	var d apiservice.InferDeps
+	u, err := url.Parse(*inferenceURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing inference URL")
+	}
+	runclient, err := idtoken.NewClient(ctx, *inferenceURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing inference client")
+	}
+	d.InferStub = api.StubFromHandler(runclient, u.JoinPath("infer"), inferenceservice.Infer)
+	return &d, nil
+}
+
 func CreateRebuildOpInit(ctx context.Context) (*apiservice.CreateRebuildOpDeps, error) {
 	var d apiservice.CreateRebuildOpDeps
 	var err error
@@ -349,6 +363,7 @@ func main() {
 	http.HandleFunc("/rebuild/op/create", api.Handler(CreateRebuildOpInit, apiservice.CreateRebuildOp))
 	http.HandleFunc("/rebuild/op/get", api.Handler(GetRebuildOpInit, apiservice.GetRebuildOp))
 	http.HandleFunc("/version", api.Handler(VersionInit, apiservice.Version))
+	http.HandleFunc("/infer", api.Handler(InferInit, apiservice.Infer))
 	http.HandleFunc("/runs", api.Handler(CreateRunInit, apiservice.CreateRun))
 	http.HandleFunc("/agent", api.Handler(AgentCreateInit, apiservice.AgentCreate))
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil); err != nil {

--- a/internal/api/apiservice/infer.go
+++ b/internal/api/apiservice/infer.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package apiservice
+
+import (
+	"context"
+
+	"github.com/google/oss-rebuild/pkg/act/api"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+)
+
+// InferDeps carries the inference-service stub for the standalone infer endpoint.
+type InferDeps struct {
+	InferStub api.StubFn[schema.InferenceRequest, schema.StrategyOneOf]
+}
+
+// Infer resolves a build strategy without executing a rebuild, proxying the
+// request to the inference service.
+// NOTE: This exists only as a way of exposing the inference service while
+// limiting the number of services configured to be directly invoked.
+func Infer(ctx context.Context, req schema.InferenceRequest, deps *InferDeps) (*schema.StrategyOneOf, error) {
+	return deps.InferStub(ctx, req)
+}

--- a/tools/benchmark/run/run.go
+++ b/tools/benchmark/run/run.go
@@ -42,6 +42,7 @@ type remoteExecutionService struct {
 	createOpStub api.StubFn[schema.RebuildPackageRequest, longrunning.Operation[schema.Verdict]]
 	getOpStub    api.StubFn[schema.GetOperationRequest, longrunning.Operation[schema.Verdict]]
 	versionStub  api.StubFn[schema.VersionRequest, schema.VersionResponse]
+	inferStub    api.StubFn[schema.InferenceRequest, schema.StrategyOneOf]
 }
 
 // NewRemoteExecutionService creates a new service for remote API execution.
@@ -50,6 +51,7 @@ func NewRemoteExecutionService(client *http.Client, baseURL *url.URL) ExecutionS
 		createOpStub: api.Stub[schema.RebuildPackageRequest, longrunning.Operation[schema.Verdict]](client, baseURL.JoinPath("rebuild", "op", "create")),
 		getOpStub:    api.Stub[schema.GetOperationRequest, longrunning.Operation[schema.Verdict]](client, baseURL.JoinPath("rebuild", "op", "get")),
 		versionStub:  api.Stub[schema.VersionRequest, schema.VersionResponse](client, baseURL.JoinPath("version")),
+		inferStub:    api.Stub[schema.InferenceRequest, schema.StrategyOneOf](client, baseURL.JoinPath("infer")),
 	}
 }
 
@@ -83,7 +85,7 @@ func (s *remoteExecutionService) RebuildPackage(ctx context.Context, req schema.
 }
 
 func (s *remoteExecutionService) Infer(ctx context.Context, req schema.InferenceRequest) (*schema.StrategyOneOf, error) {
-	return nil, errors.New("not implemented")
+	return s.inferStub(ctx, req)
 }
 
 func (s *remoteExecutionService) Warmup(ctx context.Context) {


### PR DESCRIPTION
run-bench's infer mode had a stubbed, unimplemented remote path and no
viable path that exposed the remote inference service. This change
exposes /infer from api so as to minimize changes necessary to
client-side configuration and IAM settings.