### PR TITLE
signals: add the published signal database

### DIFF
--- a/internal/signals/doc.go
+++ b/internal/signals/doc.go
@@ -10,7 +10,12 @@
 // ecosystem. We define it as "how many other packages depend on this one,
 // directly or transitively," measured both per package and per version.
 //
-// This package holds the record types, the scoring, and the exports' storage.
-// The jobs that produce and consume the exports live in
-// tools/ctl/command/onboard.
+// The exports are also assembled into a published SQLite database, read by
+// enqueue and by the snapshot. Unlike the snapshot's doc tables, its rows are
+// plain columns with no raw document: the exports are the raw record and the
+// database is regenerable from them, so per-row JSON would only triple the
+// file (measured 183 vs 55 bytes per row at 10^6-package scale).
+//
+// This package holds the record types, the scoring, and that database. The
+// jobs that produce and consume the exports live in tools/ctl/command/onboard.
 package signals

--- a/internal/signals/join.go
+++ b/internal/signals/join.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+// PackageSignal is the read-time join of the priority exports for one
+// package: each signal's raw measure and normalized score, plus the
+// combined Score.
+type PackageSignal struct {
+	Ecosystem  string
+	Package    string
+	Dependents int64   // distinct packages depending on this one, directly or transitively
+	Prevalence float64 // Dependents on a log scale against the ecosystem's top package, in (0,1]
+	Score      float64 // combined priority across the signals present
+}
+
+// JoinSignals folds the package-level rows of the priority exports into
+// one PackageSignal per (ecosystem, package). Version-level prevalence
+// rows are skipped: the join is the per-package view, and version
+// specialization happens where a version is in hand.
+func JoinSignals(prevs []PrevalenceRecord) []PackageSignal {
+	type key struct{ eco, pkg string }
+	idx := make(map[key]int)
+	var out []PackageSignal
+	at := func(eco, pkg string) int {
+		k := key{eco, pkg}
+		if i, ok := idx[k]; ok {
+			return i
+		}
+		idx[k] = len(out)
+		out = append(out, PackageSignal{Ecosystem: eco, Package: pkg})
+		return len(out) - 1
+	}
+	for _, r := range prevs {
+		if r.Version != "" {
+			continue
+		}
+		i := at(r.Ecosystem, r.Package)
+		out[i].Dependents, out[i].Prevalence = r.Dependents, r.Prevalence
+	}
+	for i := range out {
+		// Prevalence is the only signal so far, so it is the score.
+		out[i].Score = out[i].Prevalence
+	}
+	return out
+}

--- a/internal/signals/join_test.go
+++ b/internal/signals/join_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestJoinSignals(t *testing.T) {
+	got := JoinSignals(
+		[]PrevalenceRecord{
+			{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8},
+			// Version-level rows never join: the merge is per package.
+			{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Dependents: 40, Prevalence: 0.75},
+			{Ecosystem: "pypi", Package: "pkgB", Dependents: 10, Prevalence: 0.4},
+		},
+	)
+	want := []PackageSignal{
+		{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8, Score: 0.8},
+		{Ecosystem: "pypi", Package: "pkgB", Dependents: 10, Prevalence: 0.4, Score: 0.4},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("JoinSignals mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/signals/signals.go
+++ b/internal/signals/signals.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/ncruces/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+// SchemaVersion identifies the signal database layout. Bump it on any
+// change that would mislead an older reader, cutting consumers over by
+// artifact name as with the snapshot database.
+const SchemaVersion = 1
+
+// Object is the destination object name of the signal database, stored
+// gzip-compressed as its name says. The name is stable within an era: each
+// publish replaces it wholesale.
+var Object = fmt.Sprintf("signals-v%d.db.gz", SchemaVersion)
+
+// Table names in the signal database.
+const (
+	TablePackageSignals = "package_signals"
+	TableVersionSignals = "version_signals"
+)
+
+const schema = `
+CREATE TABLE package_signals(
+	ecosystem TEXT NOT NULL, package TEXT NOT NULL,
+	dependents INTEGER NOT NULL, prevalence REAL NOT NULL, score REAL NOT NULL,
+	PRIMARY KEY(ecosystem, package)) WITHOUT ROWID;
+CREATE TABLE version_signals(
+	ecosystem TEXT NOT NULL, package TEXT NOT NULL, version TEXT NOT NULL,
+	dependents INTEGER NOT NULL, prevalence REAL NOT NULL,
+	PRIMARY KEY(ecosystem, package, version)) WITHOUT ROWID;
+CREATE INDEX package_signals_score ON package_signals(ecosystem, score);
+CREATE TABLE signal_meta(built_at TEXT, tool_version TEXT);
+`
+
+// Meta is the single-row provenance record of a signal database, stored in
+// its signal_meta table. The schema era lives in the file header instead
+// (sqlitex.Version).
+type Meta struct {
+	BuiltAt     time.Time // when the build began
+	ToolVersion string    // builder binary version
+}
+
+// ReadMeta loads the database's meta row.
+func ReadMeta(db *sqlite3.Conn) (Meta, error) {
+	var m Meta
+	stmt, _, err := db.Prepare("SELECT built_at, tool_version FROM signal_meta")
+	if err != nil {
+		return m, errors.Wrap(err, "preparing signal_meta read")
+	}
+	defer stmt.Close()
+	if !stmt.Step() {
+		if err := stmt.Err(); err != nil {
+			return m, errors.Wrap(err, "reading signal_meta")
+		}
+		return m, errors.New("signal_meta is empty")
+	}
+	if stmt.ColumnType(0) != sqlite3.NULL {
+		if m.BuiltAt, err = time.Parse(sqlitex.TimeFormat, stmt.ColumnText(0)); err != nil {
+			return m, errors.Wrap(err, "parsing signal_meta built_at")
+		}
+	}
+	m.ToolVersion = stmt.ColumnText(1)
+	return m, nil
+}
+
+// Build writes a signal database at path from the priority exports:
+// package rows joined per package via JoinSignals and one
+// version_signals row per version-level prevalence record. Returns
+// per-table row counts.
+func Build(path string, prevs []PrevalenceRecord, meta Meta) (map[string]int, error) {
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating database")
+	}
+	defer db.Close()
+	if err := db.Exec(schema); err != nil {
+		return nil, errors.Wrap(err, "creating schema")
+	}
+	if err := sqlitex.SetVersion(db, SchemaVersion); err != nil {
+		return nil, err
+	}
+	if err := db.Exec("BEGIN"); err != nil {
+		return nil, err
+	}
+	pkgs := JoinSignals(prevs)
+	pstmt, _, err := db.Prepare("INSERT INTO package_signals VALUES(?,?,?,?,?)")
+	if err != nil {
+		return nil, err
+	}
+	defer pstmt.Close()
+	for _, s := range pkgs {
+		pstmt.BindText(1, s.Ecosystem)
+		pstmt.BindText(2, s.Package)
+		pstmt.BindInt64(3, s.Dependents)
+		pstmt.BindFloat(4, s.Prevalence)
+		pstmt.BindFloat(5, s.Score)
+		if err := pstmt.Exec(); err != nil {
+			return nil, errors.Wrap(err, "inserting package signal")
+		}
+	}
+	vstmt, _, err := db.Prepare("INSERT INTO version_signals VALUES(?,?,?,?,?)")
+	if err != nil {
+		return nil, err
+	}
+	defer vstmt.Close()
+	versions := 0
+	for _, r := range prevs {
+		if r.Version == "" {
+			continue
+		}
+		versions++
+		vstmt.BindText(1, r.Ecosystem)
+		vstmt.BindText(2, r.Package)
+		vstmt.BindText(3, r.Version)
+		vstmt.BindInt64(4, r.Dependents)
+		vstmt.BindFloat(5, r.Prevalence)
+		if err := vstmt.Exec(); err != nil {
+			return nil, errors.Wrap(err, "inserting version signal")
+		}
+	}
+	mstmt, _, err := db.Prepare("INSERT INTO signal_meta VALUES(?,?)")
+	if err != nil {
+		return nil, err
+	}
+	defer mstmt.Close()
+	if meta.BuiltAt.IsZero() {
+		mstmt.BindNull(1)
+	} else {
+		mstmt.BindText(1, sqlitex.TimeColumn(meta.BuiltAt))
+	}
+	mstmt.BindText(2, meta.ToolVersion)
+	if err := mstmt.Exec(); err != nil {
+		return nil, errors.Wrap(err, "writing signal_meta")
+	}
+	if err := db.Exec("COMMIT"); err != nil {
+		return nil, err
+	}
+	return map[string]int{TablePackageSignals: len(pkgs), TableVersionSignals: versions}, nil
+}
+
+// PackageSignals reads every package row from an opened signal database.
+func PackageSignals(db *sqlite3.Conn) ([]PackageSignal, error) {
+	stmt, _, err := db.Prepare(`SELECT ecosystem, package, dependents, prevalence, score
+		FROM package_signals ORDER BY ecosystem, package`)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	var out []PackageSignal
+	for stmt.Step() {
+		out = append(out, PackageSignal{
+			Ecosystem:  stmt.ColumnText(0),
+			Package:    stmt.ColumnText(1),
+			Dependents: stmt.ColumnInt64(2),
+			Prevalence: stmt.ColumnFloat(3),
+			Score:      stmt.ColumnFloat(4),
+		})
+	}
+	return out, stmt.Err()
+}
+
+// Fetch downloads the signal database published under dest into dir and
+// returns its local path, refusing a database from a different schema era.
+func Fetch(dest billy.Basic, dir string) (string, error) {
+	path := filepath.Join(dir, "signals.db")
+	if err := sqlitex.Fetch(dest, Object, path); err != nil {
+		return "", errors.Wrapf(err, "downloading %s", Object)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		return "", errors.Wrap(err, "opening signal database")
+	}
+	defer db.Close()
+	if err := sqlitex.CheckVersion(db, SchemaVersion); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/signals/signals_test.go
+++ b/internal/signals/signals_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/ncruces/go-sqlite3"
+)
+
+var testPrevs = []PrevalenceRecord{
+	{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8},
+	{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Dependents: 60, Prevalence: 0.75},
+	{Ecosystem: "pypi", Package: "pkgA", Version: "2.0", Dependents: 40, Prevalence: 0.6},
+	{Ecosystem: "npm", Package: "pkgB", Dependents: 10, Prevalence: 0.4},
+}
+
+// publish builds a signal database from prevs at version and publishes it
+// under Object in a fresh in-memory destination.
+func publish(t *testing.T, prevs []PrevalenceRecord, version int) billy.Filesystem {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "built.db")
+	if _, err := Build(path, prevs, Meta{}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := sqlitex.SetVersion(db, version); err != nil {
+		t.Fatalf("SetVersion: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	dest := memfs.New()
+	if err := sqlitex.Publish(dest, Object, path); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	return dest
+}
+
+func TestBuildAndReadBack(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "signals.db")
+	built := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	counts, err := Build(path, testPrevs, Meta{BuiltAt: built, ToolVersion: "v-test"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if counts[TablePackageSignals] != 2 || counts[TableVersionSignals] != 2 {
+		t.Errorf("counts = %v, want 2 packages and 2 versions", counts)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	got, err := PackageSignals(db)
+	if err != nil {
+		t.Fatalf("PackageSignals: %v", err)
+	}
+	want := []PackageSignal{
+		{Ecosystem: "npm", Package: "pkgB", Dependents: 10, Prevalence: 0.4, Score: 0.4},
+		{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8, Score: 0.8},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("package rows mismatch (-want +got):\n%s", diff)
+	}
+	meta, err := ReadMeta(db)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+	if !meta.BuiltAt.Equal(built) || meta.ToolVersion != "v-test" {
+		t.Errorf("meta = %+v, want built %v by v-test", meta, built)
+	}
+	if v, err := sqlitex.Version(db); err != nil || v != SchemaVersion {
+		t.Errorf("schema version = (%d, %v), want %d", v, err, SchemaVersion)
+	}
+}
+
+func TestFetchRoundTrip(t *testing.T) {
+	dest := publish(t, testPrevs, SchemaVersion)
+	path, err := Fetch(dest, t.TempDir())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	got, err := PackageSignals(db)
+	if err != nil {
+		t.Fatalf("PackageSignals: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("fetched %d package rows, want 2", len(got))
+	}
+}
+
+func TestFetchRefusesOtherEra(t *testing.T) {
+	dest := publish(t, nil, SchemaVersion+1)
+	if _, err := Fetch(dest, t.TempDir()); err == nil {
+		t.Error("Fetch accepted a database from a different schema era")
+	}
+}


### PR DESCRIPTION
The signal database is a SQLite file assembled from the ranked priority
exports and published alongside the snapshot db: one package_signals row
per package carrying each signal's raw measure, its normalized score,
and the combined score, and one version_signals row per version-level
prevalence record. Rows are plain columns with no raw document: the
exports are the raw record and the database is regenerable from them.
Prevalence is the only signal so far, so its score is the combined
score.