### PR TITLE
dashboard: add coverage page

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -70,6 +70,7 @@ var (
 	agentTimeoutSeconds   = flag.Int("agent-timeout-seconds", 3600, "Seconds to allow agent to run")
 	rebuildJobName        = flag.String("rebuild-job-name", "", "Name of the pre-created Cloud Run Job for rebuilds")
 	analyticsURI          = flag.String("analytics-uri", "", "URI for snapshots (supported schemes: gs, file). Empty disables the /snapshot endpoints")
+	signalsDBURI          = flag.String("signals-db-uri", "", "URI the signal database publishes under, ingested at rollup (supported schemes: gs, file). Empty skips signal ingest")
 	port                  = flag.Int("port", 8080, "port on which to serve")
 )
 
@@ -368,6 +369,11 @@ func SnapshotRollupInit(ctx context.Context) (*snapshotservice.RollupDeps, error
 	src, err := snapshot.NewFirestoreSource(ctx, *project)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating snapshot source")
+	}
+	if *signalsDBURI != "" {
+		if src.SignalsDB, err = billyx.NewResolver().DirFS(ctx, *signalsDBURI); err != nil {
+			return nil, err
+		}
 	}
 	dest, err := analyticsDest(ctx)
 	if err != nil {

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -147,6 +147,7 @@ func main() {
 	http.HandleFunc("/resources", api.Translate(func(r *http.Request) (dashboard.ResourcesRequest, error) {
 		return dashboard.ResourcesRequest{Eco: r.URL.Query().Get("eco")}, nil
 	}, api.HTMLHandler(DashboardInit, api.WithTimeout(30*time.Second, dashboard.ResourcesPage), dashboard.ResourcesTmpl)))
+	http.HandleFunc("/coverage", api.HTMLHandler(DashboardInit, api.WithTimeout(30*time.Second, dashboard.CoveragePage), dashboard.CoverageTmpl))
 	http.HandleFunc("/package/{ecosystem}/{package}", api.Translate(func(r *http.Request) (dashboard.PackageRequest, error) {
 		t := encoding.New(rebuild.Ecosystem(r.PathValue("ecosystem")), r.PathValue("package"), "", "").Decode()
 		// TODO: Make this param and field name more precise.

--- a/internal/api/dashboard/coverage.gohtml
+++ b/internal/api/dashboard/coverage.gohtml
@@ -1,0 +1,135 @@
+<!--
+ Copyright 2026 Google LLC
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+<style>
+    .asof { color: var(--muted); }
+    .tabs a.active { color: var(--heading); border-bottom-color: var(--accent); }
+    .cards { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); margin-bottom: 12px; }
+    .info { display: inline-block; position: relative; margin-left: 5px; width: 1.15em; height: 1.15em; line-height: 1.15em; border-radius: 50%; border: 1px solid var(--border); background: var(--fill); color: var(--muted); font-size: 0.72rem; font-weight: 600; text-align: center; vertical-align: middle; cursor: help; }
+    .info::after { content: attr(data-tip); position: absolute; left: 50%; top: calc(100% + 6px); transform: translateX(-50%); width: max-content; max-width: 22em; padding: 6px 10px; border-radius: 4px; background: var(--heading); color: var(--bg); font-size: 0.8rem; font-weight: 400; line-height: 1.4; text-align: left; white-space: normal; visibility: hidden; z-index: 1; }
+    .info:hover::after, .info:focus-visible::after { visibility: visible; }
+    .info:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+    th.group { text-align: center; color: var(--muted); font-weight: 400; }
+    .barcell { width: 25%; min-width: 120px; }
+    .bar { background-color: var(--accent); height: 12px; border-radius: 2px; min-width: 1px; }
+</style>
+
+{{define "def"}}<span class="info" tabindex="0" data-tip="{{.}}">?</span>{{end}}
+<h2>Coverage</h2>
+{{if not .Loaded}}
+<p>No analytics snapshot loaded. Start the dashboard with
+<code>-rundex=&lt;gs://…|file://…&gt;</code>.</p>
+{{else}}
+<p class="asof">Snapshot as of {{.AsOf}}</p>
+<div class="tabs">
+    <a class="tab{{if not .Eco}} active{{end}}" href="/coverage">All</a>
+    {{$sel := .Eco}}
+    {{range .Ecos}}<a class="tab{{if eq .Ecosystem $sel}} active{{end}}" href="/coverage?eco={{.Ecosystem}}">{{.Ecosystem}}</a>
+    {{end}}
+</div>
+{{if not .Detail}}
+{{if not .Ecos}}
+<p>No attempts, signals, or campaigns in the snapshot.</p>
+{{else}}
+<table>
+    <tr>
+        <th></th>
+        <th class="group" colspan="5">Packages</th>
+        <th class="group" colspan="4">Campaigns{{template "def" "One campaign per package version."}}</th>
+    </tr>
+    <tr>
+        <th>Ecosystem</th>
+        <th>In scope{{template "def" "Packages the published signals rank, the onboarding goal."}}</th>
+        <th>Started{{template "def" "In scope, with a campaign or an attempt."}}</th>
+        <th>Reproduced{{template "def" "Started, and attested at the latest version attempted."}}</th>
+        <th>Coverage{{template "def" "Reproduced over in scope."}}</th>
+        <th>Weighted{{template "def" "Coverage, weighting each package by its score."}}</th>
+        <th>Queued{{template "def" "Campaigns waiting for dispatch at their next stage."}}</th>
+        <th>In flight{{template "def" "Campaigns dispatched and awaiting an outcome."}}</th>
+        <th>Needs triage{{template "def" "Campaigns whose automated stages are exhausted, awaiting a person."}}</th>
+        <th>Done{{template "def" "Campaigns attested."}}</th>
+    </tr>
+    {{range .Ecos}}
+    <tr>
+        <td><a href="/coverage?eco={{.Ecosystem}}">{{.Ecosystem}}</a></td>
+        {{if .HasScope}}
+        <td>{{.InScope}}</td>
+        <td>{{.Started}}</td>
+        <td>{{.Reproduced}}</td>
+        <td>{{.CoveragePct}}%</td>
+        <td>{{.WeightedPct}}%</td>
+        {{else}}
+        <td>&mdash;</td><td>&mdash;</td><td>&mdash;</td><td>&mdash;</td><td>&mdash;</td>
+        {{end}}
+        {{if .HasQueue}}
+        <td>{{.Queued}}</td>
+        <td>{{.InFlight}}</td>
+        <td>{{.NeedsTriage}}</td>
+        <td>{{.Done}}</td>
+        {{else}}
+        <td>&mdash;</td><td>&mdash;</td><td>&mdash;</td><td>&mdash;</td>
+        {{end}}
+    </tr>
+    {{end}}
+</table>
+{{end}}
+{{else}}
+{{with .Detail}}
+<h3>Packages</h3>
+{{if .HasScope}}
+<div class="cards">
+    <div class="card"><div class="card-value">{{.InScope}}</div><div class="card-label">in scope{{template "def" "Packages the published signals rank, the onboarding goal."}}</div></div>
+    <div class="card"><div class="card-value">{{.Started}}</div><div class="card-label">started{{template "def" "In scope, with a campaign or an attempt."}}</div></div>
+    <div class="card"><div class="card-value">{{.Reproduced}}</div><div class="card-label">reproduced{{template "def" "Started, and attested at the latest version attempted."}}</div></div>
+    <div class="card"><div class="card-value">{{.CoveragePct}}%</div><div class="card-label">coverage{{template "def" "Reproduced over in scope."}}</div></div>
+    <div class="card"><div class="card-value">{{.WeightedPct}}%</div><div class="card-label">weighted by score{{template "def" "Coverage, weighting each package by its score."}}</div></div>
+</div>
+{{else}}
+<p>No published signals for {{.Ecosystem}}, so there is no scope to measure against.</p>
+{{end}}
+<h3>Campaigns{{template "def" "One campaign per package version. Done campaigns are listed under the stage that attested them."}}</h3>
+{{if .HasQueue}}
+<div class="cards">
+    <div class="card"><div class="card-value">{{.Queued}}</div><div class="card-label">queued{{template "def" "Campaigns waiting for dispatch at their next stage."}}</div></div>
+    <div class="card"><div class="card-value">{{.InFlight}}</div><div class="card-label">in flight{{template "def" "Campaigns dispatched and awaiting an outcome."}}</div></div>
+    <div class="card"><div class="card-value">{{.NeedsTriage}}</div><div class="card-label">needs triage{{template "def" "Campaigns whose automated stages are exhausted, awaiting a person."}}</div></div>
+    {{range .DoneByStage}}<div class="card"><div class="card-value">{{.Done}}</div><div class="card-label">done at {{.Stage}}</div></div>
+    {{end}}
+</div>
+{{else}}
+<p>No campaigns for {{.Ecosystem}}.</p>
+{{end}}
+{{if .Weeks}}
+<h3>Weekly{{template "def" "Cumulative through each week over the packages attempted by then."}}</h3>
+<table>
+    <tr>
+        <th>Week</th>
+        <th>Attempted{{template "def" "Packages with an attempt by the end of the week."}}</th>
+        <th>Reproduced{{template "def" "Attested at the latest version attempted by then."}}</th>
+        <th>Behind{{template "def" "An earlier version is attested but not the latest."}}</th>
+        <th>Share{{template "def" "Reproduced over attempted, so it moves as the queue reaches harder packages."}}</th>
+        <th class="barcell"></th>
+        <th>Weighted{{template "def" "Share, weighting each package by its score."}}</th>
+        <th>Newly broken{{template "def" "Latest version failed that week where the previous one had built."}}</th>
+    </tr>
+    {{range .Weeks}}
+    <tr>
+        <td>{{.Week}}</td>
+        <td>{{.Attempted}}</td>
+        <td>{{.Reproduced}}</td>
+        <td>{{.Behind}}</td>
+        <td>{{.SharePct}}%</td>
+        <td class="barcell"><div class="bar" style="width: {{.SharePct}}%"></div></td>
+        <td>{{if .HasWeighted}}{{.WeightedPct}}%{{else}}&mdash;{{end}}</td>
+        <td>{{.NewlyBroken}}</td>
+    </tr>
+    {{end}}
+</table>
+{{end}}
+{{end}}
+{{end}}
+{{end}}
+</body>
+</html>

--- a/internal/api/dashboard/dashboard.go
+++ b/internal/api/dashboard/dashboard.go
@@ -32,6 +32,8 @@ var (
 	logsHTML string
 	//go:embed resources.gohtml
 	resourcesHTML string
+	//go:embed coverage.gohtml
+	coverageHTML string
 	//go:embed dashboard.css
 	css string
 	//go:embed theme.css
@@ -61,6 +63,7 @@ var (
 	AttemptTmpl   *template.Template
 	LogsTmpl      *template.Template
 	ResourcesTmpl *template.Template
+	CoverageTmpl  *template.Template
 )
 
 func init() {
@@ -70,6 +73,7 @@ func init() {
 	AttemptTmpl = template.Must(template.New("attempt").Parse(headerHTML + attemptHTML))
 	LogsTmpl = template.Must(template.New("logs").Parse(logsHTML))
 	ResourcesTmpl = template.Must(template.New("resources").Parse(headerHTML + resourcesHTML))
+	CoverageTmpl = template.Must(template.New("coverage").Parse(headerHTML + coverageHTML))
 }
 
 var packagePathEncoding = rebuild.FilesystemTargetEncoding

--- a/internal/api/dashboard/header.gohtml
+++ b/internal/api/dashboard/header.gohtml
@@ -18,6 +18,7 @@
 <body>
     <nav>
         <a href="/">Home</a>
+        <a href="/coverage">Coverage</a>
         <a href="/resources">Resources</a>
     </nav>
     <h1>OSS Rebuild Dashboard</h1>

--- a/internal/api/dashboard/trends.go
+++ b/internal/api/dashboard/trends.go
@@ -1,0 +1,198 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"strconv"
+
+	"github.com/google/oss-rebuild/pkg/act/api"
+	"github.com/google/oss-rebuild/pkg/scheduler"
+	"github.com/ncruces/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+// trendWeeks bounds the weekly history shown on an ecosystem tab.
+const trendWeeks = 12
+
+var _ api.HandlerFn[CoverageRequest, CoverageData, *Deps] = CoveragePage
+
+type CoverageRequest struct {
+	Eco string // ecosystem tab; empty compares every ecosystem
+}
+
+func (CoverageRequest) Validate() error { return nil }
+
+// CoverageWeek is one week of an ecosystem's funnel, cumulative over the
+// packages attempted by the end of that week.
+type CoverageWeek struct {
+	Week        string
+	Attempted   int64
+	Reproduced  int64 // attested at their latest attempted version
+	Behind      int64 // attested an earlier version but not the latest
+	SharePct    int64 // Reproduced over Attempted
+	WeightedPct int64 // the same, weighting each package by its score
+	HasWeighted bool
+	NewlyBroken int64
+}
+
+// StageDone counts the campaigns one stage attested.
+type StageDone struct {
+	Stage scheduler.Stage
+	Done  int64
+}
+
+// CoverageEco is one ecosystem's standing against the packages in scope and
+// the state of its onboarding queue. A package is in scope when the
+// published signals rank it, started once a campaign or an attempt has
+// touched it, and reproduced when its latest attempted version is attested.
+type CoverageEco struct {
+	Ecosystem   string
+	HasScope    bool // false until the ecosystem's signals are published
+	InScope     int64
+	Started     int64
+	Reproduced  int64
+	CoveragePct int64 // Reproduced over InScope
+	WeightedPct int64 // the same, weighting each package by its score
+	HasQueue    bool  // false until the ecosystem has campaigns
+	Queued      int64 // campaigns, which count package versions
+	InFlight    int64
+	NeedsTriage int64
+	Done        int64
+	DoneByStage []StageDone // ladder order, every stage present
+	Weeks       []CoverageWeek
+}
+
+type CoverageData struct {
+	Loaded bool
+	AsOf   string
+	Eco    string        // selected tab, empty is the comparison view
+	Ecos   []CoverageEco // one per ecosystem, in name order
+	Detail *CoverageEco  // the selected ecosystem with its weekly trend
+}
+
+func coverageWeekFromStmt(stmt *sqlite3.Stmt) CoverageWeek {
+	w := CoverageWeek{
+		Week:        stmt.ColumnText(0),
+		Attempted:   stmt.ColumnInt64(1),
+		Reproduced:  stmt.ColumnInt64(2),
+		Behind:      stmt.ColumnInt64(3),
+		SharePct:    int64(100 * stmt.ColumnFloat(4)),
+		NewlyBroken: stmt.ColumnInt64(6),
+	}
+	if weighted := stmt.ColumnFloat(5); weighted > 0 {
+		w.WeightedPct = int64(100 * weighted)
+		w.HasWeighted = true
+	}
+	return w
+}
+
+// ladder lists the stages cheapest first, as Stage.Next walks them.
+func ladder() []scheduler.Stage {
+	out := []scheduler.Stage{scheduler.StageReplay}
+	for s, ok := scheduler.StageReplay.Next(); ok; s, ok = s.Next() {
+		out = append(out, s)
+	}
+	return out
+}
+
+func CoveragePage(ctx context.Context, req CoverageRequest, deps *Deps) (*CoverageData, error) {
+	data := &CoverageData{}
+	if deps.Analytics == nil {
+		return data, nil
+	}
+	data.Loaded = true
+	data.AsOf = asOf(deps.Analytics)
+	byEco := map[string]*CoverageEco{}
+	eco := func(name string) *CoverageEco {
+		if byEco[name] == nil {
+			byEco[name] = &CoverageEco{Ecosystem: name}
+		}
+		return byEco[name]
+	}
+	// Ecosystems with attempts but no signals or campaigns still get a tab
+	// for their weekly funnel.
+	err := forEachRow(deps.Analytics, `SELECT DISTINCT ecosystem FROM coverage_weekly`,
+		func(stmt *sqlite3.Stmt) error {
+			eco(stmt.ColumnText(0))
+			return nil
+		})
+	if err != nil {
+		return nil, errors.Wrap(err, "querying ecosystems")
+	}
+	err = forEachRow(deps.Analytics, `
+		SELECT ecosystem, universe_packages, tracked_packages, current_packages, covered_mass_share
+		FROM signal_coverage`,
+		func(stmt *sqlite3.Stmt) error {
+			e := eco(stmt.ColumnText(0))
+			e.HasScope = true
+			e.InScope, e.Started, e.Reproduced = stmt.ColumnInt64(1), stmt.ColumnInt64(2), stmt.ColumnInt64(3)
+			if e.InScope > 0 {
+				e.CoveragePct = 100 * e.Reproduced / e.InScope
+			}
+			e.WeightedPct = int64(100 * stmt.ColumnFloat(4))
+			return nil
+		})
+	if err != nil {
+		return nil, errors.Wrap(err, "querying signal coverage")
+	}
+	doneByStage := map[string]map[scheduler.Stage]int64{}
+	err = forEachRow(deps.Analytics, `SELECT ecosystem, state, stage, count(*) FROM campaigns GROUP BY 1, 2, 3`,
+		func(stmt *sqlite3.Stmt) error {
+			e := eco(stmt.ColumnText(0))
+			e.HasQueue = true
+			n := stmt.ColumnInt64(3)
+			switch scheduler.State(stmt.ColumnText(1)) {
+			case scheduler.StateQueued:
+				e.Queued += n
+			case scheduler.StateInFlight:
+				e.InFlight += n
+			case scheduler.StateNeedsTriage:
+				e.NeedsTriage += n
+			case scheduler.StateDone:
+				// A done campaign's stage is the one that attested it.
+				e.Done += n
+				if doneByStage[e.Ecosystem] == nil {
+					doneByStage[e.Ecosystem] = map[scheduler.Stage]int64{}
+				}
+				doneByStage[e.Ecosystem][scheduler.Stage(stmt.ColumnText(2))] += n
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, errors.Wrap(err, "querying campaigns")
+	}
+	for name, e := range byEco {
+		if !e.HasQueue {
+			continue
+		}
+		for _, s := range ladder() {
+			e.DoneByStage = append(e.DoneByStage, StageDone{Stage: s, Done: doneByStage[name][s]})
+		}
+	}
+	// An unknown tab (stale link) falls back to the comparison view. The
+	// membership check also makes the interpolation below safe.
+	if e := byEco[req.Eco]; e != nil {
+		data.Eco = req.Eco
+		data.Detail = e
+		err = forEachRow(deps.Analytics, `
+			SELECT week, packages_attempted, packages_current, packages_stale,
+				coverage, coalesce(weighted_coverage, 0), newly_broken
+			FROM coverage_weekly WHERE ecosystem = '`+req.Eco+`'
+			ORDER BY week DESC LIMIT `+strconv.Itoa(trendWeeks),
+			func(stmt *sqlite3.Stmt) error {
+				e.Weeks = append(e.Weeks, coverageWeekFromStmt(stmt))
+				return nil
+			})
+		if err != nil {
+			return nil, errors.Wrap(err, "querying coverage")
+		}
+	}
+	for _, name := range slices.Sorted(maps.Keys(byEco)) {
+		data.Ecos = append(data.Ecos, *byEco[name])
+	}
+	return data, nil
+}

--- a/internal/api/dashboard/trends_test.go
+++ b/internal/api/dashboard/trends_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dashboard
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/scheduler"
+	"github.com/ncruces/go-sqlite3"
+)
+
+// memAnalytics serves one in-memory snapshot database.
+type memAnalytics struct{ db *sqlite3.Conn }
+
+func (m memAnalytics) Query(f func(*sqlite3.Conn) error) error { return f(m.db) }
+func (m memAnalytics) Freshness() time.Time                    { return time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC) }
+
+func newMemAnalytics(t *testing.T, stmts ...string) memAnalytics {
+	t.Helper()
+	db, err := sqlite3.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	for _, s := range stmts {
+		if err := db.Exec(s); err != nil {
+			t.Fatalf("exec %q: %v", s, err)
+		}
+	}
+	return memAnalytics{db}
+}
+
+func coverageFixture(t *testing.T) memAnalytics {
+	return newMemAnalytics(t,
+		`CREATE TABLE coverage_weekly (ecosystem TEXT, week TEXT, packages_attempted INT, packages_current INT, packages_stale INT, coverage REAL, weighted_coverage REAL, newly_broken INT)`,
+		`INSERT INTO coverage_weekly VALUES ('npm', '2026-08-24', 10, 6, 2, 0.6, 0.75, 1), ('npm', '2026-08-31', 12, 9, 1, 0.75, 0.9, 0), ('maven', '2026-08-31', 4, 4, 0, 1.0, NULL, 0)`,
+		`CREATE TABLE signal_coverage (ecosystem TEXT, universe_packages INT, universe_mass REAL, tracked_packages INT, tracked_mass REAL, current_packages INT, current_mass REAL, covered_mass_share REAL, sidecar_built_at TEXT)`,
+		`INSERT INTO signal_coverage VALUES ('npm', 300, 100.0, 12, 3.0, 9, 2.5, 0.025, ''), ('pypi', 4000, 100.0, 0, 0.0, 0, 0.0, 0.0, '')`,
+		`CREATE TABLE campaigns (ecosystem TEXT, package TEXT, version TEXT, artifact TEXT, state TEXT, stage TEXT)`,
+		`INSERT INTO campaigns VALUES ('npm', 'a', '1', 'a.tgz', 'DONE', 'replay'), ('npm', 'b', '1', 'b.tgz', 'DONE', 'agent'), ('npm', 'c', '1', 'c.tgz', 'QUEUED', 'infer'), ('npm', 'd', '1', 'd.tgz', 'NEEDS_TRIAGE', 'agent'), ('npm', 'e', '1', 'e.tgz', 'INFLIGHT', 'replay')`,
+	)
+}
+
+func TestCoveragePage(t *testing.T) {
+	npm := CoverageEco{
+		Ecosystem: "npm", HasScope: true, InScope: 300, Started: 12, Reproduced: 9, CoveragePct: 3, WeightedPct: 2,
+		HasQueue: true, Queued: 1, InFlight: 1, Done: 2, NeedsTriage: 1,
+		DoneByStage: []StageDone{{scheduler.StageReplay, 1}, {scheduler.StageInfer, 0}, {scheduler.StageAgent, 1}},
+	}
+	npmWeeks := []CoverageWeek{
+		{Week: "2026-08-31", Attempted: 12, Reproduced: 9, Behind: 1, SharePct: 75, WeightedPct: 90, HasWeighted: true},
+		{Week: "2026-08-24", Attempted: 10, Reproduced: 6, Behind: 2, SharePct: 60, WeightedPct: 75, HasWeighted: true, NewlyBroken: 1},
+	}
+	maven := CoverageEco{Ecosystem: "maven"}
+	pypi := CoverageEco{Ecosystem: "pypi", HasScope: true, InScope: 4000}
+	for _, tc := range []struct {
+		name string
+		req  CoverageRequest
+		want CoverageData
+	}{
+		{
+			name: "Comparison",
+			want: CoverageData{Loaded: true, AsOf: "2026-09-01 00:00:00 UTC", Ecos: []CoverageEco{maven, npm, pypi}},
+		},
+		{
+			name: "EcosystemTab",
+			req:  CoverageRequest{Eco: "npm"},
+			want: func() CoverageData {
+				detail := npm
+				detail.Weeks = npmWeeks
+				return CoverageData{Loaded: true, AsOf: "2026-09-01 00:00:00 UTC", Eco: "npm", Ecos: []CoverageEco{maven, detail, pypi}, Detail: &detail}
+			}(),
+		},
+		{
+			name: "UnknownTabFallsBack",
+			req:  CoverageRequest{Eco: "cratesio"},
+			want: CoverageData{Loaded: true, AsOf: "2026-09-01 00:00:00 UTC", Ecos: []CoverageEco{maven, npm, pypi}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := CoveragePage(context.Background(), tc.req, &Deps{Analytics: coverageFixture(t)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(&tc.want, got); diff != "" {
+				t.Errorf("CoveragePage diff (-want +got):\n%s", diff)
+			}
+			if err := CoverageTmpl.Execute(io.Discard, got); err != nil {
+				t.Errorf("rendering: %v", err)
+			}
+		})
+	}
+}
+
+func TestCoveragePageNoAnalytics(t *testing.T) {
+	got, err := CoveragePage(context.Background(), CoverageRequest{}, &Deps{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(&CoverageData{}, got); diff != "" {
+		t.Errorf("CoveragePage diff (-want +got):\n%s", diff)
+	}
+}

--- a/internal/api/snapshotservice/rollup_test.go
+++ b/internal/api/snapshotservice/rollup_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"google.golang.org/grpc/codes"
@@ -36,6 +37,7 @@ func (f *fakeSource) Execs(context.Context, time.Time) ([]schema.ScratchExec, er
 func (f *fakeSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
 	return nil, nil
 }
+func (f *fakeSource) Signals(context.Context) ([]signals.PackageSignal, error) { return nil, nil }
 
 func TestRollupUnconfigured(t *testing.T) {
 	_, err := Rollup(context.Background(), RollupRequest{}, &RollupDeps{})

--- a/internal/db/campaign.go
+++ b/internal/db/campaign.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/google/oss-rebuild/pkg/scheduler"
+	"google.golang.org/api/iterator"
+)
+
+const campaignsCollection = "scheduler_campaigns"
+
+// Campaigns persists the queue state of each onboarding campaign.
+type Campaigns = Resource[scheduler.Campaign, rebuild.Target]
+
+func campaignKey(t rebuild.Target) []string {
+	return []string{campaignsCollection, scheduler.TargetID(t)}
+}
+
+func campaignPath(c scheduler.Campaign) []string { return campaignKey(c.Target()) }
+
+// NewFirestoreCampaigns returns a Firestore-backed queue-state store.
+func NewFirestoreCampaigns(c *firestore.Client) Campaigns {
+	return &firestoreResource[scheduler.Campaign, rebuild.Target]{client: c, pathFor: campaignPath, pathForKey: campaignKey}
+}
+
+// NewMemoryCampaigns returns an in-memory queue-state store for tests.
+func NewMemoryCampaigns() Campaigns {
+	return &memoryResource[scheduler.Campaign, rebuild.Target]{data: map[string]scheduler.Campaign{}, pathFor: campaignPath, pathForKey: campaignKey}
+}
+
+// ListCampaigns returns every queue-state document. The onboarded set is
+// small enough that a full scan is acceptable. Readers sort and filter in
+// memory, which keeps the collection free of composite indexes.
+func ListCampaigns(ctx context.Context, c *firestore.Client) ([]scheduler.Campaign, error) {
+	it := c.Collection(campaignsCollection).Documents(ctx)
+	defer it.Stop()
+	var out []scheduler.Campaign
+	for {
+		snap, err := it.Next()
+		if err == iterator.Done {
+			return out, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		var v scheduler.Campaign
+		if err := snap.DataTo(&v); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+}

--- a/internal/rundex/sqlite_test.go
+++ b/internal/rundex/sqlite_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/snapshot"
 	"github.com/google/oss-rebuild/internal/sqlitex"
 	"github.com/google/oss-rebuild/pkg/feed"
@@ -46,6 +47,9 @@ func (s *snapshotSource) Execs(context.Context, time.Time) ([]schema.ScratchExec
 	return nil, nil
 }
 func (s *snapshotSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
+	return nil, nil
+}
+func (s *snapshotSource) Signals(context.Context) ([]signals.PackageSignal, error) {
 	return nil, nil
 }
 

--- a/internal/signals/doc.go
+++ b/internal/signals/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package signals defines the priority signals that rank packages for
+// onboarding: per-package measures of importance, each normalized within its
+// ecosystem into (0,1] so heavy tails and incomparable registry scales stay
+// out of the arithmetic, and combined into one priority score at read time.
+//
+// "Prevalence" is the signal derived from the dependency graphs of each
+// ecosystem. We define it as "how many other packages depend on this one,
+// directly or transitively," measured both per package and per version.
+//
+// This package holds the record types, the scoring, and the exports' storage.
+// The jobs that produce and consume the exports live in
+// tools/ctl/command/onboard.
+package signals

--- a/internal/signals/doc.go
+++ b/internal/signals/doc.go
@@ -10,7 +10,12 @@
 // ecosystem. We define it as "how many other packages depend on this one,
 // directly or transitively," measured both per package and per version.
 //
-// This package holds the record types, the scoring, and the exports' storage.
-// The jobs that produce and consume the exports live in
-// tools/ctl/command/onboard.
+// The exports are also assembled into a published SQLite database, read by
+// enqueue and by the snapshot. Unlike the snapshot's doc tables, its rows are
+// plain columns with no raw document: the exports are the raw record and the
+// database is regenerable from them, so per-row JSON would only triple the
+// file (measured 183 vs 55 bytes per row at 10^6-package scale).
+//
+// This package holds the record types, the scoring, and that database. The
+// jobs that produce and consume the exports live in tools/ctl/command/onboard.
 package signals

--- a/internal/signals/join.go
+++ b/internal/signals/join.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+// PackageSignal is the read-time join of the priority exports for one
+// package: each signal's raw measure and normalized score, plus the
+// combined Score.
+type PackageSignal struct {
+	Ecosystem  string
+	Package    string
+	Dependents int64   // distinct packages depending on this one, directly or transitively
+	Prevalence float64 // Dependents on a log scale against the ecosystem's top package, in (0,1]
+	Score      float64 // combined priority across the signals present
+}
+
+// JoinSignals folds the package-level rows of the priority exports into
+// one PackageSignal per (ecosystem, package). Version-level prevalence
+// rows are skipped: the join is the per-package view, and version
+// specialization happens where a version is in hand.
+func JoinSignals(prevs []PrevalenceRecord) []PackageSignal {
+	type key struct{ eco, pkg string }
+	idx := make(map[key]int)
+	var out []PackageSignal
+	at := func(eco, pkg string) int {
+		k := key{eco, pkg}
+		if i, ok := idx[k]; ok {
+			return i
+		}
+		idx[k] = len(out)
+		out = append(out, PackageSignal{Ecosystem: eco, Package: pkg})
+		return len(out) - 1
+	}
+	for _, r := range prevs {
+		if r.Version != "" {
+			continue
+		}
+		i := at(r.Ecosystem, r.Package)
+		out[i].Dependents, out[i].Prevalence = r.Dependents, r.Prevalence
+	}
+	for i := range out {
+		// Prevalence is the only signal so far, so it is the score.
+		out[i].Score = out[i].Prevalence
+	}
+	return out
+}

--- a/internal/signals/join_test.go
+++ b/internal/signals/join_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestJoinSignals(t *testing.T) {
+	got := JoinSignals(
+		[]PrevalenceRecord{
+			{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8},
+			// Version-level rows never join: the merge is per package.
+			{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Dependents: 40, Prevalence: 0.75},
+			{Ecosystem: "pypi", Package: "pkgB", Dependents: 10, Prevalence: 0.4},
+		},
+	)
+	want := []PackageSignal{
+		{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8, Score: 0.8},
+		{Ecosystem: "pypi", Package: "pkgB", Dependents: 10, Prevalence: 0.4, Score: 0.4},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("JoinSignals mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/signals/prevalence.go
+++ b/internal/signals/prevalence.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// EcosystemSystem maps a local Ecosystem to its deps.dev `System`.
+// This allows querying against the enum in bigquery-public-data.deps_dev_v1.
+var EcosystemSystem = map[rebuild.Ecosystem]string{
+	rebuild.NPM:      "NPM",
+	rebuild.PyPI:     "PYPI",
+	rebuild.CratesIO: "CARGO",
+	rebuild.RubyGems: "RUBYGEMS",
+	rebuild.Maven:    "MAVEN",
+}
+
+// PrevalenceRecord contains the number of distinct packages that depend on a
+// package, directly or transitively, resolved against the latest deps.dev
+// dependency-graph snapshot, and that count scored against its ecosystem.
+// Version is omitted for package-level rows and set for version-level ones.
+//
+// Version granularity is pertinent because the most-depended-upon version is
+// rarely the newest and old versions may retain use (and, thus, value) well
+// past their publication. Ranking a package's versions by its
+// package-level prevalence would leave recency as the only differentiator,
+// which may not correlate strongly with blast radius.
+type PrevalenceRecord struct {
+	Ecosystem  string `json:"ecosystem"`
+	Package    string `json:"package"`
+	Version    string `json:"version,omitempty"`
+	Dependents int64  `json:"dependents"`
+	// Prevalence is Dependents on a log scale relative to the ecosystem's most
+	// depended-on package, in (0,1]. Counts are tail heavy enough that a rank
+	// quantile over the ecosystem would crowd every exported row above 0.99.
+	Prevalence float64 `json:"prevalence"`
+}

--- a/internal/signals/score.go
+++ b/internal/signals/score.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import "math"
+
+// LogScale maps a dependent count onto (0,1] by its order of magnitude
+// relative to max, the ecosystem's most depended-on package:
+// ln(1+count)/ln(1+max). Dependent counts are tail heavy, so a rank quantile
+// over a whole ecosystem crowds every exported row above 0.99 where a log
+// scale spreads them by blast radius. A count at or above max scores 1 and
+// max <= 0 yields 0.
+func LogScale(count, max int64) float64 {
+	if max <= 0 || count <= 0 {
+		return 0
+	}
+	return min(1, math.Log1p(float64(count))/math.Log1p(float64(max)))
+}

--- a/internal/signals/score_test.go
+++ b/internal/signals/score_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLogScale(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		count, max int64
+		want       float64
+	}{
+		{"Top", 9000, 9000, 1.0},
+		{"Single", 1, 9000, math.Log1p(1) / math.Log1p(9000)},
+		{"AboveMax", 10000, 9000, 1.0},
+		{"ZeroCount", 0, 9000, 0},
+		{"EmptyPopulation", 5, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, LogScale(tc.count, tc.max)); diff != "" {
+				t.Errorf("LogScale(%d, %d) mismatch (-want +got):\n%s", tc.count, tc.max, diff)
+			}
+		})
+	}
+}

--- a/internal/signals/signals.go
+++ b/internal/signals/signals.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/ncruces/go-sqlite3"
+	"github.com/pkg/errors"
+)
+
+// SchemaVersion identifies the signal database layout. Bump it on any
+// change that would mislead an older reader, cutting consumers over by
+// artifact name as with the snapshot database.
+const SchemaVersion = 1
+
+// Object is the destination object name of the signal database, stored
+// gzip-compressed as its name says. The name is stable within an era: each
+// publish replaces it wholesale.
+var Object = fmt.Sprintf("signals-v%d.db.gz", SchemaVersion)
+
+// Table names in the signal database.
+const (
+	TablePackageSignals = "package_signals"
+	TableVersionSignals = "version_signals"
+)
+
+const schema = `
+CREATE TABLE package_signals(
+	ecosystem TEXT NOT NULL, package TEXT NOT NULL,
+	dependents INTEGER NOT NULL, prevalence REAL NOT NULL, score REAL NOT NULL,
+	PRIMARY KEY(ecosystem, package)) WITHOUT ROWID;
+CREATE TABLE version_signals(
+	ecosystem TEXT NOT NULL, package TEXT NOT NULL, version TEXT NOT NULL,
+	dependents INTEGER NOT NULL, prevalence REAL NOT NULL,
+	PRIMARY KEY(ecosystem, package, version)) WITHOUT ROWID;
+CREATE INDEX package_signals_score ON package_signals(ecosystem, score);
+CREATE TABLE signal_meta(built_at TEXT, tool_version TEXT);
+`
+
+// Meta is the single-row provenance record of a signal database, stored in
+// its signal_meta table. The schema era lives in the file header instead
+// (sqlitex.Version).
+type Meta struct {
+	BuiltAt     time.Time // when the build began
+	ToolVersion string    // builder binary version
+}
+
+// ReadMeta loads the database's meta row.
+func ReadMeta(db *sqlite3.Conn) (Meta, error) {
+	var m Meta
+	stmt, _, err := db.Prepare("SELECT built_at, tool_version FROM signal_meta")
+	if err != nil {
+		return m, errors.Wrap(err, "preparing signal_meta read")
+	}
+	defer stmt.Close()
+	if !stmt.Step() {
+		if err := stmt.Err(); err != nil {
+			return m, errors.Wrap(err, "reading signal_meta")
+		}
+		return m, errors.New("signal_meta is empty")
+	}
+	if stmt.ColumnType(0) != sqlite3.NULL {
+		if m.BuiltAt, err = time.Parse(sqlitex.TimeFormat, stmt.ColumnText(0)); err != nil {
+			return m, errors.Wrap(err, "parsing signal_meta built_at")
+		}
+	}
+	m.ToolVersion = stmt.ColumnText(1)
+	return m, nil
+}
+
+// Build writes a signal database at path from the priority exports:
+// package rows joined per package via JoinSignals and one
+// version_signals row per version-level prevalence record. Returns
+// per-table row counts.
+func Build(path string, prevs []PrevalenceRecord, meta Meta) (map[string]int, error) {
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating database")
+	}
+	defer db.Close()
+	if err := db.Exec(schema); err != nil {
+		return nil, errors.Wrap(err, "creating schema")
+	}
+	if err := sqlitex.SetVersion(db, SchemaVersion); err != nil {
+		return nil, err
+	}
+	if err := db.Exec("BEGIN"); err != nil {
+		return nil, err
+	}
+	pkgs := JoinSignals(prevs)
+	pstmt, _, err := db.Prepare("INSERT INTO package_signals VALUES(?,?,?,?,?)")
+	if err != nil {
+		return nil, err
+	}
+	defer pstmt.Close()
+	for _, s := range pkgs {
+		pstmt.BindText(1, s.Ecosystem)
+		pstmt.BindText(2, s.Package)
+		pstmt.BindInt64(3, s.Dependents)
+		pstmt.BindFloat(4, s.Prevalence)
+		pstmt.BindFloat(5, s.Score)
+		if err := pstmt.Exec(); err != nil {
+			return nil, errors.Wrap(err, "inserting package signal")
+		}
+	}
+	vstmt, _, err := db.Prepare("INSERT INTO version_signals VALUES(?,?,?,?,?)")
+	if err != nil {
+		return nil, err
+	}
+	defer vstmt.Close()
+	versions := 0
+	for _, r := range prevs {
+		if r.Version == "" {
+			continue
+		}
+		versions++
+		vstmt.BindText(1, r.Ecosystem)
+		vstmt.BindText(2, r.Package)
+		vstmt.BindText(3, r.Version)
+		vstmt.BindInt64(4, r.Dependents)
+		vstmt.BindFloat(5, r.Prevalence)
+		if err := vstmt.Exec(); err != nil {
+			return nil, errors.Wrap(err, "inserting version signal")
+		}
+	}
+	mstmt, _, err := db.Prepare("INSERT INTO signal_meta VALUES(?,?)")
+	if err != nil {
+		return nil, err
+	}
+	defer mstmt.Close()
+	if meta.BuiltAt.IsZero() {
+		mstmt.BindNull(1)
+	} else {
+		mstmt.BindText(1, sqlitex.TimeColumn(meta.BuiltAt))
+	}
+	mstmt.BindText(2, meta.ToolVersion)
+	if err := mstmt.Exec(); err != nil {
+		return nil, errors.Wrap(err, "writing signal_meta")
+	}
+	if err := db.Exec("COMMIT"); err != nil {
+		return nil, err
+	}
+	return map[string]int{TablePackageSignals: len(pkgs), TableVersionSignals: versions}, nil
+}
+
+// PackageSignals reads every package row from an opened signal database.
+func PackageSignals(db *sqlite3.Conn) ([]PackageSignal, error) {
+	stmt, _, err := db.Prepare(`SELECT ecosystem, package, dependents, prevalence, score
+		FROM package_signals ORDER BY ecosystem, package`)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	var out []PackageSignal
+	for stmt.Step() {
+		out = append(out, PackageSignal{
+			Ecosystem:  stmt.ColumnText(0),
+			Package:    stmt.ColumnText(1),
+			Dependents: stmt.ColumnInt64(2),
+			Prevalence: stmt.ColumnFloat(3),
+			Score:      stmt.ColumnFloat(4),
+		})
+	}
+	return out, stmt.Err()
+}
+
+// Fetch downloads the signal database published under dest into dir and
+// returns its local path, refusing a database from a different schema era.
+func Fetch(dest billy.Basic, dir string) (string, error) {
+	path := filepath.Join(dir, "signals.db")
+	if err := sqlitex.Fetch(dest, Object, path); err != nil {
+		return "", errors.Wrapf(err, "downloading %s", Object)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		return "", errors.Wrap(err, "opening signal database")
+	}
+	defer db.Close()
+	if err := sqlitex.CheckVersion(db, SchemaVersion); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/signals/signals_test.go
+++ b/internal/signals/signals_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/ncruces/go-sqlite3"
+)
+
+var testPrevs = []PrevalenceRecord{
+	{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8},
+	{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Dependents: 60, Prevalence: 0.75},
+	{Ecosystem: "pypi", Package: "pkgA", Version: "2.0", Dependents: 40, Prevalence: 0.6},
+	{Ecosystem: "npm", Package: "pkgB", Dependents: 10, Prevalence: 0.4},
+}
+
+// publish builds a signal database from prevs at version and publishes it
+// under Object in a fresh in-memory destination.
+func publish(t *testing.T, prevs []PrevalenceRecord, version int) billy.Filesystem {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "built.db")
+	if _, err := Build(path, prevs, Meta{}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := sqlitex.SetVersion(db, version); err != nil {
+		t.Fatalf("SetVersion: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	dest := memfs.New()
+	if err := sqlitex.Publish(dest, Object, path); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	return dest
+}
+
+func TestBuildAndReadBack(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "signals.db")
+	built := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	counts, err := Build(path, testPrevs, Meta{BuiltAt: built, ToolVersion: "v-test"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if counts[TablePackageSignals] != 2 || counts[TableVersionSignals] != 2 {
+		t.Errorf("counts = %v, want 2 packages and 2 versions", counts)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	got, err := PackageSignals(db)
+	if err != nil {
+		t.Fatalf("PackageSignals: %v", err)
+	}
+	want := []PackageSignal{
+		{Ecosystem: "npm", Package: "pkgB", Dependents: 10, Prevalence: 0.4, Score: 0.4},
+		{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8, Score: 0.8},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("package rows mismatch (-want +got):\n%s", diff)
+	}
+	meta, err := ReadMeta(db)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+	if !meta.BuiltAt.Equal(built) || meta.ToolVersion != "v-test" {
+		t.Errorf("meta = %+v, want built %v by v-test", meta, built)
+	}
+	if v, err := sqlitex.Version(db); err != nil || v != SchemaVersion {
+		t.Errorf("schema version = (%d, %v), want %d", v, err, SchemaVersion)
+	}
+}
+
+func TestFetchRoundTrip(t *testing.T) {
+	dest := publish(t, testPrevs, SchemaVersion)
+	path, err := Fetch(dest, t.TempDir())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	got, err := PackageSignals(db)
+	if err != nil {
+		t.Fatalf("PackageSignals: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("fetched %d package rows, want 2", len(got))
+	}
+}
+
+func TestFetchRefusesOtherEra(t *testing.T) {
+	dest := publish(t, nil, SchemaVersion+1)
+	if _, err := Fetch(dest, t.TempDir()); err == nil {
+		t.Error("Fetch accepted a database from a different schema era")
+	}
+}

--- a/internal/snapshot/local.go
+++ b/internal/snapshot/local.go
@@ -36,6 +36,11 @@ func OpenLocal(path string) (*LocalDB, error) {
 	if err := db.Exec("PRAGMA busy_timeout = 10000"); err != nil {
 		return fail(errors.Wrap(err, "setting busy timeout"))
 	}
+	// Local connections materialize derived tables via Refresh, so they
+	// need the collations the derived queries use, unlike pure readers.
+	if err := registerCollations(db); err != nil {
+		return fail(err)
+	}
 	if err := docdb.EnsureDocTables(db, Tables()); err != nil {
 		return fail(err)
 	}

--- a/internal/snapshot/saturation_test.go
+++ b/internal/snapshot/saturation_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/oss-rebuild/internal/docdb"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/ncruces/go-sqlite3"
 )
@@ -121,6 +122,7 @@ func TestSaturatedDocumentFillsEveryColumn(t *testing.T) {
 		"scratch_vms":      saturated[schema.Scratch](),
 		"scratch_execs":    saturated[schema.ScratchExec](),
 		"repo_metrics":     saturated[schema.RepoMetrics](),
+		"package_signals":  saturated[signals.PackageSignal](),
 	}
 	db, err := sqlite3.Open(":memory:")
 	if err != nil {
@@ -192,6 +194,7 @@ func TestSkeletonDocumentsKeepGuardedColumnsDefined(t *testing.T) {
 		"scratch_vms":      `{"id":"sc1"}`,
 		"scratch_execs":    `{"id":"e1"}`,
 		"repo_metrics":     `{"uri":"u"}`,
+		"package_signals":  `{"Ecosystem":"pypi","Package":"p"}`,
 	}
 	db, err := sqlite3.Open(":memory:")
 	if err != nil {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/oss-rebuild/internal/docdb"
 	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/google/oss-rebuild/internal/versionx"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/ncruces/go-sqlite3"
 	"github.com/pkg/errors"
@@ -181,12 +182,26 @@ func buildSnapshotDB(path string, docTables map[string][]json.RawMessage, meta M
 	if err != nil {
 		return nil, errors.Wrap(err, "creating database")
 	}
+	if err := registerCollations(db); err != nil {
+		db.Close()
+		return nil, err
+	}
 	counts, err := fillSnapshotDB(db, docTables, meta)
 	if err != nil {
 		db.Close()
 		return nil, err
 	}
 	return counts, errors.Wrap(db.Close(), "closing database")
+}
+
+// registerCollations registers the version_approx_compare collation the
+// derived queries use to order version strings. Only build connections need
+// it: derived tables are materialized, so readers never re-run the queries.
+func registerCollations(db *sqlite3.Conn) error {
+	err := db.CreateCollation("version_approx_compare", func(a, b []byte) int {
+		return versionx.ApproxCompare(string(a), string(b))
+	})
+	return errors.Wrap(err, "registering version_approx_compare collation")
 }
 
 func fillSnapshotDB(db *sqlite3.Conn, docTables map[string][]json.RawMessage, meta Meta) (map[string]int, error) {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/google/oss-rebuild/internal/docdb"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/google/oss-rebuild/pkg/rebuild/schema"
 	"github.com/ncruces/go-sqlite3"
 	"github.com/pkg/errors"
 )
@@ -112,6 +114,11 @@ func Rollup(ctx context.Context, src Source, dest billy.Filesystem, opts Options
 	if err != nil {
 		return nil, errors.Wrap(err, "scanning repo metrics")
 	}
+	sigs, err := src.Signals(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading priority signals")
+	}
+	sigs = pruneSignals(sigs, attempts)
 	docTables := map[string][]json.RawMessage{
 		TableAttempts:        docsOf(attempts),
 		TableRuns:            docsOf(runs),
@@ -120,6 +127,7 @@ func Rollup(ctx context.Context, src Source, dest billy.Filesystem, opts Options
 		TableScratchVMs:      docsOf(scratches),
 		TableScratchExecs:    docsOf(execs),
 		TableRepoMetrics:     docsOf(repoMetrics),
+		TablePackageSignals:  docsOf(sigs),
 	}
 	meta := Meta{
 		BuiltAt:       now,
@@ -141,6 +149,26 @@ func Rollup(ctx context.Context, src Source, dest billy.Filesystem, opts Options
 		return nil, errors.Wrap(err, "uploading snapshot")
 	}
 	return &RollupResult{Meta: meta, RowCounts: counts}, nil
+}
+
+// pruneSignals keeps only signals for packages the snapshot itself carries:
+// those with an attempt. The signal exports cover the registry universe, so
+// without this package_signals would scale with the registry rather than
+// with coverage. Presence in this database is the rollup's only notion of a
+// tracked package.
+func pruneSignals(sigs []signals.PackageSignal, attempts []schema.RebuildAttempt) []signals.PackageSignal {
+	type key struct{ eco, pkg string }
+	tracked := make(map[key]bool)
+	for _, a := range attempts {
+		tracked[key{a.Ecosystem, a.Package}] = true
+	}
+	var kept []signals.PackageSignal
+	for _, s := range sigs {
+		if tracked[key{s.Ecosystem, s.Package}] {
+			kept = append(kept, s)
+		}
+	}
+	return kept
 }
 
 // buildSnapshotDB writes every registry table plus the database meta to a

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/internal/sqlitex"
 	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
@@ -29,6 +30,7 @@ type fakeSource struct {
 	scratches   []schema.Scratch
 	execs       []schema.ScratchExec
 	repoMetrics []schema.RepoMetrics
+	signals     []signals.PackageSignal
 }
 
 func (f *fakeSource) Attempts(_ context.Context, since time.Time) ([]schema.RebuildAttempt, error) {
@@ -50,6 +52,9 @@ func (f *fakeSource) Execs(context.Context, time.Time) ([]schema.ScratchExec, er
 }
 func (f *fakeSource) RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error) {
 	return f.repoMetrics, nil
+}
+func (f *fakeSource) Signals(context.Context) ([]signals.PackageSignal, error) {
+	return f.signals, nil
 }
 
 // openPublished fetches the snapshot database dest holds and opens it.
@@ -193,4 +198,30 @@ func TestMetaRoundTrip(t *testing.T) {
 		t.Errorf("rewritten meta = (%+v, %v), want zero watermark", got, err)
 	}
 	assertCount(t, db, "SELECT count(*) FROM snapshot_meta", "1")
+}
+
+func TestRollupPrunesSignalsToTrackedPackages(t *testing.T) {
+	ctx := context.Background()
+	dest := memfs.New()
+	src := &fakeSource{
+		attempts: []schema.RebuildAttempt{
+			attempt("pypi", "pkgA", "1.0", "r1", true, schema.RebuildStatusSuccess, at(0)),
+		},
+		signals: []signals.PackageSignal{
+			{Ecosystem: "pypi", Package: "pkgA", Score: 0.9},   // attempted
+			{Ecosystem: "pypi", Package: "famous", Score: 1.0}, // untracked
+		},
+	}
+	res, err := Rollup(ctx, src, dest, Options{Now: time.Date(2026, 7, 14, 15, 4, 5, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("Rollup: %v", err)
+	}
+	// The exports cover the registry universe. Only the packages this
+	// database carries keep their signals.
+	if got := res.RowCounts[TablePackageSignals]; got != 1 {
+		t.Errorf("package_signals count = %d, want 1", got)
+	}
+	db := openPublished(t, dest)
+	assertCount(t, db, "SELECT count(*) FROM package_signals WHERE package='famous'", "0")
+	assertCount(t, db, "SELECT count(*) FROM package_signals WHERE package='pkgA' AND score=0.9", "1")
 }

--- a/internal/snapshot/source.go
+++ b/internal/snapshot/source.go
@@ -5,11 +5,15 @@ package snapshot
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/go-git/go-billy/v5"
 	"github.com/google/oss-rebuild/internal/iterx"
+	"github.com/google/oss-rebuild/internal/signals"
 	"github.com/google/oss-rebuild/pkg/rebuild/schema"
+	"github.com/ncruces/go-sqlite3"
 	"github.com/pkg/errors"
 	"google.golang.org/api/iterator"
 )
@@ -17,7 +21,9 @@ import (
 // Source is the read side of the snapshot pipelines: each scan yields the
 // records written at or after the given watermark, and FullScan yields
 // every record. Scanning is isolated behind this interface so the
-// derivations can be tested with in-memory fixtures.
+// derivations can be tested with in-memory fixtures. Signals takes no
+// watermark: the priority exports are rewritten whole at job cadence, so
+// they are rollup-only and have no delta path.
 type Source interface {
 	Attempts(context.Context, time.Time) ([]schema.RebuildAttempt, error)
 	Runs(context.Context, time.Time) ([]schema.Run, error)
@@ -26,6 +32,7 @@ type Source interface {
 	Scratches(context.Context, time.Time) ([]schema.Scratch, error)
 	Execs(context.Context, time.Time) ([]schema.ScratchExec, error)
 	RepoMetrics(context.Context, time.Time) ([]schema.RepoMetrics, error)
+	Signals(context.Context) ([]signals.PackageSignal, error)
 }
 
 // FullScan is the zero watermark: a scan given it reads every record.
@@ -38,6 +45,10 @@ var FullScan time.Time
 // potentially via BigQuery.
 type FirestoreSource struct {
 	client *firestore.Client
+	// SignalsDB is the filesystem the signal database publishes under.
+	// Optional: nil yields no signal rows, so a rollup stays runnable
+	// before the first publish.
+	SignalsDB billy.Filesystem
 }
 
 var _ Source = (*FirestoreSource)(nil)
@@ -134,4 +145,32 @@ func (s *FirestoreSource) Execs(ctx context.Context, since time.Time) ([]schema.
 
 func (s *FirestoreSource) RepoMetrics(ctx context.Context, since time.Time) ([]schema.RepoMetrics, error) {
 	return scanQuery[schema.RepoMetrics](ctx, sinceQuery(s.client.Collection("repo_metrics").Query, "updated", since))
+}
+
+// Signals reads the priority signals from the published signal database.
+func (s *FirestoreSource) Signals(context.Context) ([]signals.PackageSignal, error) {
+	return readSignals(s.SignalsDB)
+}
+
+// readSignals fetches the published signal database and reads its package
+// rows. A nil filesystem yields no rows.
+func readSignals(dest billy.Filesystem) ([]signals.PackageSignal, error) {
+	if dest == nil {
+		return nil, nil
+	}
+	dir, err := os.MkdirTemp("", "signals-fetch-")
+	if err != nil {
+		return nil, errors.Wrap(err, "creating fetch directory")
+	}
+	defer os.RemoveAll(dir)
+	path, err := signals.Fetch(dest, dir)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching signal database")
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening signal database")
+	}
+	defer db.Close()
+	return signals.PackageSignals(db)
 }

--- a/internal/snapshot/source_test.go
+++ b/internal/snapshot/source_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/signals"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+)
+
+func TestReadSignals(t *testing.T) {
+	built := filepath.Join(t.TempDir(), "signals.db")
+	if _, err := signals.Build(built,
+		[]signals.PrevalenceRecord{
+			{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8},
+			// Version rows publish but only package rows reach the snapshot.
+			{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Dependents: 60, Prevalence: 0.75},
+		},
+		signals.Meta{}); err != nil {
+		t.Fatalf("building signal database: %v", err)
+	}
+	pub := memfs.New()
+	if err := sqlitex.Publish(pub, signals.Object, built); err != nil {
+		t.Fatalf("publishing signal database: %v", err)
+	}
+	got, err := readSignals(pub)
+	if err != nil {
+		t.Fatalf("readSignals: %v", err)
+	}
+	want := []signals.PackageSignal{
+		{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8, Score: 0.8},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("signals mismatch (-want +got):\n%s", diff)
+	}
+	if empty, err := readSignals(nil); err != nil || empty != nil {
+		t.Errorf("readSignals(nil) = (%v, %v), want no rows and no error", empty, err)
+	}
+}

--- a/internal/snapshot/tables.go
+++ b/internal/snapshot/tables.go
@@ -32,6 +32,7 @@ const (
 	TableScratchVMs       = "scratch_vms"
 	TableScratchExecs     = "scratch_execs"
 	TableRepoMetrics      = "repo_metrics"
+	TablePackageSignals   = "package_signals"
 	TableCostObservations = "cost_observations"
 	TableEcosystemDaily   = "ecosystem_daily"
 )
@@ -309,6 +310,19 @@ func Tables() []docdb.TableDef {
 				{Name: "bytes", Type: "INTEGER", Expr: docdb.Raw("$.bytes")},
 				{Name: "commits", Type: "INTEGER", Expr: docdb.Raw("$.commits")},
 				{Name: "head", Type: "TEXT", Expr: docdb.Raw("$.head")},
+			},
+		},
+		{
+			Name: TablePackageSignals,
+			Cols: []docdb.Col{
+				{Name: "ecosystem", Type: "TEXT", Expr: docdb.Doc("$.Ecosystem")},
+				{Name: "package", Type: "TEXT", Expr: docdb.Doc("$.Package")},
+			},
+			PK: []string{"ecosystem", "package"},
+			GenCols: []docdb.GenCol{
+				{Name: "dependents", Type: "INTEGER", Expr: docdb.Raw("$.Dependents")},
+				{Name: "prevalence", Type: "REAL", Expr: docdb.Raw("$.Prevalence")},
+				{Name: "score", Type: "REAL", Expr: docdb.Raw("$.Score"), Stored: true},
 			},
 		},
 		{Name: TableCostObservations, Query: costObservationsQuery, Indexes: [][]string{{"ecosystem", "package"}, {"source"}, {"timestamp"}}},

--- a/internal/snapshot/tables.go
+++ b/internal/snapshot/tables.go
@@ -35,6 +35,9 @@ const (
 	TablePackageSignals   = "package_signals"
 	TableCostObservations = "cost_observations"
 	TableEcosystemDaily   = "ecosystem_daily"
+	TableVersionStats     = "version_stats"
+	TableCoverageWeekly   = "coverage_weekly"
+	TableTopGaps          = "top_gaps"
 )
 
 // Observation source discriminators for cost_observations rows.
@@ -117,6 +120,141 @@ LEFT JOIN days d ON d.ecosystem = k.ecosystem AND d.day = k.day
 LEFT JOIN first_days f ON f.ecosystem = k.ecosystem AND f.day = k.day
 LEFT JOIN tokens t ON t.ecosystem = k.ecosystem AND t.day = k.day
 LEFT JOIN vm v ON v.ecosystem = k.ecosystem AND v.day = k.day
+ORDER BY 1, 2`
+
+// Gap reasons, derived from recorded statuses rather than message parsing.
+const (
+	GapReasonStale    = "stale"    // earlier version built but latest has not
+	GapReasonMismatch = "mismatch" // latest version completed without matching upstream
+	GapReasonError    = "error"    // latest version's build failed
+)
+
+// topGapsPerEcosystem caps the top_gaps table per ecosystem.
+const topGapsPerEcosystem = "100"
+
+// versionStatsQuery folds completed attempts into one row per (ecosystem,
+// package, version). Attempts are recorded per artifact: a version is
+// current when every attempted artifact has succeeded, and flaky when any
+// one artifact has both succeeded and failed. published_at is NULL until a
+// source of registry publish times exists.
+const versionStatsQuery = `
+WITH completed AS (SELECT * FROM attempts WHERE status != 'RUNNING'),
+by_artifact AS (
+	SELECT ecosystem, package, version, artifact,
+		max(success) AS succeeded, max(success = 0) AS failed
+	FROM completed GROUP BY 1, 2, 3, 4),
+per_version AS (
+	SELECT ecosystem, package, version, count(*) AS attempts, min(created) AS first_attempted_at
+	FROM completed GROUP BY 1, 2, 3),
+artifacts AS (
+	SELECT ecosystem, package, version, count(*) AS artifacts_attempted,
+		sum(succeeded) AS artifacts_succeeded, max(succeeded AND failed) AS any_flaky
+	FROM by_artifact GROUP BY 1, 2, 3),
+first_success AS (
+	SELECT *, row_number() OVER (PARTITION BY ecosystem, package, version ORDER BY created ASC, run_id ASC) AS rn
+	FROM completed WHERE success),
+last_attempt AS (
+	SELECT *, row_number() OVER (PARTITION BY ecosystem, package, version ORDER BY created DESC, run_id DESC) AS rn
+	FROM completed)
+SELECT g.ecosystem, g.package, g.version,
+	NULL AS published_at,
+	g.first_attempted_at, fs.created AS first_succeeded_at,
+	la.created AS last_attempted_at, la.status AS last_status,
+	g.attempts, a.artifacts_attempted, a.artifacts_succeeded,
+	a.artifacts_attempted > 0 AND a.artifacts_succeeded = a.artifacts_attempted AS current,
+	fs.mechanism AS first_success_mechanism, fs.executor_version AS first_success_executor,
+	la.executor_version AS last_executor,
+	a.any_flaky AS flaky
+FROM per_version g
+JOIN artifacts a ON a.ecosystem = g.ecosystem AND a.package = g.package AND a.version = g.version
+LEFT JOIN first_success fs ON fs.ecosystem = g.ecosystem AND fs.package = g.package AND fs.version = g.version AND fs.rn = 1
+LEFT JOIN last_attempt la ON la.ecosystem = g.ecosystem AND la.package = g.package AND la.version = g.version AND la.rn = 1
+ORDER BY 1, 2, 3`
+
+// topGapsQuery lists packages whose latest version is not current, capped
+// at topGapsPerEcosystem rows per ecosystem. Latest is chosen by ordering
+// versions with the version_approx_compare collation, not the attempt order, so a
+// backfilled old version is never taken as newest. score, score_percentile,
+// and dependents are zero until signals are ingested, so rows order by
+// attempt count for now.
+const topGapsQuery = `
+WITH ranked AS (
+	SELECT *, row_number() OVER (PARTITION BY ecosystem, package ORDER BY version COLLATE version_approx_compare DESC) AS vrank
+	FROM version_stats),
+built_besides AS (
+	SELECT ecosystem, package, max(artifacts_succeeded > 0) AS any
+	FROM ranked WHERE vrank > 1 GROUP BY 1, 2),
+gaps AS (
+	SELECT l.ecosystem, l.package, l.version AS latest_version,
+		CASE WHEN coalesce(b.any, 0) OR l.artifacts_succeeded > 0 THEN '` + GapReasonStale + `'
+			WHEN l.last_status = 'FAILURE' THEN '` + GapReasonMismatch + `'
+			ELSE '` + GapReasonError + `' END AS reason,
+		l.last_status, l.last_attempted_at, l.attempts,
+		0.0 AS score, 0.0 AS score_percentile, 0 AS dependents
+	FROM ranked l LEFT JOIN built_besides b ON b.ecosystem = l.ecosystem AND b.package = l.package
+	WHERE l.vrank = 1 AND NOT l.current)
+SELECT ecosystem, package, latest_version, reason, last_status, last_attempted_at,
+	attempts, score, score_percentile, dependents
+FROM (SELECT *, row_number() OVER (PARTITION BY ecosystem ORDER BY score DESC, attempts DESC, package) AS n FROM gaps)
+WHERE n <= ` + topGapsPerEcosystem + `
+ORDER BY ecosystem, score DESC, attempts DESC, package`
+
+// coverageWeeklyQuery aggregates version_stats into one row per
+// (ecosystem, week): cumulative package counts as of the end of each week,
+// considering only versions first attempted by then and taking each
+// package's latest such version by the version_approx_compare collation. Weeks start
+// Monday and run from each ecosystem's first attempt to its last.
+// weighted_coverage and the freshness columns are zero until usage signals
+// and published_at are available.
+const coverageWeeklyQuery = `
+WITH bounds AS (
+	SELECT ecosystem, min(first_attempted_at) AS lo, max(last_attempted_at) AS hi
+	FROM version_stats WHERE first_attempted_at IS NOT NULL GROUP BY 1),
+weeks(ecosystem, week, hi) AS (
+	SELECT ecosystem, date(lo, '-' || ((strftime('%w', lo) + 6) % 7) || ' days'), hi FROM bounds
+	UNION ALL
+	SELECT ecosystem, date(week, '+7 days'), hi FROM weeks WHERE date(week, '+7 days') <= date(hi)),
+vis AS (
+	SELECT w.week, v.*,
+		row_number() OVER (PARTITION BY w.week, v.package ORDER BY v.version COLLATE version_approx_compare DESC) AS vrank
+	FROM weeks w JOIN version_stats v ON v.ecosystem = w.ecosystem
+	WHERE v.first_attempted_at < date(w.week, '+7 days')),
+pkgs AS (
+	SELECT ecosystem, week, package,
+		max(artifacts_succeeded > 0 AND first_succeeded_at < date(week, '+7 days')) AS ever_built
+	FROM vis GROUP BY 1, 2, 3),
+latest AS (SELECT * FROM vis WHERE vrank = 1),
+prev AS (SELECT * FROM vis WHERE vrank = 2),
+funnel AS (
+	SELECT p.ecosystem, p.week,
+		count(*) AS packages_attempted,
+		sum(p.ever_built) AS packages_ever_built,
+		sum(l.current AND l.first_succeeded_at < date(p.week, '+7 days')) AS packages_current,
+		sum(p.ever_built AND NOT (l.current AND l.first_succeeded_at < date(p.week, '+7 days'))) AS packages_stale,
+		sum(l.first_attempted_at >= p.week AND l.first_attempted_at < date(p.week, '+7 days')
+			AND l.artifacts_succeeded = 0 AND coalesce(pr.artifacts_succeeded, 0) > 0) AS newly_broken,
+		sum(l.first_succeeded_at >= p.week AND l.first_succeeded_at < date(p.week, '+7 days')
+			AND l.current AND pr.package IS NOT NULL AND NOT coalesce(pr.current, 0)) AS newly_fixed
+	FROM pkgs p
+	JOIN latest l ON l.ecosystem = p.ecosystem AND l.week = p.week AND l.package = p.package
+	LEFT JOIN prev pr ON pr.ecosystem = p.ecosystem AND pr.week = p.week AND pr.package = p.package
+	GROUP BY 1, 2),
+weekly AS (
+	SELECT v.ecosystem, w.week,
+		count(*) AS versions_attempted, sum(v.flaky) AS flaky_versions
+	FROM weeks w JOIN version_stats v ON v.ecosystem = w.ecosystem
+	WHERE v.first_attempted_at >= w.week AND v.first_attempted_at < date(w.week, '+7 days')
+	GROUP BY 1, 2)
+SELECT f.ecosystem, f.week,
+	f.packages_attempted, f.packages_ever_built, f.packages_current, f.packages_stale,
+	CASE WHEN f.packages_attempted > 0 THEN 1.0 * f.packages_current / f.packages_attempted ELSE 0 END AS coverage,
+	0.0 AS weighted_coverage,
+	f.newly_broken, f.newly_fixed,
+	coalesce(wk.versions_attempted, 0) AS versions_attempted,
+	coalesce(wk.flaky_versions, 0) AS flaky_versions,
+	0 AS versions_published, 0.0 AS fresh_p50_hours, 0.0 AS fresh_p95_hours, 0.0 AS fresh_72h_pct
+FROM funnel f
+LEFT JOIN weekly wk ON wk.ecosystem = f.ecosystem AND wk.week = f.week
 ORDER BY 1, 2`
 
 // Tables is the registry of snapshot tables and the single declaration of
@@ -327,5 +465,8 @@ func Tables() []docdb.TableDef {
 		},
 		{Name: TableCostObservations, Query: costObservationsQuery, Indexes: [][]string{{"ecosystem", "package"}, {"source"}, {"timestamp"}}},
 		{Name: TableEcosystemDaily, Query: ecosystemDailyQuery, Indexes: [][]string{{"ecosystem", "day"}}},
+		{Name: TableVersionStats, Query: versionStatsQuery, Indexes: [][]string{{"ecosystem", "package", "version"}, {"last_attempted_at"}}},
+		{Name: TableCoverageWeekly, Query: coverageWeeklyQuery, Indexes: [][]string{{"ecosystem", "week"}}},
+		{Name: TableTopGaps, Query: topGapsQuery, Indexes: [][]string{{"ecosystem"}}},
 	}
 }

--- a/internal/snapshot/tables_test.go
+++ b/internal/snapshot/tables_test.go
@@ -81,6 +81,9 @@ func fill(t *testing.T, src *fakeSource) (*sqlite3.Conn, map[string]int) {
 		t.Fatalf("open: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+	if err := registerCollations(db); err != nil {
+		t.Fatalf("registerCollations: %v", err)
+	}
 	counts, err := fillSnapshotDB(db, map[string][]json.RawMessage{
 		TableAttempts:        docsOf(src.attempts),
 		TableRuns:            docsOf(src.runs),
@@ -242,4 +245,51 @@ func TestEcosystemDaily(t *testing.T) {
 	assertCount(t, db, "SELECT count(*) FROM ecosystem_daily WHERE ecosystem='pypi' AND day='' AND attempts=1 AND successes=0", "1")
 	assertCount(t, db, `SELECT count(*) FROM ecosystem_daily WHERE ecosystem='pypi' AND day='2026-07-02'
 		AND first_time_successes=0 AND successes=1`, "1")
+}
+
+func TestVersionStatsAndTopGaps(t *testing.T) {
+	flakyOK := attempt("pypi", "pkgE", "1.0", "r8", true, schema.RebuildStatusSuccess, at(2*time.Hour))
+	db, _ := fill(t, &fakeSource{attempts: []schema.RebuildAttempt{
+		// pkgA: an old version built, but the numerically-newest (10.0,
+		// which naive lexicographic ordering would rank below 2.0) fails.
+		attempt("pypi", "pkgA", "2.0", "r1", true, schema.RebuildStatusSuccess, at(0)),
+		attempt("pypi", "pkgA", "10.0", "r2", false, schema.RebuildStatusError, at(1*time.Hour)),
+		// pkgB: latest completed without matching upstream.
+		attempt("pypi", "pkgB", "1.0", "r3", false, schema.RebuildStatusFailure, at(0)),
+		// pkgC: latest errored.
+		attempt("pypi", "pkgC", "1.0", "r4", false, schema.RebuildStatusError, at(0)),
+		// pkgD: current, so absent from the gap queue.
+		attempt("pypi", "pkgD", "1.0", "r5", true, schema.RebuildStatusSuccess, at(0)),
+		// pkgE: one artifact with mixed outcomes, so flaky but current.
+		attempt("pypi", "pkgE", "1.0", "r7", false, schema.RebuildStatusError, at(1*time.Hour)),
+		flakyOK,
+	}})
+	assertCount(t, db, `SELECT count(*) FROM version_stats WHERE package='pkgA' AND version='10.0'
+		AND current=0 AND artifacts_attempted=1 AND artifacts_succeeded=0 AND last_status='ERROR'`, "1")
+	assertCount(t, db, "SELECT count(*) FROM version_stats WHERE package='pkgE' AND flaky=1 AND current=1", "1")
+	assertCount(t, db, "SELECT count(*) FROM version_stats WHERE package='pkgD' AND current=1 AND flaky=0", "1")
+	// The version_approx_compare collation picks 10.0 (not 2.0) as pkgA's latest, making
+	// the package stale rather than current.
+	assertCount(t, db, "SELECT count(*) FROM top_gaps WHERE package='pkgA' AND latest_version='10.0' AND reason='stale'", "1")
+	assertCount(t, db, "SELECT count(*) FROM top_gaps WHERE package='pkgB' AND reason='mismatch'", "1")
+	assertCount(t, db, "SELECT count(*) FROM top_gaps WHERE package='pkgC' AND reason='error'", "1")
+	assertCount(t, db, "SELECT count(*) FROM top_gaps WHERE package IN ('pkgD','pkgE')", "0")
+}
+
+func TestCoverageWeekly(t *testing.T) {
+	// Week of 2026-06-29: pkgA 1.0 builds. Week of 2026-07-06: 2.0 arrives
+	// and fails, breaking the package.
+	week2 := base.AddDate(0, 0, 7)
+	db, _ := fill(t, &fakeSource{attempts: []schema.RebuildAttempt{
+		attempt("pypi", "pkgA", "1.0", "r1", true, schema.RebuildStatusSuccess, base),
+		attempt("pypi", "pkgA", "2.0", "r2", false, schema.RebuildStatusError, week2),
+	}})
+	assertCount(t, db, `SELECT count(*) FROM coverage_weekly WHERE week='2026-06-29'
+		AND packages_attempted=1 AND packages_current=1 AND packages_stale=0
+		AND coverage=1.0 AND newly_broken=0 AND versions_attempted=1`, "1")
+	assertCount(t, db, `SELECT count(*) FROM coverage_weekly WHERE week='2026-07-06'
+		AND packages_attempted=1 AND packages_current=0 AND packages_stale=1
+		AND packages_ever_built=1 AND newly_broken=1 AND versions_attempted=1`, "1")
+	// The series ends at the week containing the last attempt.
+	assertCount(t, db, "SELECT count(*) FROM coverage_weekly WHERE week > '2026-07-06'", "0")
 }

--- a/internal/snapshot/tables_test.go
+++ b/internal/snapshot/tables_test.go
@@ -89,6 +89,7 @@ func fill(t *testing.T, src *fakeSource) (*sqlite3.Conn, map[string]int) {
 		TableScratchVMs:      docsOf(src.scratches),
 		TableScratchExecs:    docsOf(src.execs),
 		TableRepoMetrics:     docsOf(src.repoMetrics),
+		TablePackageSignals:  docsOf(src.signals),
 	}, Meta{BuiltAt: at(time.Hour)})
 	if err != nil {
 		t.Fatalf("fillSnapshotDB: %v", err)

--- a/internal/snapshot/testdata/schema_v1.json
+++ b/internal/snapshot/testdata/schema_v1.json
@@ -111,6 +111,14 @@
     "successes": "",
     "tokens": ""
   },
+  "package_signals": {
+    "dependents": "INTEGER",
+    "ecosystem": "TEXT pk=1",
+    "package": "TEXT pk=2",
+    "prevalence": "REAL",
+    "raw": "TEXT",
+    "score": "REAL"
+  },
   "repo_metrics": {
     "bytes": "INTEGER",
     "commits": "INTEGER",

--- a/internal/snapshot/testdata/schema_v1.json
+++ b/internal/snapshot/testdata/schema_v1.json
@@ -99,6 +99,24 @@
     "version": "TEXT",
     "vm_seconds": "REAL"
   },
+  "coverage_weekly": {
+    "coverage": "",
+    "ecosystem": "TEXT",
+    "flaky_versions": "",
+    "fresh_72h_pct": "",
+    "fresh_p50_hours": "",
+    "fresh_p95_hours": "",
+    "newly_broken": "",
+    "newly_fixed": "",
+    "packages_attempted": "",
+    "packages_current": "",
+    "packages_ever_built": "",
+    "packages_stale": "",
+    "versions_attempted": "",
+    "versions_published": "",
+    "week": "",
+    "weighted_coverage": ""
+  },
   "ecosystem_daily": {
     "attempts": "",
     "builder_seconds": "",
@@ -160,5 +178,35 @@
     "updated": "TEXT",
     "vm_seconds": "REAL",
     "zone": "TEXT"
+  },
+  "top_gaps": {
+    "attempts": "",
+    "dependents": "",
+    "ecosystem": "TEXT",
+    "last_attempted_at": "TEXT",
+    "last_status": "TEXT",
+    "latest_version": "TEXT",
+    "package": "TEXT",
+    "reason": "",
+    "score": "",
+    "score_percentile": ""
+  },
+  "version_stats": {
+    "artifacts_attempted": "",
+    "artifacts_succeeded": "",
+    "attempts": "",
+    "current": "",
+    "ecosystem": "TEXT",
+    "first_attempted_at": "",
+    "first_succeeded_at": "TEXT",
+    "first_success_executor": "TEXT",
+    "first_success_mechanism": "TEXT",
+    "flaky": "",
+    "last_attempted_at": "TEXT",
+    "last_executor": "TEXT",
+    "last_status": "TEXT",
+    "package": "TEXT",
+    "published_at": "",
+    "version": "TEXT"
   }
 }

--- a/pkg/scheduler/campaign.go
+++ b/pkg/scheduler/campaign.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"math"
+	"time"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// Stage is a rung on the escalation ladder: one automated way of attempting a
+// rebuild, each more expensive than the last. Escalation past the cheap stages
+// is what the budget rations.
+type Stage string
+
+const (
+	// StageReplay re-runs a known or promoted strategy with no inference.
+	// Reserved for sibling fan-out. Nothing enqueues at it yet: every
+	// campaign starts at StageInfer.
+	StageReplay Stage = "replay"
+	// StageInfer runs heuristic inference plus a build.
+	StageInfer Stage = "infer"
+	// StageAgent runs the multi-iteration LLM agent. Rationed.
+	StageAgent Stage = "agent"
+)
+
+// stages orders the ladder, cheapest first.
+var stages = []Stage{StageReplay, StageInfer, StageAgent}
+
+// Next returns the stage after s. The second return is false when s is the
+// last (or an unknown) stage, meaning nothing more expensive is left to try.
+func (s Stage) Next() (Stage, bool) {
+	for i, cur := range stages[:len(stages)-1] {
+		if cur == s {
+			return stages[i+1], true
+		}
+	}
+	return "", false
+}
+
+// Outcome is the classification of a single attempt. Exactly one applies.
+type Outcome string
+
+const (
+	OutcomePending   Outcome = ""          // no terminal result yet
+	OutcomeAttested  Outcome = "ATTESTED"  // reproduced, an attestation exists
+	OutcomeTransient Outcome = "TRANSIENT" // throttle or infra flake, retry same stage
+	OutcomeFailure   Outcome = "FAILURE"   // ran and failed, escalate
+)
+
+// State tracks where a campaign sits in the dispatch workflow.
+type State string
+
+const (
+	StateQueued      State = "QUEUED"       // eligible for dispatch at Stage
+	StateInFlight    State = "INFLIGHT"     // dispatched, awaiting outcome
+	StateNeedsTriage State = "NEEDS_TRIAGE" // automated stages exhausted, awaiting a human
+	StateDone        State = "DONE"         // attested
+)
+
+// Campaign is the queue-state document for one package version working
+// through the escalation ladder. Document ID is TargetID(Target()).
+type Campaign struct {
+	Ecosystem string `firestore:"ecosystem,omitempty"`
+	Package   string `firestore:"package,omitempty"`
+	Version   string `firestore:"version,omitempty"`
+	Artifact  string `firestore:"artifact,omitempty"`
+
+	Stage    Stage   `firestore:"stage,omitempty"` // next stage to run
+	State    State   `firestore:"state,omitempty"`
+	Outcome  Outcome `firestore:"outcome,omitempty"`
+	Attempts int     `firestore:"attempts,omitempty"`
+	Retries  int     `firestore:"retries,omitempty"` // same-stage transient retries
+
+	LastRunID    string `firestore:"last_run_id,omitempty"`
+	LastSession  string `firestore:"last_session,omitempty"`
+	Repo         string `firestore:"repo,omitempty"` // discovered source repo (for jumbo routing)
+	TriageReason string `firestore:"triage_reason,omitempty"`
+
+	// Score is the package's priority specialized to this version, copied at
+	// enqueue. Recency is deliberately not stored: DispatchOrder derives it
+	// from Published at read time, so the boost decays while the campaign
+	// waits instead of freezing at whatever it was when it was enqueued.
+	Score     float64   `firestore:"score,omitempty"`
+	Published time.Time `firestore:"published,omitempty"`
+
+	DispatchedAt time.Time `firestore:"dispatched_at,omitempty"`
+	Updated      time.Time `firestore:"updated,omitempty"`
+}
+
+// DispatchOrder is the queue position of a campaign as of now, highest first.
+// Importance and recency multiply rather than add so that a stale version of a
+// critical package and a fresh version of an unimportant one both stay ranked
+// below a fresh version of a critical one.
+func (c Campaign) DispatchOrder(now time.Time, k, tauHours float64) float64 {
+	return c.Score * Freshness(c.Published, now, k, tauHours)
+}
+
+func (c Campaign) Target() rebuild.Target {
+	return rebuild.Target{
+		Ecosystem: rebuild.Ecosystem(c.Ecosystem),
+		Package:   c.Package,
+		Version:   c.Version,
+		Artifact:  c.Artifact,
+	}
+}
+
+// Default freshness parameters, shared by enqueue-time admission and
+// dispatch-time ordering so the two rank alike.
+const (
+	DefaultFreshnessK        = 3
+	DefaultFreshnessTauHours = 120
+)
+
+// Freshness returns the recency boost for a campaign: 1 + k*exp(-age/tau), so
+// new releases spike and decay into the backlog. tauHours must be > 0.
+func Freshness(published, now time.Time, k, tauHours float64) float64 {
+	if published.IsZero() || tauHours <= 0 {
+		return 1
+	}
+	age := now.Sub(published).Hours()
+	if age < 0 {
+		age = 0
+	}
+	return 1 + k*math.Exp(-age/tauHours)
+}

--- a/pkg/scheduler/campaign_test.go
+++ b/pkg/scheduler/campaign_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStageNext(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     Stage
+		want   Stage
+		wantOK bool
+	}{
+		{"ReplayEscalatesToInfer", StageReplay, StageInfer, true},
+		{"InferEscalatesToAgent", StageInfer, StageAgent, true},
+		{"AgentIsLast", StageAgent, "", false},
+		{"UnknownStage", Stage("bogus"), "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tc.in.Next()
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("%q.Next() = (%q, %t), want (%q, %t)", tc.in, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestFreshness(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name      string
+		published time.Time
+		tauHours  float64
+		want      float64
+	}{
+		// An unknown publish date must not boost or penalize, so it lands at
+		// the multiplicative identity.
+		{"UnknownPublishDate", time.Time{}, 120, 1},
+		{"NonPositiveTau", now, 0, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, Freshness(tc.published, now, 3, tc.tauHours)); diff != "" {
+				t.Errorf("Freshness mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+	t.Run("DecaysWithAge", func(t *testing.T) {
+		fresh := Freshness(now.Add(-time.Hour), now, 3, 120)
+		old := Freshness(now.Add(-30*24*time.Hour), now, 3, 120)
+		if !(fresh > old && old >= 1) {
+			t.Errorf("expected fresh (%v) > old (%v) >= 1", fresh, old)
+		}
+	})
+	t.Run("FutureDateDoesNotAmplify", func(t *testing.T) {
+		// Registry clock skew can report a publish time slightly ahead of now.
+		// Negative age must clamp rather than run the exponential above 1+k.
+		if got, want := Freshness(now.Add(time.Hour), now, 3, 120), 4.0; got != want {
+			t.Errorf("Freshness = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestDispatchOrder(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	order := func(c Campaign) float64 {
+		return c.DispatchOrder(now, DefaultFreshnessK, DefaultFreshnessTauHours)
+	}
+	// A fresh release of a mid-tier package can outrank a stale version of a
+	// critical one. That mobility is the point of deriving recency at read time.
+	freshMidTier := Campaign{Score: 0.30, Published: now.Add(-time.Hour)}
+	staleCritical := Campaign{Score: 0.99, Published: now.AddDate(-1, 0, 0)}
+	if order(freshMidTier) <= order(staleCritical) {
+		t.Errorf("fresh mid-tier (%v) should outrank stale critical (%v)",
+			order(freshMidTier), order(staleCritical))
+	}
+	freshCritical := Campaign{Score: 0.99, Published: now.Add(-time.Hour)}
+	if order(freshCritical) <= order(freshMidTier) {
+		t.Error("a fresh critical package must still outrank a fresh mid-tier one")
+	}
+	// The boost decays in the queue: the same campaign ordered a month later
+	// has lost its spike.
+	if later := freshMidTier.DispatchOrder(now.AddDate(0, 1, 0), DefaultFreshnessK, DefaultFreshnessTauHours); later >= order(freshMidTier) {
+		t.Errorf("dispatch order must decay while queued: %v then %v", order(freshMidTier), later)
+	}
+}

--- a/pkg/scheduler/doc.go
+++ b/pkg/scheduler/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package scheduler holds the data model for the onboarding queue: which
+// package versions are being worked on, in what order, and where each one
+// stands.
+//
+// "Campaign" tracks one package version's progress through the escalation
+// ladder of stages, each more expensive than the last. The queue is ordered by
+// DispatchOrder, which combines the priority score with recency so that
+// importance and freshness both count.
+//
+// This package holds only pure types and functions. The commands that drive
+// the queue live in tools/ctl/command/onboard.
+package scheduler

--- a/pkg/scheduler/id.go
+++ b/pkg/scheduler/id.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+// Firestore document IDs here percent-escape each component and join with "!".
+// Escaping is required because Firestore forbids "/" in a document ID and
+// scoped npm names contain one. Joining with "!" rather than concatenating
+// keeps the ID reversible and legible in the console.
+
+// PackageID is the document ID for a package.
+func PackageID(ecosystem, pkg string) string {
+	return url.PathEscape(ecosystem) + "!" + url.PathEscape(pkg)
+}
+
+// TargetID is the document ID for a target. Components left empty still
+// contribute a separator, so a package-level and a version-level ID for the
+// same package never collide.
+func TargetID(t rebuild.Target) string {
+	return strings.Join([]string{
+		url.PathEscape(string(t.Ecosystem)),
+		url.PathEscape(t.Package),
+		url.PathEscape(t.Version),
+		url.PathEscape(t.Artifact),
+	}, "!")
+}

--- a/pkg/scheduler/id_test.go
+++ b/pkg/scheduler/id_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+)
+
+func TestDocumentIDsEscapeSeparators(t *testing.T) {
+	// Scoped npm names contain "/", which Firestore forbids in document IDs.
+	if diff := cmp.Diff("npm!@babel%2Fcore", PackageID("npm", "@babel/core")); diff != "" {
+		t.Errorf("PackageID mismatch (-want +got):\n%s", diff)
+	}
+	id := TargetID(rebuild.Target{Ecosystem: rebuild.NPM, Package: "@scope/name", Version: "1.0.0", Artifact: "a.tgz"})
+	if strings.Contains(id, "/") {
+		t.Errorf("TargetID must not contain '/': %q", id)
+	}
+	if got, want := strings.Count(id, "!"), 3; got != want {
+		t.Errorf("TargetID has %d separators, want %d: %q", got, want, id)
+	}
+	// A name containing the separator must not produce another pair's ID.
+	if PackageID("npm", "a!b") == PackageID("npm", "a")+"!b" {
+		t.Error("PackageID collides with its own separator")
+	}
+}

--- a/tools/ctl/command/onboard/README.md
+++ b/tools/ctl/command/onboard/README.md
@@ -1,0 +1,36 @@
+# Onboarding
+
+Bringing a package into oss-rebuild coverage means two things: deciding it is
+worth the capacity, and then spending capacity until it reproduces.
+`ctl onboard priority` answers the first.
+
+## Priority
+
+There are far more packages than rebuild capacity, so something has to say
+which ones matter. Priority is a per-package score combining independent
+signals of importance, each computed by its own offline job and each
+normalized per ecosystem into (0,1] so heavy tails and incomparable registry
+scales stay out of the arithmetic.
+
+| Signal     | What it measures                                            | Source                    |
+| ---------- | ----------------------------------------------------------- | ------------------------- |
+| prevalence | distinct packages depending on this one, transitively too   | deps.dev dependency graph |
+
+Prevalence is computed at two granularities. The package number measures total
+use and is a coarse estimation of overall value. The per-version number allows
+us to better assess priority within a package's publications. Both are the
+dependent count on a log scale relative to the ecosystem's most depended-on
+package, so a version never outscores its package and the gap between them is
+the share of the package's use that version carries: lodash sits near the top
+of npm, lodash@4.17.21 just under it, and lodash@3.10.1 well below. The
+package number says lodash is worth tracking at all. The version numbers say
+which of its releases to rebuild first.
+
+Each job writes its ranked signal as a JSONL export, to a local path or a
+gs:// object:
+
+```sh
+# Read-only against public BigQuery data.
+ctl onboard priority prevalence --project my-project --out prevalence.jsonl
+ctl onboard priority prevalence --project my-project --out gs://my-analytics/priority/prevalence.jsonl
+```

--- a/tools/ctl/command/onboard/onboard.go
+++ b/tools/ctl/command/onboard/onboard.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package onboard implements the commands that bring packages into oss-rebuild coverage.
+package onboard
+
+import (
+	"context"
+
+	"github.com/google/oss-rebuild/pkg/act/cli"
+	"github.com/spf13/cobra"
+)
+
+// Deps is shared by all onboard subcommands.
+type Deps struct{ IO cli.IO }
+
+func (d *Deps) SetIO(cio cli.IO) { d.IO = cio }
+
+// InitDeps initializes shared dependencies.
+func InitDeps(context.Context) (*Deps, error) { return &Deps{}, nil }
+
+// Command returns the parent `onboard` command.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "onboard",
+		Short: "Bring packages into rebuild coverage",
+	}
+	cmd.AddCommand(priorityCommand())
+	return cmd
+}

--- a/tools/ctl/command/onboard/prevalence.go
+++ b/tools/ctl/command/onboard/prevalence.go
@@ -1,0 +1,356 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import (
+	"cmp"
+	"context"
+	"flag"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/google/oss-rebuild/internal/billyx"
+	"github.com/google/oss-rebuild/internal/jsonl"
+	"github.com/google/oss-rebuild/internal/signals"
+	"github.com/google/oss-rebuild/pkg/act"
+	"github.com/google/oss-rebuild/pkg/act/cli"
+	"github.com/google/oss-rebuild/pkg/rebuild/rebuild"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+type prevalenceConfig struct {
+	Project     string
+	Ecosystems  string
+	Top         int // bounds the package rows kept per ecosystem
+	TopVersions int // bounds the version rows kept per ecosystem
+	Out         string
+}
+
+func (c prevalenceConfig) Validate() error {
+	if c.Project == "" {
+		return errors.New("project is required")
+	}
+	if c.Out == "" {
+		return errors.New("out is required")
+	}
+	ecos := c.ecosystems()
+	if len(ecos) == 0 {
+		return errors.New("at least one ecosystem is required")
+	}
+	for _, name := range ecos {
+		if _, ok := signals.EcosystemSystem[rebuild.Ecosystem(name)]; !ok {
+			return errors.Errorf("ecosystem %q has no deps.dev dependency-graph coverage", name)
+		}
+	}
+	return nil
+}
+
+func (c prevalenceConfig) ecosystems() []string {
+	var out []string
+	for name := range strings.SplitSeq(c.Ecosystems, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func prevalenceHandler(ctx context.Context, cfg prevalenceConfig, deps *Deps) (*act.NoOutput, error) {
+	client, err := bigquery.NewClient(ctx, cfg.Project, option.WithQuotaProject(cfg.Project))
+	if err != nil {
+		return nil, errors.Wrap(err, "creating bigquery client")
+	}
+	defer client.Close()
+	ds, err := workDataset(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	snap, err := latestSnapshot(ctx, client, ds)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(deps.IO.Err, "deps.dev snapshot %s\n", snap.Format(time.RFC3339))
+	var recs []signals.PrevalenceRecord
+	for _, name := range cfg.ecosystems() {
+		pkgs, err := packagePrevalence(ctx, client, ds, name, snap, cfg.Top)
+		if err != nil {
+			return nil, errors.Wrapf(err, "querying %s package prevalence", name)
+		}
+		vers, err := versionPrevalence(ctx, client, ds, name, snap, cfg.TopVersions)
+		if err != nil {
+			return nil, errors.Wrapf(err, "querying %s version prevalence", name)
+		}
+		fmt.Fprintf(deps.IO.Err, "[%s] %d package(s), %d version(s)\n", name, len(pkgs), len(vers))
+		recs = append(recs, pkgs...)
+		recs = append(recs, vers...)
+	}
+	scored := scoreByEcosystem(recs)
+	outFS, out, err := billyx.NewResolver().FS(ctx, cfg.Out)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolving %s", cfg.Out)
+	}
+	w, err := outFS.Create(out)
+	if err != nil {
+		return nil, errors.Wrapf(err, "opening %s", cfg.Out)
+	}
+	if err := jsonl.Encode(w, scored); err != nil {
+		w.Close()
+		return nil, errors.Wrap(err, "writing export")
+	}
+	if err := w.Close(); err != nil {
+		return nil, errors.Wrapf(err, "finalizing %s", cfg.Out)
+	}
+	fmt.Fprintf(deps.IO.Out, "wrote %d prevalence record(s) to %s\n", len(scored), cfg.Out)
+	return &act.NoOutput{}, nil
+}
+
+// scoreByEcosystem attaches per-ecosystem scores: each row's dependent count on
+// a log scale relative to the ecosystem's most depended-on package. Scoring is
+// per-ecosystem because raw counts are not comparable across registries:
+// npm's graph is denser than RubyGems' by an order of magnitude, so a shared
+// scale would bury every gem below the npm long tail. Package and version rows
+// share the denominator, so a version never outscores its package and the gap
+// between them is the share of the package's use that version carries.
+// Package rows precede version rows, ecosystems are sorted, and ties break by
+// name, so the export is stable to rerun.
+func scoreByEcosystem(recs []signals.PrevalenceRecord) []signals.PrevalenceRecord {
+	pkgsByEco := map[string][]signals.PrevalenceRecord{}
+	versByEco := map[string][]signals.PrevalenceRecord{}
+	for _, r := range recs {
+		if r.Ecosystem == "" || r.Package == "" {
+			continue
+		}
+		if r.Version == "" {
+			pkgsByEco[r.Ecosystem] = append(pkgsByEco[r.Ecosystem], r)
+		} else {
+			versByEco[r.Ecosystem] = append(versByEco[r.Ecosystem], r)
+		}
+	}
+	maxByEco := map[string]int64{}
+	for _, byEco := range []map[string][]signals.PrevalenceRecord{pkgsByEco, versByEco} {
+		for eco, rs := range byEco {
+			for _, r := range rs {
+				maxByEco[eco] = max(maxByEco[eco], r.Dependents)
+			}
+		}
+	}
+	var out []signals.PrevalenceRecord
+	for _, byEco := range []map[string][]signals.PrevalenceRecord{pkgsByEco, versByEco} {
+		for _, eco := range slices.Sorted(maps.Keys(byEco)) {
+			scored := byDependents(byEco[eco])
+			for i := range scored {
+				scored[i].Prevalence = signals.LogScale(scored[i].Dependents, maxByEco[eco])
+			}
+			out = append(out, scored...)
+		}
+	}
+	return out
+}
+
+// byDependents orders by descending dependent count with a name tiebreak. The
+// queries apply the same total order to their LIMIT, so membership at the
+// cutoff is deterministic and the export is byte-stable across reruns of the
+// same snapshot.
+func byDependents(recs []signals.PrevalenceRecord) []signals.PrevalenceRecord {
+	slices.SortFunc(recs, func(a, b signals.PrevalenceRecord) int {
+		return cmp.Or(
+			cmp.Compare(b.Dependents, a.Dependents),
+			cmp.Compare(a.Package, b.Package),
+			cmp.Compare(a.Version, b.Version),
+		)
+	})
+	return recs
+}
+
+// latestSnapshot reads the most recent deps.dev snapshot time. Pinning queries
+// to it as a TIMESTAMP parameter lets BigQuery prune to a single partition.
+func latestSnapshot(ctx context.Context, client *bigquery.Client, ds *bigquery.Dataset) (time.Time, error) {
+	it, err := runQuery(ctx, client.Query("SELECT MAX(Time) AS Time FROM `bigquery-public-data.deps_dev_v1.Snapshots`"), ds.Table("latest_snapshot"))
+	if err != nil {
+		return time.Time{}, errors.Wrap(err, "reading deps.dev snapshots")
+	}
+	var row struct{ Time time.Time }
+	if err := it.Next(&row); err != nil {
+		return time.Time{}, errors.Wrap(err, "reading latest snapshot")
+	}
+	if row.Time.IsZero() {
+		return time.Time{}, errors.New("no deps.dev snapshot found")
+	}
+	return row.Time, nil
+}
+
+// depsDevSystem resolves an ecosystem to the deps.dev `System` enum naming it.
+func depsDevSystem(ecosystem string) (string, error) {
+	system, ok := signals.EcosystemSystem[rebuild.Ecosystem(ecosystem)]
+	if !ok {
+		return "", errors.Errorf("ecosystem %q has no deps.dev dependency-graph coverage", ecosystem)
+	}
+	return system, nil
+}
+
+// packagePrevalence counts, for each package, the distinct packages whose
+// resolved dependency graph contains it at the given snapshot: its transitive
+// dependents. Every edge row names the root package version whose graph it
+// belongs to, so this is a distinct count over that root, not a graph walk. A
+// root's graph can contain another version of the root itself; those rows are
+// excluded, as are bundled copies: deps.dev names a dependency vendored inside
+// another package's tarball by its nesting path joined with ">", e.g.
+// "react-scripts>0.5.1>babel-preset-react-app>regjsgen". Consumers receive
+// those copies through the parent artifact, not the registry, so they are not
+// rebuild targets and would otherwise inflate the population several-fold.
+func packagePrevalence(ctx context.Context, client *bigquery.Client, ds *bigquery.Dataset, ecosystem string, snap time.Time, top int) ([]signals.PrevalenceRecord, error) {
+	system, err := depsDevSystem(ecosystem)
+	if err != nil {
+		return nil, err
+	}
+	q := client.Query("SELECT T.`To`.Name AS Package, COUNT(DISTINCT T.Name) AS Dependents\n" +
+		"FROM `bigquery-public-data.deps_dev_v1.DependencyGraphEdges` T\n" +
+		"WHERE T.System = @system AND T.SnapshotAt = @snap\n" +
+		"  AND T.Name != T.`To`.Name\n" +
+		"  AND T.`To`.Name NOT LIKE '%>%'\n" +
+		"GROUP BY Package\n" +
+		"ORDER BY Dependents DESC, Package\n" +
+		"LIMIT @top")
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "system", Value: system},
+		{Name: "snap", Value: snap},
+		{Name: "top", Value: top},
+	}
+	it, err := runQuery(ctx, q, ds.Table("pkg_prevalence_"+ecosystem))
+	if err != nil {
+		return nil, err
+	}
+	var out []signals.PrevalenceRecord
+	for {
+		var row struct {
+			Package    string
+			Dependents int64
+		}
+		switch err := it.Next(&row); err {
+		case nil:
+			out = append(out, signals.PrevalenceRecord{Ecosystem: ecosystem, Package: row.Package, Dependents: row.Dependents})
+		case iterator.Done:
+			return out, nil
+		default:
+			return nil, errors.Wrap(err, "iterating results")
+		}
+	}
+}
+
+// versionPrevalence counts, for each exact version, the distinct packages
+// whose resolved dependency graph contains that version. Same table, snapshot
+// and exclusions as packagePrevalence, grouped one column finer.
+func versionPrevalence(ctx context.Context, client *bigquery.Client, ds *bigquery.Dataset, ecosystem string, snap time.Time, top int) ([]signals.PrevalenceRecord, error) {
+	system, err := depsDevSystem(ecosystem)
+	if err != nil {
+		return nil, err
+	}
+	q := client.Query("SELECT T.`To`.Name AS Package, T.`To`.Version AS Version, COUNT(DISTINCT T.Name) AS Dependents\n" +
+		"FROM `bigquery-public-data.deps_dev_v1.DependencyGraphEdges` T\n" +
+		"WHERE T.System = @system AND T.SnapshotAt = @snap\n" +
+		"  AND T.Name != T.`To`.Name\n" +
+		"  AND T.`To`.Name NOT LIKE '%>%'\n" +
+		"  AND T.`To`.Version != ''\n" +
+		"GROUP BY Package, Version\n" +
+		"ORDER BY Dependents DESC, Package, Version\n" +
+		"LIMIT @top")
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "system", Value: system},
+		{Name: "snap", Value: snap},
+		{Name: "top", Value: top},
+	}
+	it, err := runQuery(ctx, q, ds.Table("ver_prevalence_"+ecosystem))
+	if err != nil {
+		return nil, err
+	}
+	var out []signals.PrevalenceRecord
+	for {
+		var row struct {
+			Package    string
+			Version    string
+			Dependents int64
+		}
+		switch err := it.Next(&row); err {
+		case nil:
+			out = append(out, signals.PrevalenceRecord{Ecosystem: ecosystem, Package: row.Package, Version: row.Version, Dependents: row.Dependents})
+		case iterator.Done:
+			return out, nil
+		default:
+			return nil, errors.Wrap(err, "iterating results")
+		}
+	}
+}
+
+// workDataset returns the dataset that holds query results, creating it if
+// missing. Without an explicit destination BigQuery materializes results
+// into a hidden per-user dataset whose ACL names the querying user, which
+// domain-restricted organizations reject at creation; a dataset granted
+// only the project's special groups never names a user, so it is allowed.
+func workDataset(ctx context.Context, client *bigquery.Client) (*bigquery.Dataset, error) {
+	ds := client.Dataset("onboard_prevalence")
+	if _, err := ds.Metadata(ctx); err == nil {
+		return ds, nil
+	}
+	err := ds.Create(ctx, &bigquery.DatasetMetadata{
+		Description:            "Query results for ctl onboard priority prevalence.",
+		DefaultTableExpiration: 24 * time.Hour,
+		Access: []*bigquery.AccessEntry{
+			{Role: bigquery.OwnerRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectOwners"},
+			{Role: bigquery.WriterRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectWriters"},
+			{Role: bigquery.ReaderRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectReaders"},
+		},
+	})
+	return ds, errors.Wrap(err, "creating work dataset")
+}
+
+func runQuery(ctx context.Context, q *bigquery.Query, dst *bigquery.Table) (*bigquery.RowIterator, error) {
+	q.Dst = dst
+	q.WriteDisposition = bigquery.WriteTruncate
+	job, err := q.Run(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "running query")
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "waiting for query")
+	}
+	if err := status.Err(); err != nil {
+		return nil, errors.Wrap(err, "query failed")
+	}
+	it, err := job.Read(ctx)
+	return it, errors.Wrap(err, "reading results")
+}
+
+func prevalenceCommand() *cobra.Command {
+	cfg := prevalenceConfig{}
+	cmd := &cobra.Command{
+		Use:   "prevalence --project <project> --out <uri> [--ecosystems <eco,...>] [--top <n>] [--top-versions <n>]",
+		Short: "Rank packages by distinct transitive dependents (deps.dev graph)",
+		Long: `Rank packages by distinct transitive dependents (deps.dev graph).
+
+Counts how many distinct packages depend, directly or transitively, on each
+package, and separately on each exact version, at the latest deps.dev
+snapshot, then scores both on a log scale relative to the ecosystem's most
+depended-on package and writes the result as a JSONL export.
+
+Reads public data and writes externally so no BigQuery write access required.`,
+		Args: cobra.NoArgs,
+		RunE: cli.RunE(&cfg, cli.SkipArgs[prevalenceConfig], InitDeps, prevalenceHandler),
+	}
+	set := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
+	set.StringVar(&cfg.Project, "project", "", "GCP project that runs and is billed for the BigQuery jobs")
+	set.StringVar(&cfg.Ecosystems, "ecosystems", "npm,pypi,cratesio,rubygems,maven", "comma-separated ecosystems to rank")
+	set.IntVar(&cfg.Top, "top", 5000, "max packages to keep per ecosystem, by dependent count")
+	set.IntVar(&cfg.TopVersions, "top-versions", 20000, "max versions to keep per ecosystem, by dependent count")
+	set.StringVar(&cfg.Out, "out", "", "write the ranked JSONL export to this path or gs:// URI")
+	cmd.Flags().AddGoFlagSet(set)
+	return cmd
+}

--- a/tools/ctl/command/onboard/prevalence_test.go
+++ b/tools/ctl/command/onboard/prevalence_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/oss-rebuild/internal/jsonl"
+	"github.com/google/oss-rebuild/internal/signals"
+)
+
+func TestRankByEcosystem(t *testing.T) {
+	// Package and version rows share each ecosystem's denominator, its most
+	// depended-on package, so a version never outscores its package.
+	got := scoreByEcosystem([]signals.PrevalenceRecord{
+		{Ecosystem: "npm", Package: "rarely-used", Dependents: 1},
+		{Ecosystem: "rubygems", Package: "rack", Dependents: 50},
+		{Ecosystem: "npm", Package: "lodash", Dependents: 9000},
+		{Ecosystem: "npm", Package: "lodash", Version: "4.17.21", Dependents: 8000},
+		{Ecosystem: "npm", Package: "lodash", Version: "3.10.1", Dependents: 400},
+		{Ecosystem: "npm", Package: "rarely-used", Version: "1.0.0", Dependents: 1},
+		{Ecosystem: "", Package: "dropped-no-ecosystem", Dependents: 5},
+		{Ecosystem: "npm", Package: "", Dependents: 5},
+	})
+
+	npm := func(dependents int64) float64 { return math.Log1p(float64(dependents)) / math.Log1p(9000) }
+	want := []signals.PrevalenceRecord{
+		{Ecosystem: "npm", Package: "lodash", Dependents: 9000, Prevalence: 1.0},
+		{Ecosystem: "npm", Package: "rarely-used", Dependents: 1, Prevalence: npm(1)},
+		{Ecosystem: "rubygems", Package: "rack", Dependents: 50, Prevalence: 1.0},
+		{Ecosystem: "npm", Package: "lodash", Version: "4.17.21", Dependents: 8000, Prevalence: npm(8000)},
+		{Ecosystem: "npm", Package: "lodash", Version: "3.10.1", Dependents: 400, Prevalence: npm(400)},
+		{Ecosystem: "npm", Package: "rarely-used", Version: "1.0.0", Dependents: 1, Prevalence: npm(1)},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ranked records mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestWriteJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prevalence.jsonl")
+	rows := []signals.PrevalenceRecord{
+		{Ecosystem: "npm", Package: "lodash", Dependents: 9000, Prevalence: 1.0},
+		{Ecosystem: "npm", Package: "lodash", Version: "4.17.21", Dependents: 8000, Prevalence: 1.0},
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := jsonl.Encode(f, rows); err != nil {
+		t.Fatalf("jsonl.Encode: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading export: %v", err)
+	}
+	var got []signals.PrevalenceRecord
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	for dec.More() {
+		var r signals.PrevalenceRecord
+		if err := dec.Decode(&r); err != nil {
+			t.Fatalf("decoding line: %v", err)
+		}
+		got = append(got, r)
+	}
+	if diff := cmp.Diff(rows, got); diff != "" {
+		t.Errorf("round-tripped records mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/tools/ctl/command/onboard/priority.go
+++ b/tools/ctl/command/onboard/priority.go
@@ -11,6 +11,6 @@ func priorityCommand() *cobra.Command {
 		Use:   "priority",
 		Short: "Compute and export the signals that rank onboarding candidates",
 	}
-	cmd.AddCommand(prevalenceCommand())
+	cmd.AddCommand(prevalenceCommand(), publishCommand())
 	return cmd
 }

--- a/tools/ctl/command/onboard/priority.go
+++ b/tools/ctl/command/onboard/priority.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import "github.com/spf13/cobra"
+
+// priorityCommand groups the jobs that rank onboarding candidates.
+func priorityCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "priority",
+		Short: "Compute and export the signals that rank onboarding candidates",
+	}
+	cmd.AddCommand(prevalenceCommand())
+	return cmd
+}

--- a/tools/ctl/command/onboard/publish.go
+++ b/tools/ctl/command/onboard/publish.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/oss-rebuild/internal/billyx"
+	"github.com/google/oss-rebuild/internal/buildinfo"
+	"github.com/google/oss-rebuild/internal/jsonl"
+	"github.com/google/oss-rebuild/internal/signals"
+	"github.com/google/oss-rebuild/internal/sqlitex"
+	"github.com/google/oss-rebuild/pkg/act"
+	"github.com/google/oss-rebuild/pkg/act/cli"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type publishConfig struct {
+	Prevalence string
+	Dest       string
+}
+
+func (c publishConfig) Validate() error {
+	if c.Prevalence == "" {
+		return errors.New("prevalence is required")
+	}
+	if c.Dest == "" {
+		return errors.New("dest is required")
+	}
+	return nil
+}
+
+// publishHandler assembles the signal database from the ranked exports and
+// uploads it to the destination as one object write, so consumers never
+// observe a partial publish.
+func publishHandler(ctx context.Context, cfg publishConfig, deps *Deps) (*act.NoOutput, error) {
+	resolve := billyx.NewResolver()
+	prevs, err := readExport[signals.PrevalenceRecord](ctx, resolve, cfg.Prevalence)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading prevalence export")
+	}
+	dir, err := os.MkdirTemp("", "signals-publish-")
+	if err != nil {
+		return nil, errors.Wrap(err, "creating build directory")
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "signals.db")
+	counts, err := signals.Build(path, prevs, signals.Meta{BuiltAt: time.Now().UTC(), ToolVersion: buildinfo.Version})
+	if err != nil {
+		return nil, errors.Wrap(err, "building signal database")
+	}
+	dest, err := resolve.DirFS(ctx, cfg.Dest)
+	if err != nil {
+		return nil, err
+	}
+	if err := sqlitex.Publish(dest, signals.Object, path); err != nil {
+		return nil, errors.Wrap(err, "uploading signal database")
+	}
+	fmt.Fprintf(deps.IO.Out, "wrote %s (%d packages, %d versions)\n",
+		signals.Object, counts[signals.TablePackageSignals], counts[signals.TableVersionSignals])
+	return &act.NoOutput{}, nil
+}
+
+// readExport resolves, opens, and fully decodes one JSONL export: the
+// database build needs every row in hand.
+func readExport[T any](ctx context.Context, resolve *billyx.Resolver, uri string) ([]T, error) {
+	fsys, name, err := resolve.FS(ctx, uri)
+	if err != nil {
+		return nil, errors.Wrap(err, "resolving export")
+	}
+	r, err := fsys.Open(name)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening export")
+	}
+	defer r.Close()
+	return jsonl.DecodeAll[T](r)
+}
+
+// publishCommand creates the `onboard priority publish` subcommand.
+func publishCommand() *cobra.Command {
+	cfg := publishConfig{}
+	cmd := &cobra.Command{
+		Use:   "publish --prevalence <uri> --dest <gs://...|file://...>",
+		Short: "Assemble and publish the signal database from the ranked exports",
+		Args:  cobra.NoArgs,
+		RunE:  cli.RunE(&cfg, cli.SkipArgs[publishConfig], InitDeps, publishHandler),
+	}
+	set := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
+	set.StringVar(&cfg.Prevalence, "prevalence", "", "prevalence JSONL export (gs:// URI or local path)")
+	set.StringVar(&cfg.Dest, "dest", "", "destination URI the signal database publishes under")
+	cmd.Flags().AddGoFlagSet(set)
+	return cmd
+}

--- a/tools/ctl/command/onboard/publish_test.go
+++ b/tools/ctl/command/onboard/publish_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package onboard
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/google/oss-rebuild/internal/jsonl"
+	"github.com/google/oss-rebuild/internal/signals"
+	"github.com/google/oss-rebuild/pkg/act/cli"
+	"github.com/ncruces/go-sqlite3"
+)
+
+func writeJSONLFile[T any](t *testing.T, path string, rows []T) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := jsonl.Encode(f, rows); err != nil {
+		t.Fatalf("jsonl.Encode: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestPublish(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	prev := filepath.Join(dir, "prevalence.jsonl")
+	writeJSONLFile(t, prev, []signals.PrevalenceRecord{
+		{Ecosystem: "pypi", Package: "pkgA", Dependents: 100, Prevalence: 0.8},
+		{Ecosystem: "pypi", Package: "pkgA", Version: "1.0", Dependents: 60, Prevalence: 0.75},
+	})
+	dest := t.TempDir()
+	var out bytes.Buffer
+	_, err := publishHandler(ctx, publishConfig{Prevalence: prev, Dest: "file://" + dest},
+		&Deps{IO: cli.IO{Out: &out, Err: &out}})
+	if err != nil {
+		t.Fatalf("publishHandler: %v", err)
+	}
+	if !strings.Contains(out.String(), "1 packages, 1 versions") {
+		t.Errorf("output = %q, want package and version counts", out.String())
+	}
+	path, err := signals.Fetch(osfs.New(dest), t.TempDir())
+	if err != nil {
+		t.Fatalf("fetching published database: %v", err)
+	}
+	db, err := sqlite3.Open(path)
+	if err != nil {
+		t.Fatalf("opening published database: %v", err)
+	}
+	defer db.Close()
+	rows, err := signals.PackageSignals(db)
+	if err != nil {
+		t.Fatalf("PackageSignals: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Score != 0.8 {
+		t.Errorf("published rows = %+v, want one pkgA row scored 0.8", rows)
+	}
+}

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/oss-rebuild/tools/ctl/command/listruns"
 	"github.com/google/oss-rebuild/tools/ctl/command/localagent"
 	"github.com/google/oss-rebuild/tools/ctl/command/migrate"
+	"github.com/google/oss-rebuild/tools/ctl/command/onboard"
 	"github.com/google/oss-rebuild/tools/ctl/command/runagent"
 	"github.com/google/oss-rebuild/tools/ctl/command/runagentbenchmark"
 	"github.com/google/oss-rebuild/tools/ctl/command/runbenchmark"
@@ -48,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(localagent.Command())
 	rootCmd.AddCommand(runagentbenchmark.Command())
 	rootCmd.AddCommand(scratch.Command())
+	rootCmd.AddCommand(onboard.Command())
 	// Reading data
 	rootCmd.AddCommand(tui.Command())
 	rootCmd.AddCommand(getresults.Command())


### PR DESCRIPTION
/coverage is the onboarding scoreboard. The All tab compares ecosystems
e.g. packages in the ranked head, how many the queue tracks, how many
are current at their latest version, the share of the head's score mass
that is current, and the queue by state. An ecosystem tab adds
the done campaigns by the stage that attested them and the funnel from
coverage_weekly.

> Parents: [#1537](https://redirect.github.com/google/oss-rebuild/pull/1537)