### PR TITLE
snapshot: merge in signals

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -70,6 +70,7 @@ var (
 	agentTimeoutSeconds   = flag.Int("agent-timeout-seconds", 3600, "Seconds to allow agent to run")
 	rebuildJobName        = flag.String("rebuild-job-name", "", "Name of the pre-created Cloud Run Job for rebuilds")
 	analyticsURI          = flag.String("analytics-uri", "", "URI for snapshots (supported schemes: gs, file). Empty disables the /snapshot endpoints")
+	signalsDBURI          = flag.String("signals-db-uri", "", "URI the signal database publishes under, ingested at rollup (supported schemes: gs, file). Empty skips signal ingest")
 	port                  = flag.Int("port", 8080, "port on which to serve")
 )
 
@@ -368,6 +369,11 @@ func SnapshotRollupInit(ctx context.Context) (*snapshotservice.RollupDeps, error
 	src, err := snapshot.NewFirestoreSource(ctx, *project)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating snapshot source")
+	}
+	if *signalsDBURI != "" {
+		if src.SignalsDB, err = billyx.NewResolver().DirFS(ctx, *signalsDBURI); err != nil {
+			return nil, err
+		}
 	}
 	dest, err := analyticsDest(ctx)
 	if err != nil {

--- a/internal/api/snapshotservice/rollup_test.go
+++ b/internal/api/snapshotservice/rollup_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"google.golang.org/grpc/codes"
@@ -36,6 +37,7 @@ func (f *fakeSource) Execs(context.Context, time.Time) ([]schema.ScratchExec, er
 func (f *fakeSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
 	return nil, nil
 }
+func (f *fakeSource) Signals(context.Context) ([]signals.PackageSignal, error) { return nil, nil }
 
 func TestRollupUnconfigured(t *testing.T) {
 	_, err := Rollup(context.Background(), RollupRequest{}, &RollupDeps{})

--- a/internal/rundex/sqlite_test.go
+++ b/internal/rundex/sqlite_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/internal/sqlitex"
 	"github.com/google/oss-rebuild/pkg/feed"
@@ -46,6 +47,9 @@ func (s *snapshotSource) Execs(context.Context, time.Time) ([]schema.ScratchExec
 	return nil, nil
 }
 func (s *snapshotSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
+	return nil, nil
+}
+func (s *snapshotSource) Signals(context.Context) ([]signals.PackageSignal, error) {
 	return nil, nil
 }
 

--- a/internal/snapshot/saturation_test.go
+++ b/internal/snapshot/saturation_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/docdb"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/ncruces/go-sqlite3"
 )
@@ -121,6 +122,7 @@ func TestSaturatedDocumentFillsEveryColumn(t *testing.T) {
 		"scratch_vms":      saturated[schema.Scratch](),
 		"scratch_execs":    saturated[schema.ScratchExec](),
 		"repo_metrics":     saturated[schema.RepoMetrics](),
+		"package_signals":  saturated[signals.PackageSignal](),
 	}
 	db, err := sqlite3.Open(":memory:")
 	if err != nil {
@@ -192,6 +194,7 @@ func TestSkeletonDocumentsKeepGuardedColumnsDefined(t *testing.T) {
 		"scratch_vms":      `{"id":"sc1"}`,
 		"scratch_execs":    `{"id":"e1"}`,
 		"repo_metrics":     `{"uri":"u"}`,
+		"package_signals":  `{"Ecosystem":"pypi","Package":"p"}`,
 	}
 	db, err := sqlite3.Open(":memory:")
 	if err != nil {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/google/oss-rebuild/internal/docdb"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/ncruces/go-sqlite3"
 	"github.com/pkg/errors"
 )
@@ -112,6 +114,11 @@ func Rollup(ctx context.Context, src Source, dest billy.Filesystem, opts Options
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning repo metrics")
 	}
+	sigs, err := src.Signals(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading priority signals")
+	}
+	sigs = pruneSignals(sigs, attempts)
 	docTables := map[string][]json.RawMessage{
 		TableAttempts:        docsOf(attempts),
 		TableRuns:            docsOf(runs),
@@ -120,6 +127,7 @@ func Rollup(ctx context.Context, src Source, dest billy.Filesystem, opts Options
 		TableScratchVMs:      docsOf(scratches),
 		TableScratchExecs:    docsOf(execs),
 		TableRepoMetrics:     docsOf(repoMetrics),
+		TablePackageSignals:  docsOf(sigs),
 	}
 	meta := Meta{
 		BuiltAt:       now,
@@ -141,6 +149,26 @@ func Rollup(ctx context.Context, src Source, dest billy.Filesystem, opts Options
 		return nil, errors.Wrap(err, "uploading snapshot")
 	}
 	return &RollupResult{Meta: meta, RowCounts: counts}, nil
+}
+
+// pruneSignals keeps only signals for packages the snapshot itself carries:
+// those with an attempt. The signal exports cover the registry universe, so
+// without this package_signals would scale with the registry rather than
+// with coverage. Presence in this database is the rollup's only notion of a
+// tracked package.
+func pruneSignals(sigs []signals.PackageSignal, attempts []schema.RebuildAttempt) []signals.PackageSignal {
+	type key struct{ eco, pkg string }
+	tracked := make(map[key]bool)
+	for _, a := range attempts {
+		tracked[key{a.Ecosystem, a.Package}] = true
+	}
+	var kept []signals.PackageSignal
+	for _, s := range sigs {
+		if tracked[key{s.Ecosystem, s.Package}] {
+			kept = append(kept, s)
+		}
+	}
+	return kept
 }
 
 // buildSnapshotDB writes every registry table plus the database meta to a

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/sqlitex"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
@@ -29,6 +30,7 @@ type fakeSource struct {
 	scratches   []schema.Scratch
 	execs       []schema.ScratchExec
 	repoMetrics []schema.RepoMetrics
+	signals     []signals.PackageSignal
 }
 
 func (f *fakeSource) Attempts(_ context.Context, since time.Time) ([]schema.RebuildAttempt, error) {
@@ -50,6 +52,9 @@ func (f *fakeSource) Execs(context.Context, time.Time) ([]schema.ScratchExec, er
 }
 func (f *fakeSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
 	return f.repoMetrics, nil
+}
+func (f *fakeSource) Signals(context.Context) ([]signals.PackageSignal, error) {
+	return f.signals, nil
 }
 
 // openPublished fetches the snapshot database dest holds and opens it.
@@ -193,4 +198,30 @@ func TestMetaRoundTrip(t *testing.T) {
 		t.Errorf("rewritten meta = (%+v, %v), want zero watermark", got, err)
 	}
 	assertCount(t, db, "SELECT count(*) FROM snapshot_meta", "1")
+}
+
+func TestRollupPrunesSignalsToTrackedPackages(t *testing.T) {
+	ctx := context.Background()
+	dest := memfs.New()
+	src := &fakeSource{
+		attempts: []schema.RebuildAttempt{
+			attempt("pypi", "pkgA", "1.0", "r1", true, schema.RebuildStatusSuccess, at(0)),
+		},
+		signals: []signals.PackageSignal{
+			{Ecosystem: "pypi", Package: "pkgA", Score: 0.9},   // attempted
+			{Ecosystem: "pypi", Package: "famous", Score: 1.0}, // untracked
+		},
+	}
+	res, err := Rollup(ctx, src, dest, Options{Now: time.Date(2026, 7, 14, 15, 4, 5, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("Rollup: %v", err)
+	}
+	// The exports cover the registry universe. Only the packages this
+	// database carries keep their signals.
+	if got := res.RowCounts[TablePackageSignals]; got != 1 {
+		t.Errorf("package_signals count = %d, want 1", got)
+	}
+	db := openPublished(t, dest)
+	assertCount(t, db, "SELECT count(*) FROM package_signals WHERE package='famous'", "0")
+	assertCount(t, db, "SELECT count(*) FROM package_signals WHERE package='pkgA' AND score=0.9", "1")
 }

--- a/internal/snapshot/source.go
+++ b/internal/snapshot/source.go
@@ -5,11 +5,15 @@ package snapshot
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/go-git/go-billy/v5"
 	"github.com/google/oss-rebuild/internal/iterx"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/ncruces/go-sqlite3"
 	"github.com/pkg/errors"
 	"google.golang.org/api/iterator"
 )
@@ -17,7 +21,9 @@ import (
 // Source is the read side of the snapshot pipelines: each scan yields the
 // records written at or after the given watermark, and FullScan yields
 // every record. Scanning is isolated behind this interface so the
-// derivations can be tested with in-memory fixtures.
+// derivations can be tested with in-memory fixtures. Signals takes no
+// watermark: the priority exports are rewritten whole at job cadence, so
+// they are rollup-only and have no delta path.
 type Source interface {
 	Attempts(context.Context, time.Time) ([]schema.RebuildAttempt, error)
 	Runs(context.Context, time.Time) ([]schema.Run, error)
@@ -26,6 +32,7 @@ type Source interface {
 	Scratches(context.Context, time.Time) ([]schema.Scratch, error)
 	Execs(context.Context, time.Time) ([]schema.ScratchExec, error)
 	RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error)
+	Signals(context.Context) ([]signals.PackageSignal, error)
 }
 
 // FullScan is the zero watermark: a scan given it reads every record.
@@ -38,6 +45,10 @@ var FullScan time.Time
 // potentially via BigQuery.
 type FirestoreSource struct {
 	client *firestore.Client
+	// SignalsDB is the filesystem the signal database publishes under.
+	// Optional: nil yields no signal rows, so a rollup stays runnable
+	// before the first publish.
+	SignalsDB billy.Filesystem
 }
 
 var _ Source = (*FirestoreSource)(nil)
@@ -134,4 +145,32 @@ func (s *FirestoreSource) Execs(ctx context.Context, since time.Time) ([]schema.
 
 func (s *FirestoreSource) RepoMetrics(ctx context.Context, since time.Time) ([]schema.RepoMetrics, error) {
 	return scanQuery[schema.RepoMetrics](ctx, sinceQuery(s.client.Collection("repo_metrics").Query, "updated", since))
+}
+
+// Signals reads the priority signals from the published signal database.
+func (s *FirestoreSource) Signals(context.Context) ([]signals.PackageSignal, error) {
+	return readSignals(s.SignalsDB)
+}
+
+// readSignals fetches the published signal database and reads its package
+// rows. A nil filesystem yields no rows.
+func readSignals(dest billy.Filesystem) ([]signals.PackageSignal, error) {
+	if dest == nil {
+		return nil, nil
+	}
+	dir, err := os.MkdirTemp("", "signals-fetch-")
+	if err != nil {
+		return nil, errors.Wrap(err, "creating fetch directory")
+	}
+	defer os.RemoveAll(dir)
+	path, err := signals.Fetch(dest, dir)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching signal database")
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening signal database")
+	}
+	defer db.Close()
+	return signals.PackageSignals(db)
 }

--- a/internal/snapshot/source_test.go
+++ b/internal/snapshot/source_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/signals"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+)
+
+func TestReadSignals(t *testing.T) {
+	built := filepath.Join(t.TempDir(), "signals.db")
+	if _, err := signals.Build(built,
+		[]signals.PrevalenceRecord{
+			{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8},
+			// Version rows publish but only package rows reach the snapshot.
+			{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Dependents: 60, Prevalence: 0.75},
+		},
+		signals.Meta{}); err != nil {
+		t.Fatalf("building signal database: %v", err)
+	}
+	pub := memfs.New()
+	if err := sqlitex.Publish(pub, signals.Object, built); err != nil {
+		t.Fatalf("publishing signal database: %v", err)
+	}
+	got, err := readSignals(pub)
+	if err != nil {
+		t.Fatalf("readSignals: %v", err)
+	}
+	want := []signals.PackageSignal{
+		{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8, Score: 0.8},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("signals mismatch (-want +got):\n%s", diff)
+	}
+	if empty, err := readSignals(nil); err != nil || empty != nil {
+		t.Errorf("readSignals(nil) = (%v, %v), want no rows and no error", empty, err)
+	}
+}

--- a/internal/snapshot/tables.go
+++ b/internal/snapshot/tables.go
@@ -32,6 +32,7 @@ const (
 	TableScratchVMs       = "scratch_vms"
 	TableScratchExecs     = "scratch_execs"
 	TableRepoMetrics      = "repo_metrics"
+	TablePackageSignals   = "package_signals"
 	TableCostObservations = "cost_observations"
 	TableEcosystemDaily   = "ecosystem_daily"
 )
@@ -309,6 +310,19 @@ func Tables() []docdb.TableDef {
 				{Name: "bytes", Type: "INTEGER", Expr: docdb.Raw("$.bytes")},
 				{Name: "commits", Type: "INTEGER", Expr: docdb.Raw("$.commits")},
 				{Name: "head", Type: "TEXT", Expr: docdb.Raw("$.head")},
+			},
+		},
+		{
+			Name: TablePackageSignals,
+			Cols: []docdb.Col{
+				{Name: "ecosystem", Type: "TEXT", Expr: docdb.Doc("$.Ecosystem")},
+				{Name: "package", Type: "TEXT", Expr: docdb.Doc("$.Package")},
+			},
+			PK: []string{"ecosystem", "package"},
+			GenCols: []docdb.GenCol{
+				{Name: "dependents", Type: "INTEGER", Expr: docdb.Raw("$.Dependents")},
+				{Name: "prevalence", Type: "REAL", Expr: docdb.Raw("$.Prevalence")},
+				{Name: "score", Type: "REAL", Expr: docdb.Raw("$.Score"), Stored: true},
 			},
 		},
 		{Name: TableCostObservations, Query: costObservationsQuery, Indexes: [][]string{{"ecosystem", "package"}, {"source"}, {"timestamp"}}},

--- a/internal/snapshot/tables_test.go
+++ b/internal/snapshot/tables_test.go
@@ -89,6 +89,7 @@ func fill(t *testing.T, src *fakeSource) (*sqlite3.Conn, map[string]int) {
 		TableScratchVMs:      docsOf(src.scratches),
 		TableScratchExecs:    docsOf(src.execs),
 		TableRepoMetrics:     docsOf(src.repoMetrics),
+		TablePackageSignals:  docsOf(src.signals),
 	}, Meta{BuiltAt: at(time.Hour)})
 	if err != nil {
 		t.Fatalf("fillSnapshotDB: %v", err)

--- a/internal/snapshot/testdata/schema_v1.json
+++ b/internal/snapshot/testdata/schema_v1.json
@@ -111,6 +111,14 @@
     "successes": "",
     "tokens": ""
   },
+  "package_signals": {
+    "dependents": "INTEGER",
+    "ecosystem": "TEXT pk=1",
+    "package": "TEXT pk=2",
+    "prevalence": "REAL",
+    "raw": "TEXT",
+    "score": "REAL"
+  },
   "repo_metrics": {
     "bytes": "INTEGER",
     "commits": "INTEGER",


### PR DESCRIPTION
Rollups fetch the published signal database and carry one
package_signals row per tracked package: each signal's raw measure, its
per-ecosystem score, and the combined score, extracted from the
PackageSignal document. Signals don't have a watermark (exports are
rewritten whole) so they are rollup-only and have no deltas. The rows
are filtered to packages the snapshot itself carries, since the exports
cover the registry universe while we only care about covered packages.