### PR TITLE
pypi: cap inferred setuptools pins at registry_time

### DIFF
--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -192,19 +192,18 @@ func inferRequirements(name, version string, zr *zip.Reader) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "[INTERNAL] Failed to extract upstream %s", metadataPath)
 	}
+	// NOTE: These version ceilings pin with <= rather than == as timewarp will
+	// fail to resolve equality constraints where registry_time is configured
+	// before that version's release (which has been observed).
 	switch {
 	case !bytes.Contains(metadata, []byte("License-File")):
-		// The License-File value was introduced in later versions so this is the
-		// most recent version it could be.
-		reqs = append(reqs, "setuptools==56.2.0")
+		// License-File was introduced in later versions, bounding this above.
+		reqs = append(reqs, "setuptools<=56.2.0")
 	case bytes.Contains(metadata, []byte("Platform: UNKNOWN")):
-		// In later versions, unknown platform is omitted. If we see this pattern, it's an older version
-		// of setup tools.
-		// TODO: There's probably a more specific version where this behavior changed. I just chose the
-		// first version I found that worked.
-		reqs = append(reqs, "setuptools==57.5.0")
+		// Later versions omit the unknown platform, so this is an older setuptools.
+		reqs = append(reqs, "setuptools<=57.5.0")
 	default:
-		reqs = append(reqs, "setuptools==67.7.2")
+		reqs = append(reqs, "setuptools<=67.7.2")
 	}
 	return reqs, nil
 }


### PR DESCRIPTION
Pin the setuptools version-detection ceilings with <= rather than ==.
The build index is timewarp'd to the package's registry_time, so <=
resolves to the newest release at or below the ceiling that existed
then, which is always installable. == overshoots for packages that
predate the ceiling version and, unlike npm, pip's timewarp impl will
refuse to resolve it.

Measured on a small representative sample of tracked package versions,
this raises the deterministic rebuild success rate from roughly 51% to
61% and lowers the build-failure rate from roughly 41% to 30%.