### PR TITLE
pypi: build with a modern PEP 517 frontend

### DIFF
--- a/pkg/rebuild/pypi/strategy.go
+++ b/pkg/rebuild/pypi/strategy.go
@@ -145,9 +145,8 @@ var toolkit = []*flow.Tool{
 		Name: "pypi/install-deps",
 		Steps: []flow.Step{{
 			Runs: textwrap.Dedent(`
-				{{.With.locator}}pip install build
-				{{- range $req := .With.requirements | fromJSON}}
-				{{$.With.locator}}pip install '{{regexReplace $req "'" "'\\''"}}'{{end}}`)[1:],
+				{{range $i, $req := .With.requirements | fromJSON}}{{if $i}}
+				{{end}}{{$.With.locator}}pip install '{{regexReplace $req "'" "'\\''"}}'{{end}}`)[1:],
 		}},
 	},
 
@@ -162,6 +161,12 @@ var toolkit = []*flow.Tool{
 					"path":          "{{.With.venv}}",
 					"pythonVersion": "{{.With.pythonVersion}}",
 				},
+			},
+			{
+				// Fetch the PEP 517 frontend from the real index, before timewarp.
+				// The frontend doesn't impact the output and contemporary
+				// versions lacked CLI flags and features we use.
+				Runs: "{{.With.venv}}/bin/pip install build",
 			},
 			{
 				Uses: "pypi/setup-registry",

--- a/pkg/rebuild/pypi/strategy_test.go
+++ b/pkg/rebuild/pypi/strategy_test.go
@@ -88,8 +88,8 @@ func TestPureWheelBuild(t *testing.T) {
 				Location: defaultLocation,
 				Source:   "git checkout --force 'the_ref'",
 				Deps: `/usr/bin/python3 -m venv /deps
-export PIP_INDEX_URL=http://pypi:2006-01-02T03:04:05Z@orange/simple
-/deps/bin/pip install build`,
+/deps/bin/pip install build
+export PIP_INDEX_URL=http://pypi:2006-01-02T03:04:05Z@orange/simple`,
 				Build: "/deps/bin/python3 -m build --wheel -n the_dir",
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "python3", "uv"},
@@ -228,8 +228,8 @@ func TestSourceDistBuild(t *testing.T) {
 				Location: defaultLocation,
 				Source:   "git checkout --force 'the_ref'",
 				Deps: `/usr/bin/python3 -m venv /deps
-export PIP_INDEX_URL=http://pypi:2006-01-02T03:04:05Z@orange/simple
-/deps/bin/pip install build`,
+/deps/bin/pip install build
+export PIP_INDEX_URL=http://pypi:2006-01-02T03:04:05Z@orange/simple`,
 				Build: "/deps/bin/python3 -m build --sdist -n the_dir",
 				Requires: rebuild.RequiredEnv{
 					SystemDeps: []string{"git", "python3", "uv"},

--- a/tools/ctl/command/annotateinferencediff/diff.go
+++ b/tools/ctl/command/annotateinferencediff/diff.go
@@ -280,6 +280,13 @@ func normalizePipInstalls(script string) string {
 	for _, ln := range lines {
 		prefix, args, ok := splitPipInstall(ln)
 		if !ok {
+			// An export must not split a pip install run: emitted above the
+			// collapsed block, old (export-first) and new (build-first)
+			// scripts annotate identically.
+			if blockPrefix != "" && strings.HasPrefix(strings.TrimSpace(ln), "export ") {
+				out = append(out, ln)
+				continue
+			}
 			flushBlock()
 			out = append(out, ln)
 			continue


### PR DESCRIPTION
Install the build frontend from the real index before pointing pip at the
timewarp'd historical index. The frontend does not empirically impact
reproducibility. So the backend selection, defined by timewarp'd
requirement constraints, determines the output shape.

Notably, an older build package lacked --no-isolation (the -n short form
arrived in build 0.7.0), so timewarping the frontend failed pre-2021
packages. This approach mirrors npm fetching its modern CLI while still
timewarping dependencies.

Measured on a small representative sample of tracked package versions, this
raises the deterministic rebuild success rate from roughly 61% to 67% and lowers
the build-failure rate from roughly 30% to 23%.